### PR TITLE
feat: Typed fields, relations and term pages

### DIFF
--- a/cmd/gophenberg/seed.go
+++ b/cmd/gophenberg/seed.go
@@ -42,6 +42,18 @@ func seedDemoData(ctx context.Context, getenv func(string) string, stdout io.Wri
 	if err != nil {
 		return err
 	}
+	if err := seedDemoContent(ctx, pool, users); err != nil {
+		return err
+	}
+	if err := seedDemoMedia(ctx, getenv, pool, users); err != nil {
+		return err
+	}
+	reportSeeded(stdout, created)
+	return nil
+}
+
+// seedDemoContent registers the demo types and stores the content they hold.
+func seedDemoContent(ctx context.Context, pool *pgxpool.Pool, users *authkitpg.UserStore) error {
 	types := content.NewRegistry(postgres.NewTypeStore(pool))
 	if err := seed.Types(ctx, types); err != nil {
 		return err
@@ -53,11 +65,7 @@ func seedDemoData(ctx context.Context, getenv func(string) string, stdout io.Wri
 	if err := seed.Pages(ctx, store, types, users); err != nil {
 		return err
 	}
-	if err := seedDemoMedia(ctx, getenv, pool, users); err != nil {
-		return err
-	}
-	reportSeeded(stdout, created)
-	return nil
+	return seed.Categories(ctx, store, types, users)
 }
 
 // seedDemoMedia stores the demo pictures when a media directory is configured.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -37,6 +37,7 @@ export default defineConfig({
 						{ slug: 'guides/media' },
 						{ slug: 'guides/publishing' },
 						{ slug: 'guides/content-types' },
+						{ slug: 'guides/fields' },
 						{ slug: 'guides/users' },
 					],
 				},

--- a/docs/src/content/docs/guides/content-types.md
+++ b/docs/src/content/docs/guides/content-types.md
@@ -18,7 +18,9 @@ Guide and Guides. Gophenberg derives the rest: the plural becomes the
 route word, so Guides answer under `/guides`.
 
 The new type appears in the admin menu right away, with the same list
-screen and editor Posts have.
+screen and editor Posts have. Press **Fields** on a type to give its
+items typed fields of their own, covered in
+[fields](/guides/fields/).
 
 ## Addresses and the route word
 

--- a/docs/src/content/docs/guides/fields.md
+++ b/docs/src/content/docs/guides/fields.md
@@ -1,0 +1,69 @@
+---
+title: Fields
+description: Giving a content type its own typed fields, including relations between types.
+---
+
+A field is one extra piece of information every item of a type
+carries. A car can have a price, a recipe a cooking time, a post a
+list of categories. This page shows how to declare fields, fill them
+in, and connect one type to another.
+
+Fields belong to a type, not to a single item. Declare a Price field
+on Cars and every car gets a Price box in the editor.
+
+## Declaring a field
+
+Open **Content Types** in the admin menu and press **Fields** on a
+type. The view lists what the type declares and lets you add more.
+
+Give the field a name and pick a kind. The name is what editors see.
+Gophenberg derives the key from it, so a field named Sold On is
+stored under `sold-on`. The key and the kind are fixed once the
+field exists. **Rename** changes only the name, which is free and
+touches nothing stored.
+
+## The kinds
+
+| Kind | Holds | Example |
+| --- | --- | --- |
+| Text | a line of text | a subtitle |
+| Number | a number | a price |
+| Yes or no | a check | in stock |
+| Date | a day | sold on |
+| Media | one item from the media library | a cover image |
+| Relation | links to items of another type | the categories of a post |
+
+## Filling fields in
+
+The editor's Document panel shows one control per declared field,
+under the excerpt. Values save with the item, autosave with it, and
+travel with revisions, so restoring an old revision also restores
+the values it held.
+
+A field can be marked **required**. A required field never blocks
+writing: drafts save freely with it empty. It blocks publishing, so
+an item goes public only once the field holds something.
+
+## Relations connect types
+
+A relation field points items of one type at items of another.
+Categories work this way: a hierarchical Categories type, plus a
+relation field on Posts pointing at it. There is no separate
+category system to learn, a category is ordinary content, so it can
+carry its own body, fields and picture.
+
+A relation field declares which type it points at, and whether an
+item holds one target or many. The editor then offers a picker
+listing the items of that type.
+
+A type whose items should list what points at them declares the
+archive page kind. Such an item serves a term page: its own title
+and body first, then the published content pointing at it, newest
+first, paginated. The seeded News category is one to look at.
+
+## Deleting a field
+
+**Delete** removes the field and everything stored under it, in
+every item of the type and in the revisions behind them. The dialog
+says so before it happens. This is what keeps old values from
+coming back if you later declare a new field under the same key.

--- a/docs/src/content/docs/guides/fields.md
+++ b/docs/src/content/docs/guides/fields.md
@@ -36,13 +36,19 @@ touches nothing stored.
 ## Filling fields in
 
 The editor's Document panel shows one control per declared field,
-under the excerpt. Values save with the item, autosave with it, and
-travel with revisions, so restoring an old revision also restores
-the values it held.
+under the excerpt. Values save with the item and travel with
+revisions, so restoring an old revision also restores the values it
+held.
+
+Autosave keeps the fields listed in the table above. It does not
+keep relations, which are stored apart from the item. Press **Save
+draft** after changing what an item points at.
 
 A field can be marked **required**. A required field never blocks
 writing: drafts save freely with it empty. It blocks publishing, so
-an item goes public only once the field holds something.
+an item goes public only once the field holds something. The admin
+has no control for this yet, so a required field has to be declared
+over the API.
 
 ## Relations connect types
 
@@ -54,7 +60,9 @@ carry its own body, fields and picture.
 
 A relation field declares which type it points at, and whether an
 item holds one target or many. The editor then offers a picker
-listing the items of that type.
+listing the items of that type. Fields added in the admin hold many
+targets. A field holding a single one has to be declared over the
+API for now.
 
 A type whose items should list what points at them declares the
 archive page kind. Such an item serves a term page: its own title

--- a/docs/src/content/docs/reference/content-api.md
+++ b/docs/src/content/docs/reference/content-api.md
@@ -36,7 +36,17 @@ curl https://example.com/api/content/v1
       "route_word": "",
       "hierarchical": false,
       "page_kind": "single",
-      "default": true
+      "default": true,
+      "fields": [
+        {
+          "key": "categories",
+          "label": "Categories",
+          "kind": "relation",
+          "relates_to": "category",
+          "many": true,
+          "required": false
+        }
+      ]
     }
   ]
 }
@@ -46,6 +56,11 @@ One request tells you the site runs Gophenberg, which version, which
 API generation, and every content type it serves. The `route_word` is
 the first segment of that type's addresses, and the type carrying an
 empty one answers at the root of the site.
+
+Each type also lists the [fields](/guides/fields/) it declares, so a
+reader knows what an item's values mean before fetching any. A
+`page_kind` of `archive` marks a type whose items answer with a term
+page, covered below.
 
 ## Listing items
 
@@ -109,6 +124,15 @@ item itself, and a `kind` of `archive` carries a page of items.
     "title": "Hello world",
     "excerpt": "The first post.",
     "content": "<!-- wp:paragraph --><p>The first post.</p><!-- /wp:paragraph -->",
+    "fields": {
+      "categories": [
+        {
+          "id": "0198f2c1-0000-7000-8000-0000000000c1",
+          "title": "News",
+          "path": "categories/news"
+        }
+      ]
+    },
     "published_at": "2026-08-01T10:00:00Z",
     "updated_at": "2026-08-02T09:30:00Z"
   }
@@ -118,6 +142,13 @@ item itself, and a `kind` of `archive` carries a page of items.
 An item's `content` is its block markup as HTML, sanitized for public
 delivery, with the block comment markers intact so a parser can
 identify each block.
+
+The `fields` object carries the item's values, keyed by field key.
+A scalar field holds its value as it was typed. A relation field
+holds a list of the items it points at, each named and addressed so
+a theme can link to it without another request. Only published
+targets of active types appear, so a draft category never leaks
+through a published post.
 
 Archive addresses answer with a page instead. The root of a type is
 its `route_word`, the front page is the default type, and both
@@ -141,7 +172,33 @@ archive page. Nothing published at an address answers
 `404 {"error":"content: not found"}`, and so does a page number below
 one.
 
+## Term pages
+
+An item of a type whose `page_kind` is `archive` answers with a third
+kind, `term`. The answer carries the item and a page together: the
+item is the term itself, a category for example, and the page lists
+the published content pointing at it, newest first.
+
+```sh
+curl "https://example.com/api/content/v1/resolve?path=/categories/news"
+```
+
+```json
+{
+  "kind": "term",
+  "type": { "key": "category", "route_word": "categories", "page_kind": "archive" },
+  "item": { "title": "News", "path": "categories/news" },
+  "page": { "items": [], "total": 0, "page": 1, "per_page": 20 }
+}
+```
+
+An item filed under the term through two different fields is listed
+once. Term pages paginate behind `/page/{n}` like archives, and a
+page suffix on an ordinary single item stays `404`.
+
 Item answers carry an `ETag`. Send it back as `If-None-Match` and an
 unchanged item answers `304` with no body, worth doing if you poll.
 Cross-origin browser scripts cannot read the `ETag` header, so this is
-for servers and command lines.
+for servers and command lines. Term answers carry no `ETag`, because
+a term page changes when other items publish, which the term's own
+timestamp cannot witness.

--- a/docs/src/content/docs/reference/content-api.md
+++ b/docs/src/content/docs/reference/content-api.md
@@ -197,7 +197,9 @@ once. Term pages paginate behind `/page/{n}` like archives, and a
 page suffix on an ordinary single item stays `404`.
 
 Item answers carry an `ETag`. Send it back as `If-None-Match` and an
-unchanged item answers `304` with no body, worth doing if you poll.
+unchanged answer comes back as `304` with no body, worth doing if you
+poll. The tag covers the whole answer, so it also moves when the type
+or its fields change.
 Cross-origin browser scripts cannot read the `ETag` header, so this is
 for servers and command lines. Term answers carry no `ETag`, because
 a term page changes when other items publish, which the term's own

--- a/docs/src/content/docs/self-hosting/updates-and-backups.md
+++ b/docs/src/content/docs/self-hosting/updates-and-backups.md
@@ -21,12 +21,16 @@ Migrations run automatically when the new version starts. While
 Gophenberg is below 1.0, read the release notes first, since a
 release can change behavior.
 
-Updating to %VERSION% changes every public address once. A post that
-answered at `/post/hello-world` now answers at `/hello-world`, and
-each [content type](/guides/content-types/) serves its own addresses
-under its route word. Links kept outside your site to the old shape
-answer 404 after the update. This is a one-time change: addresses
-are stored now, so they will not change shape again.
+Updating to %VERSION% runs two migrations on start: one adds
+[fields](/guides/fields/) to the schema, the other adds the
+relation table connecting content to content. Back up the database
+before the first start on this release, as before any update.
+Public addresses do not change shape.
+
+Themes must move to `@gophenberg/astro` %VERSION% with the update.
+The kit now requires a `Term` layout for pages like categories, and
+item payloads gained a `fields` member, so a theme built on the
+previous kit will not serve.
 
 ## What to back up
 

--- a/docs/src/content/docs/themes/writing-a-theme.md
+++ b/docs/src/content/docs/themes/writing-a-theme.md
@@ -34,9 +34,10 @@ import Archive from './layouts/Archive.astro'
 import Base from './layouts/Base.astro'
 import NotFound from './layouts/NotFound.astro'
 import Post from './layouts/Post.astro'
+import Term from './layouts/Term.astro'
 
 export default defineTheme({
-	layouts: { Base, Post, Archive, NotFound },
+	layouts: { Base, Post, Archive, Term, NotFound },
 	pagination: { perPage: 10 },
 	seo: { siteName: 'My Site' },
 })
@@ -52,8 +53,9 @@ You write no pages for content. The integration injects the front
 page, one catch-all route serving every stored address, the 404
 page, and the health route Gophenberg probes at startup. The
 catch-all asks Gophenberg what an address holds and renders your
-Post layout for an item or your Archive layout for a listing, with
-the content already fetched.
+Post layout for an item, your Archive layout for a listing, or your
+Term layout for an item that lists what points at it, with the
+content already fetched.
 
 Your own pages coexist with them: `src/pages/about.astro` serves
 `/about` as in any Astro site. To put posts on a page of your own,
@@ -118,6 +120,35 @@ const { post, blocks, seo } = Astro.props
 **Archive** receives `posts` (summaries without content), `total`,
 `page`, `perPage`, `type` (the content type being listed, carrying
 its labels and route word), and `seo`. **NotFound** receives `seo`.
+
+**Term** renders an item that lists what points at it, a category
+page for example. It receives the Archive props plus `term`, the
+item itself as a full `Post`, and `blocks`. Render the term's own
+title and content first, then the `posts` the way an archive does.
+
+A post's `fields` object carries its values, and relation values
+name the items they point at. The kit's `relatedFields` helper
+picks the relations out, so linking a post to its categories is:
+
+```astro
+---
+import { relatedFields } from '@gophenberg/astro'
+
+const related = relatedFields(post)
+---
+
+{
+	related.map((field) => (
+		<ul>
+			{field.items.map((item) => (
+				<li>
+					<a href={`/${item.path}`}>{item.title}</a>
+				</li>
+			))}
+		</ul>
+	))
+}
+```
 
 ## Trying it
 

--- a/frontend/src/content/DocumentPanels.tsx
+++ b/frontend/src/content/DocumentPanels.tsx
@@ -85,7 +85,7 @@ export function DocumentPanels({ postId, buffer }: { postId: string, buffer: Edi
 				value={buffer.excerpt}
 				onValueChange={buffer.setExcerpt}
 			/>
-			<FieldsPanel declared={listed.fields} buffer={buffer} />
+			<FieldsPanel postId={postId} declared={listed.fields} buffer={buffer} />
 			<TrashPost postId={postId} title={buffer.title} />
 		</Stack>
 	)

--- a/frontend/src/content/DocumentPanels.tsx
+++ b/frontend/src/content/DocumentPanels.tsx
@@ -3,6 +3,7 @@
 import { InputControl, SelectControl, Stack, TextareaControl } from '@gophenberg/frontend-sdk'
 import { useMemo } from 'react'
 
+import { FieldsPanel } from './FieldsPanel'
 import { ParentPicker } from './ParentPicker'
 import { TrashPost } from './TrashPost'
 import { useContentType } from './useContentType'
@@ -84,6 +85,7 @@ export function DocumentPanels({ postId, buffer }: { postId: string, buffer: Edi
 				value={buffer.excerpt}
 				onValueChange={buffer.setExcerpt}
 			/>
+			<FieldsPanel declared={listed.fields} buffer={buffer} />
 			<TrashPost postId={postId} title={buffer.title} />
 		</Stack>
 	)

--- a/frontend/src/content/FieldsDialog.tsx
+++ b/frontend/src/content/FieldsDialog.tsx
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { Button, Dialog, InputControl, SelectControl, Stack, Text } from '@gophenberg/frontend-sdk'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+
+import { typesQueryKey } from './nav'
+import { createField, deleteField, listFields, renameField, slugifyKey } from './types'
+import type { ContentField, ContentType } from './types'
+
+/** The kinds a field may be declared as, in the order the admin offers them. */
+const KINDS = [
+	{ label: 'Text', value: 'text' },
+	{ label: 'Number', value: 'number' },
+	{ label: 'Yes or no', value: 'boolean' },
+	{ label: 'Date', value: 'date' },
+	{ label: 'Media', value: 'media' },
+	{ label: 'Relation', value: 'relation' },
+]
+
+/**
+ * Returns the key for a field query over one type.
+ * @param typeKey - The type the fields belong to.
+ * @returns The query key.
+ */
+export function fieldsQueryKey(typeKey: string): string[] {
+	return ['content-fields', typeKey]
+}
+
+/** One choice a select offers. */
+interface Choice {
+	label: string
+	value: string
+}
+
+/**
+ * Returns the choice a select change asks for.
+ * @param item - The item the select reported, or nothing.
+ * @param offered - The choices the select holds.
+ * @param current - The choice held.
+ * @returns The choice to hold.
+ */
+export function chosenOf(
+	item: { value: string | null } | null,
+	offered: Choice[],
+	current: Choice,
+): Choice {
+	if (item === null || item.value === null) {
+		return current
+	}
+	return offered.find((choice) => choice.value === item.value) ?? current
+}
+
+/**
+ * Renders the view declaring and removing the fields of one content type.
+ * @param props - The type whose fields are managed, the other types, and the reporter.
+ * @returns The control and its dialog.
+ */
+export function FieldsDialog(props: {
+	registered: ContentType
+	types: ContentType[]
+	onDone: (said: string) => void
+	onRefused: (cause: unknown) => void
+}) {
+	const [open, setOpen] = useState(false)
+	return (
+		<>
+			<Button variant="outline" onClick={() => setOpen(true)}>
+				Fields
+			</Button>
+			<Dialog.Root open={open} onOpenChange={setOpen}>
+				<Dialog.Popup>
+					<Dialog.Header>
+						<Dialog.Title>Fields of {props.registered.pluralLabel}</Dialog.Title>
+						<Dialog.CloseIcon />
+					</Dialog.Header>
+					<Dialog.Content>
+						<FieldsBody {...props} />
+					</Dialog.Content>
+				</Dialog.Popup>
+			</Dialog.Root>
+		</>
+	)
+}
+
+/**
+ * Renders the declared fields and the control adding another.
+ * @param props - The type whose fields are managed, the other types, and the reporter.
+ * @returns The body element.
+ */
+function FieldsBody(props: {
+	registered: ContentType
+	types: ContentType[]
+	onDone: (said: string) => void
+	onRefused: (cause: unknown) => void
+}) {
+	const client = useQueryClient()
+	const typeKey = props.registered.key
+	const held = useQuery({
+		queryKey: fieldsQueryKey(typeKey),
+		queryFn: () => listFields(typeKey),
+	})
+	/**
+	 * Reports what a field write did and refreshes what the screen holds.
+	 * @param said - The sentence naming what was done.
+	 */
+	async function done(said: string) {
+		props.onDone(said)
+		await Promise.all([
+			client.invalidateQueries({ queryKey: fieldsQueryKey(typeKey) }),
+			client.invalidateQueries({ queryKey: typesQueryKey }),
+		])
+	}
+	const declared = held.data ?? []
+	return (
+		<Stack direction="column" gap="md">
+			{declared.length === 0 ? (
+				<Text>This type declares no fields yet.</Text>
+			) : (
+				<ul className="godmin-plain-list">
+					{declared.map((field) => (
+						<li key={field.key}>
+							<Stack direction="row" gap="xs">
+								<Text>{field.label}</Text>
+								<Text variant="body-sm">{field.kind}</Text>
+								<RenameField
+									typeKey={typeKey}
+									field={field}
+									onDone={done}
+									onRefused={props.onRefused}
+								/>
+								<DeleteField
+									typeKey={typeKey}
+									field={field}
+									onDone={done}
+									onRefused={props.onRefused}
+								/>
+							</Stack>
+						</li>
+					))}
+				</ul>
+			)}
+			<AddField
+				registered={props.registered}
+				types={props.types}
+				onDone={done}
+				onRefused={props.onRefused}
+			/>
+		</Stack>
+	)
+}
+
+/**
+ * Renders the control declaring a new field.
+ * @param props - The type declaring the field, the other types, and the reporter.
+ * @returns The control element.
+ */
+function AddField(props: {
+	registered: ContentType
+	types: ContentType[]
+	onDone: (said: string) => Promise<void>
+	onRefused: (cause: unknown) => void
+}) {
+	const targets = props.types.map((listed) => ({
+		label: listed.pluralLabel,
+		value: listed.key,
+	}))
+	const [label, setLabel] = useState('')
+	const [kind, setKind] = useState(KINDS[0])
+	const [target, setTarget] = useState(targets[0])
+	const relating = kind.value === 'relation'
+	const add = useMutation({
+		mutationFn: () =>
+			createField(props.registered.key, {
+				key: slugifyKey(label),
+				label,
+				kind: kind.value,
+				relatesTo: relating ? target.value : undefined,
+				many: relating,
+			}),
+		onSuccess: async () => {
+			setLabel('')
+			await props.onDone(`${label} declared.`)
+		},
+		onError: props.onRefused,
+	})
+	return (
+		<Stack direction="column" gap="sm">
+			<InputControl label="Name" autoComplete="off" value={label} onValueChange={setLabel} />
+			<SelectControl
+				label="Kind"
+				items={KINDS}
+				value={kind}
+				onValueChange={(item) => setKind(chosenOf(item, KINDS, kind))}
+			/>
+			{relating && (
+				<SelectControl
+					label="Points at"
+					items={targets}
+					value={target}
+					onValueChange={(item) => setTarget(chosenOf(item, targets, target))}
+				/>
+			)}
+			<Button loading={add.isPending} onClick={() => add.mutate()}>
+				Add field
+			</Button>
+		</Stack>
+	)
+}
+
+/**
+ * Renders the control carrying a new label for a field.
+ * @param props - The type, the field, and the reporter.
+ * @returns The control and its dialog.
+ */
+function RenameField(props: {
+	typeKey: string
+	field: ContentField
+	onDone: (said: string) => Promise<void>
+	onRefused: (cause: unknown) => void
+}) {
+	const [open, setOpen] = useState(false)
+	const [label, setLabel] = useState(props.field.label)
+	const rename = useMutation({
+		mutationFn: () => renameField(props.typeKey, props.field.key, label),
+		onSuccess: async () => {
+			setOpen(false)
+			await props.onDone(`${label} renamed.`)
+		},
+		onError: (cause) => {
+			setOpen(false)
+			props.onRefused(cause)
+		},
+	})
+	return (
+		<>
+			<Button variant="outline" onClick={() => setOpen(true)}>
+				Rename {props.field.label}
+			</Button>
+			<Dialog.Root open={open} onOpenChange={setOpen}>
+				<Dialog.Popup>
+					<Dialog.Header>
+						<Dialog.Title>Rename {props.field.label}</Dialog.Title>
+						<Dialog.CloseIcon />
+					</Dialog.Header>
+					<Dialog.Content>
+						<Stack direction="column" gap="md">
+							<Text>The name changes. Nothing stored under this field moves.</Text>
+							<InputControl label="Name" value={label} onValueChange={setLabel} />
+						</Stack>
+					</Dialog.Content>
+					<Dialog.Footer>
+						<Button variant="outline" onClick={() => setOpen(false)}>
+							Keep it
+						</Button>
+						<Button loading={rename.isPending} onClick={() => rename.mutate()}>
+							Rename
+						</Button>
+					</Dialog.Footer>
+				</Dialog.Popup>
+			</Dialog.Root>
+		</>
+	)
+}
+
+/**
+ * Renders the control removing a field and everything stored under it.
+ * @param props - The type, the field, and the reporter.
+ * @returns The control and its dialog.
+ */
+function DeleteField(props: {
+	typeKey: string
+	field: ContentField
+	onDone: (said: string) => Promise<void>
+	onRefused: (cause: unknown) => void
+}) {
+	const [open, setOpen] = useState(false)
+	const remove = useMutation({
+		mutationFn: () => deleteField(props.typeKey, props.field.key),
+		onSuccess: async () => {
+			setOpen(false)
+			await props.onDone(`${props.field.label} deleted.`)
+		},
+		onError: (cause) => {
+			setOpen(false)
+			props.onRefused(cause)
+		},
+	})
+	return (
+		<>
+			<Button variant="outline" onClick={() => setOpen(true)}>
+				Delete {props.field.label}
+			</Button>
+			<Dialog.Root open={open} onOpenChange={setOpen}>
+				<Dialog.Popup>
+					<Dialog.Header>
+						<Dialog.Title>Delete {props.field.label}</Dialog.Title>
+						<Dialog.CloseIcon />
+					</Dialog.Header>
+					<Dialog.Content>
+						<Text>
+							Every value stored under this field goes with it, in every item of this type
+							and in the revisions behind them.
+						</Text>
+					</Dialog.Content>
+					<Dialog.Footer>
+						<Button variant="outline" onClick={() => setOpen(false)}>
+							Keep it
+						</Button>
+						<Button loading={remove.isPending} onClick={() => remove.mutate()}>
+							Delete the field
+						</Button>
+					</Dialog.Footer>
+				</Dialog.Popup>
+			</Dialog.Root>
+		</>
+	)
+}

--- a/frontend/src/content/FieldsPanel.tsx
+++ b/frontend/src/content/FieldsPanel.tsx
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { Stack } from '@gophenberg/frontend-sdk'
 import { DataForm } from '@gophenberg/frontend-sdk/dataviews'
 import type { Field } from '@gophenberg/frontend-sdk/dataviews'
 import { useMemo } from 'react'
 
+import { MediaField, mediaHeld } from './MediaField'
+import { RelationPicker, targetsHeld } from './RelationPicker'
 import type { ContentField } from './types'
 import type { EditorBuffer } from './useEditorBuffer'
 
@@ -25,6 +28,24 @@ const TYPES: Record<string, string> = {
  */
 export function editableFields(declared: ContentField[]): ContentField[] {
 	return declared.filter((field) => TYPES[field.kind] !== undefined)
+}
+
+/**
+ * Returns the fields a relation picker edits.
+ * @param declared - The fields the type declares.
+ * @returns The declared relation fields.
+ */
+export function relationFields(declared: ContentField[]): ContentField[] {
+	return declared.filter((field) => field.kind === 'relation')
+}
+
+/**
+ * Returns the fields the media library edits.
+ * @param declared - The fields the type declares.
+ * @returns The declared media fields.
+ */
+export function mediaFields(declared: ContentField[]): ContentField[] {
+	return declared.filter((field) => field.kind === 'media')
 }
 
 /**
@@ -62,25 +83,50 @@ export function clearedEdits(edits: FieldValues): FieldValues {
  * @returns The panel element, or nothing when the type declares none.
  */
 export function FieldsPanel({
+	postId,
 	declared,
 	buffer,
 }: {
+	postId: string
 	declared: ContentField[]
 	buffer: EditorBuffer
 }) {
 	const rendered = useMemo(() => editableFields(declared), [declared])
+	const related = useMemo(() => relationFields(declared), [declared])
+	const pictured = useMemo(() => mediaFields(declared), [declared])
 	const descriptors = useMemo(() => fieldDescriptors(rendered), [rendered])
-	if (rendered.length === 0) {
+	if (rendered.length === 0 && related.length === 0 && pictured.length === 0) {
 		return null
 	}
 	return (
-		<DataForm
-			data={buffer.fields}
-			fields={descriptors}
-			form={{ fields: rendered.map((field) => field.key) }}
-			onChange={(edits: FieldValues) =>
-				buffer.setFields({ ...buffer.fields, ...clearedEdits(edits) })
-			}
-		/>
+		<Stack direction="column" gap="md">
+			{rendered.length > 0 && (
+				<DataForm
+					data={buffer.fields}
+					fields={descriptors}
+					form={{ fields: rendered.map((field) => field.key) }}
+					onChange={(edits: FieldValues) =>
+						buffer.setFields({ ...buffer.fields, ...clearedEdits(edits) })
+					}
+				/>
+			)}
+			{related.map((field) => (
+				<RelationPicker
+					key={field.key}
+					field={field}
+					postId={postId}
+					targets={targetsHeld(buffer.fields[field.key])}
+					onChange={(targets) => buffer.setFields({ ...buffer.fields, [field.key]: targets })}
+				/>
+			))}
+			{pictured.map((field) => (
+				<MediaField
+					key={field.key}
+					field={field}
+					value={mediaHeld(buffer.fields[field.key])}
+					onChange={(value) => buffer.setFields({ ...buffer.fields, [field.key]: value })}
+				/>
+			))}
+		</Stack>
 	)
 }

--- a/frontend/src/content/FieldsPanel.tsx
+++ b/frontend/src/content/FieldsPanel.tsx
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { DataForm } from '@gophenberg/frontend-sdk/dataviews'
+import type { Field } from '@gophenberg/frontend-sdk/dataviews'
+import { useMemo } from 'react'
+
+import type { ContentField } from './types'
+import type { EditorBuffer } from './useEditorBuffer'
+
+/** The values the panel edits, keyed by field key. */
+type FieldValues = Record<string, unknown>
+
+/** The DataViews type a declared kind is edited as, absent for the kinds a picker owns. */
+const TYPES: Record<string, string> = {
+	text: 'text',
+	number: 'number',
+	boolean: 'boolean',
+	date: 'date',
+}
+
+/**
+ * Returns the fields the panel edits, which are the ones a control covers.
+ * @param declared - The fields the type declares.
+ * @returns The declared fields this panel renders.
+ */
+export function editableFields(declared: ContentField[]): ContentField[] {
+	return declared.filter((field) => TYPES[field.kind] !== undefined)
+}
+
+/**
+ * Returns the DataViews field descriptors for the declared fields.
+ * @param declared - The fields the panel renders.
+ * @returns The descriptors DataForm reads.
+ */
+export function fieldDescriptors(declared: ContentField[]): Field<FieldValues>[] {
+	return declared.map((field) => ({
+		id: field.key,
+		label: field.label,
+		type: TYPES[field.kind],
+		isValid: { required: field.required },
+		enableSorting: false,
+	})) as Field<FieldValues>[]
+}
+
+/**
+ * Returns the edits with every emptied control written as the value that clears its key.
+ * @param edits - The values the control reported.
+ * @returns The edits as the write path reads them.
+ */
+export function clearedEdits(edits: FieldValues): FieldValues {
+	return Object.fromEntries(
+		Object.entries(edits).map(([key, value]) => [
+			key,
+			value === undefined || value === '' ? null : value,
+		]),
+	)
+}
+
+/**
+ * Renders the panel editing the values of a type's declared fields.
+ * @param props - The buffer the panel drives and the fields the type declares.
+ * @returns The panel element, or nothing when the type declares none.
+ */
+export function FieldsPanel({
+	declared,
+	buffer,
+}: {
+	declared: ContentField[]
+	buffer: EditorBuffer
+}) {
+	const rendered = useMemo(() => editableFields(declared), [declared])
+	const descriptors = useMemo(() => fieldDescriptors(rendered), [rendered])
+	if (rendered.length === 0) {
+		return null
+	}
+	return (
+		<DataForm
+			data={buffer.fields}
+			fields={descriptors}
+			form={{ fields: rendered.map((field) => field.key) }}
+			onChange={(edits: FieldValues) =>
+				buffer.setFields({ ...buffer.fields, ...clearedEdits(edits) })
+			}
+		/>
+	)
+}

--- a/frontend/src/content/MediaField.tsx
+++ b/frontend/src/content/MediaField.tsx
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { Button, Stack, Text } from '@gophenberg/frontend-sdk'
+
+import { MediaLibraryPicker } from '../media/MediaLibraryPicker'
+import type { ContentField } from './types'
+
+/** What the control reports when a media field points at nothing. */
+const nothingChosen = 'No media chosen'
+
+/**
+ * Returns the media identity a stored value holds.
+ * @param value - The value the buffer holds under the field key.
+ * @returns The identity, or nothing when the field holds none.
+ */
+export function mediaHeld(value: unknown): number | undefined {
+	return typeof value === 'number' ? value : undefined
+}
+
+/**
+ * Returns the identity a picked attachment carries.
+ * @param picked - What the library reported.
+ * @returns The identity, or nothing when it reported none.
+ */
+export function pickedMedia(picked: unknown): number | null {
+	if (Array.isArray(picked)) {
+		return pickedMedia(picked[0])
+	}
+	if (typeof picked === 'object' && picked !== null && 'id' in picked) {
+		const held = (picked as { id: unknown }).id
+		return typeof held === 'number' ? held : null
+	}
+	return null
+}
+
+/**
+ * Renders the control pointing a media field at a stored upload.
+ * @param props - The field, the identity held, and what to do with a choice.
+ * @returns The control element.
+ */
+export function MediaField(props: {
+	field: ContentField
+	value: number | undefined
+	onChange: (value: number | null) => void
+}) {
+	return (
+		<Stack direction="column" gap="xs">
+			<Text variant="body-sm">{props.field.label}</Text>
+			<Text>{props.value === undefined ? nothingChosen : `Media ${props.value}`}</Text>
+			<MediaLibraryPicker
+				value={props.value}
+				onSelect={(picked) => props.onChange(pickedMedia(picked))}
+				onClose={() => {}}
+				render={({ open }) => (
+					<Button variant="outline" onClick={open}>
+						Choose {props.field.label}
+					</Button>
+				)}
+			/>
+			{props.value !== undefined && (
+				<Button variant="outline" onClick={() => props.onChange(null)}>
+					Clear {props.field.label}
+				</Button>
+			)}
+		</Stack>
+	)
+}

--- a/frontend/src/content/RelationPicker.tsx
+++ b/frontend/src/content/RelationPicker.tsx
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { Button, SelectControl, Stack, Text } from '@gophenberg/frontend-sdk'
+import { useQuery } from '@tanstack/react-query'
+
+import { listPosts } from './api'
+import type { ContentField } from './types'
+
+/** What the picker offers when a single target field points at nothing. */
+const noTarget = { label: 'None', value: '' }
+
+/**
+ * Returns the identities a stored relation value holds.
+ * @param value - The value the buffer holds under the field key.
+ * @returns The targets, or none when the field holds nothing.
+ */
+export function targetsHeld(value: unknown): string[] {
+	if (!Array.isArray(value)) {
+		return []
+	}
+	return value.filter((held): held is string => typeof held === 'string')
+}
+
+/**
+ * Returns the targets after the choice a single target select reported.
+ * @param item - The item the select reported, or nothing.
+ * @returns The targets to hold.
+ */
+export function chosenTarget(item: { value: string | null } | null): string[] {
+	if (item === null || item.value === null || item.value === '') {
+		return []
+	}
+	return [item.value]
+}
+
+/**
+ * Renders the control pointing a relation field at the content it names.
+ * @param props - The field, the item being edited, the targets held, and what to do with a choice.
+ * @returns The picker element.
+ */
+export function RelationPicker(props: {
+	field: ContentField
+	postId: string
+	targets: string[]
+	onChange: (targets: string[]) => void
+}) {
+	const held = useQuery({
+		queryKey: ['relation-targets', props.field.relatesTo],
+		queryFn: () => listPosts({ type: props.field.relatesTo }),
+	})
+	const candidates = (held.data?.items ?? []).filter((item) => item.id !== props.postId)
+	if (props.field.many) {
+		return <ManyTargets {...props} candidates={candidates} />
+	}
+	const items = [noTarget, ...candidates.map((item) => ({ label: item.title, value: item.id }))]
+	const selected = items.find((item) => item.value === (props.targets[0] ?? '')) ?? noTarget
+	return (
+		<SelectControl
+			label={props.field.label}
+			items={items}
+			value={selected}
+			onValueChange={(item) => props.onChange(chosenTarget(item))}
+		/>
+	)
+}
+
+/** One item a relation field may point at. */
+interface Candidate {
+	id: string
+	title: string
+}
+
+/**
+ * Renders the control holding many targets, with what is held above what may be added.
+ * @param props - The field, the targets held, the candidates, and what to do with a change.
+ * @returns The control element.
+ */
+function ManyTargets(props: {
+	field: ContentField
+	targets: string[]
+	candidates: Candidate[]
+	onChange: (targets: string[]) => void
+}) {
+	const named = props.targets.map((id) => ({
+		id,
+		title: props.candidates.find((candidate) => candidate.id === id)?.title ?? id,
+	}))
+	const open = props.candidates.filter((candidate) => !props.targets.includes(candidate.id))
+	const items = [
+		{ label: `Add ${props.field.label}`, value: '' },
+		...open.map((candidate) => ({ label: candidate.title, value: candidate.id })),
+	]
+	return (
+		<Stack direction="column" gap="xs">
+			<Text variant="body-sm">{props.field.label}</Text>
+			<ul className="gophenberg-editor__targets" aria-label={props.field.label}>
+				{named.map((target) => (
+					<li key={target.id}>
+						<Text>{target.title}</Text>
+						<Button
+							variant="outline"
+							onClick={() => props.onChange(props.targets.filter((id) => id !== target.id))}
+						>
+							Remove {target.title}
+						</Button>
+					</li>
+				))}
+			</ul>
+			<SelectControl
+				label={`Add ${props.field.label}`}
+				items={items}
+				value={items[0]}
+				onValueChange={(item) => {
+					const chosen = chosenTarget(item)
+					if (chosen.length > 0) {
+						props.onChange([...props.targets, chosen[0]])
+					}
+				}}
+			/>
+		</Stack>
+	)
+}

--- a/frontend/src/content/RelationPicker.tsx
+++ b/frontend/src/content/RelationPicker.tsx
@@ -3,11 +3,14 @@
 import { Button, SelectControl, Stack, Text } from '@gophenberg/frontend-sdk'
 import { useQuery } from '@tanstack/react-query'
 
-import { listPosts } from './api'
+import { listEveryPost } from './api'
 import type { ContentField } from './types'
 
 /** What the picker offers when a single target field points at nothing. */
 const noTarget = { label: 'None', value: '' }
+
+/** The status an item carries while it waits in the trash. */
+const trashed = 'trash'
 
 /**
  * Returns the identities a stored relation value holds.
@@ -46,9 +49,11 @@ export function RelationPicker(props: {
 }) {
 	const held = useQuery({
 		queryKey: ['relation-targets', props.field.relatesTo],
-		queryFn: () => listPosts({ type: props.field.relatesTo }),
+		queryFn: () => listEveryPost({ type: props.field.relatesTo }),
 	})
-	const candidates = (held.data?.items ?? []).filter((item) => item.id !== props.postId)
+	const candidates = (held.data ?? []).filter(
+		(item) => item.id !== props.postId && item.status !== trashed,
+	)
 	if (props.field.many) {
 		return <ManyTargets {...props} candidates={candidates} />
 	}

--- a/frontend/src/content/RestoreBanner.tsx
+++ b/frontend/src/content/RestoreBanner.tsx
@@ -19,8 +19,20 @@ function holdsKeptWords(kept: Autosave, stored: PostDetail): boolean {
 	return (
 		kept.title === stored.title &&
 		kept.content === stored.content &&
-		kept.excerpt === stored.excerpt
+		kept.excerpt === stored.excerpt &&
+		holdsKeptValues(kept.fields, stored.fields)
 	)
+}
+
+/**
+ * Reports whether the kept values are the ones the post already holds.
+ * @param kept - The values the browser parked.
+ * @param stored - The values the post holds.
+ * @returns True when nothing was kept back.
+ */
+function holdsKeptValues(kept: Record<string, unknown>, stored: Record<string, unknown>): boolean {
+	const keys = Object.keys(kept)
+	return keys.length === Object.keys(stored).length && keys.every((key) => kept[key] === stored[key])
 }
 
 /**

--- a/frontend/src/content/RestoreBanner.tsx
+++ b/frontend/src/content/RestoreBanner.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react'
 
 import { fetchAutosave } from './api'
 import type { Autosave, PostDetail } from './api'
+import { sameFieldValues } from './fieldValues'
 
 const MESSAGE = 'The browser kept an unsaved version of this post.'
 
@@ -20,19 +21,8 @@ function holdsKeptWords(kept: Autosave, stored: PostDetail): boolean {
 		kept.title === stored.title &&
 		kept.content === stored.content &&
 		kept.excerpt === stored.excerpt &&
-		holdsKeptValues(kept.fields, stored.fields)
+		sameFieldValues(kept.fields, stored.fields)
 	)
-}
-
-/**
- * Reports whether the kept values are the ones the post already holds.
- * @param kept - The values the browser parked.
- * @param stored - The values the post holds.
- * @returns True when nothing was kept back.
- */
-function holdsKeptValues(kept: Record<string, unknown>, stored: Record<string, unknown>): boolean {
-	const keys = Object.keys(kept)
-	return keys.length === Object.keys(stored).length && keys.every((key) => kept[key] === stored[key])
 }
 
 /**

--- a/frontend/src/content/TypesScreen.tsx
+++ b/frontend/src/content/TypesScreen.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import type { ReactNode } from 'react'
 
+import { FieldsDialog } from './FieldsDialog'
 import { typesQueryKey } from './nav'
 import { createType, deleteType, listTypes, updateType } from './types'
 import type { ContentType, TypeEdit } from './types'
@@ -128,6 +129,7 @@ function TypesBody(props: Reporter & { types: ContentType[]; loading: boolean; f
 							key={registered.key}
 							registered={registered}
 							holder={props.types.find((listed) => listed.isDefault)}
+							types={props.types}
 							onDone={props.onDone}
 							onRefused={props.onRefused}
 						/>
@@ -143,7 +145,9 @@ function TypesBody(props: Reporter & { types: ContentType[]; loading: boolean; f
  * @param props - The type and the reporter.
  * @returns The row element.
  */
-function TypeRow(props: Reporter & { registered: ContentType; holder?: ContentType }): ReactNode {
+function TypeRow(
+	props: Reporter & { registered: ContentType; holder?: ContentType; types: ContentType[] },
+): ReactNode {
 	const { registered } = props
 	const edit = useMutation({
 		mutationFn: (asked: TypeEdit) => updateType(registered.key, asked),
@@ -174,6 +178,12 @@ function TypeRow(props: Reporter & { registered: ContentType; holder?: ContentTy
 			<td>
 				<Stack direction="row" gap="xs">
 					<ChangeAddress registered={registered} onMove={(word) => edit.mutate({ routeWord: word })} />
+					<FieldsDialog
+						registered={registered}
+						types={props.types}
+						onDone={props.onDone}
+						onRefused={props.onRefused}
+					/>
 					{!registered.isDefault && (
 						<HandOverRoot
 							registered={registered}

--- a/frontend/src/content/api.ts
+++ b/frontend/src/content/api.ts
@@ -21,7 +21,10 @@ const postSchema = z.object({
 	updated_at: z.string().optional(),
 })
 
-const detailSchema = postSchema.extend({ content: z.string() })
+const detailSchema = postSchema.extend({
+	content: z.string(),
+	fields: z.record(z.string(), z.unknown()).optional(),
+})
 
 const pageSchema = z.object({ items: z.array(postSchema), total: z.number() })
 
@@ -101,6 +104,7 @@ export async function createPost(type = 'post'): Promise<Post> {
 
 export interface PostDetail extends Post {
 	content: string
+	fields: Record<string, unknown>
 }
 
 export interface PostChanges {
@@ -110,6 +114,7 @@ export interface PostChanges {
 	slug?: string
 	status?: string
 	parent_id?: string | null
+	fields?: Record<string, unknown>
 }
 
 export type SaveOutcome =
@@ -123,7 +128,7 @@ export type SaveOutcome =
  * @returns The post with its content.
  */
 function toDetail(row: z.infer<typeof detailSchema>): PostDetail {
-	return { ...toPost(row), content: row.content }
+	return { ...toPost(row), content: row.content, fields: row.fields ?? {} }
 }
 
 /**
@@ -179,6 +184,7 @@ export interface AutosaveBuffer {
 	title: string
 	content: string
 	excerpt: string
+	fields: Record<string, unknown>
 }
 
 export interface Autosave extends AutosaveBuffer {
@@ -195,6 +201,7 @@ const autosaveSchema = z.object({
 	title: z.string(),
 	content: z.string(),
 	excerpt: z.string(),
+	fields: z.record(z.string(), z.unknown()).optional(),
 	saved_at: z.string(),
 })
 
@@ -209,7 +216,13 @@ export async function fetchAutosave(id: string): Promise<Autosave | null> {
 		return null
 	}
 	const row = autosaveSchema.parse(await response.json())
-	return { title: row.title, content: row.content, excerpt: row.excerpt, savedAt: row.saved_at }
+	return {
+		title: row.title,
+		content: row.content,
+		excerpt: row.excerpt,
+		fields: row.fields ?? {},
+		savedAt: row.saved_at,
+	}
 }
 
 /**

--- a/frontend/src/content/api.ts
+++ b/frontend/src/content/api.ts
@@ -328,9 +328,9 @@ export async function listPosts(query: PostQuery): Promise<PostPage> {
 }
 
 /**
- * Returns every post the query names, asking page after page until none are left.
+ * Returns the posts the query names, asking page after page up to the reading ceiling.
  * @param query - The listing to read, without paging.
- * @returns Every post the listing holds.
+ * @returns The posts the listing holds, up to the pages the ceiling allows.
  */
 export async function listEveryPost(query: PostQuery): Promise<Post[]> {
 	const held: Post[] = []
@@ -341,7 +341,7 @@ export async function listEveryPost(query: PostQuery): Promise<Post[]> {
 			return held
 		}
 	}
-	throw new Error('listing every post did not finish')
+	return held
 }
 
 /**

--- a/frontend/src/content/api.ts
+++ b/frontend/src/content/api.ts
@@ -4,6 +4,10 @@ import { z } from 'zod'
 
 const POSTS_PER_PAGE = 20
 
+const MAX_POSTS_PER_PAGE = 100
+
+const MAX_LISTING_PAGES = 100
+
 const MAX_EMPTY_ROUNDS = 50
 
 const postSchema = z.object({
@@ -57,6 +61,7 @@ export interface PostQuery {
 	status?: string
 	search?: string
 	page?: number
+	perPage?: number
 	orderBy?: string
 	order?: string
 }
@@ -295,7 +300,7 @@ export async function deletePost(id: string): Promise<void> {
  * @returns The page and the total number of matches.
  */
 export async function listPosts(query: PostQuery): Promise<PostPage> {
-	const params = new URLSearchParams({ per_page: String(POSTS_PER_PAGE) })
+	const params = new URLSearchParams({ per_page: String(query.perPage ?? POSTS_PER_PAGE) })
 	if (query.type) {
 		params.set('type', query.type)
 	}
@@ -320,6 +325,23 @@ export async function listPosts(query: PostQuery): Promise<PostPage> {
 	}
 	const page = pageSchema.parse(await response.json())
 	return { items: page.items.map(toPost), total: page.total }
+}
+
+/**
+ * Returns every post the query names, asking page after page until none are left.
+ * @param query - The listing to read, without paging.
+ * @returns Every post the listing holds.
+ */
+export async function listEveryPost(query: PostQuery): Promise<Post[]> {
+	const held: Post[] = []
+	for (let page = 1; page <= MAX_LISTING_PAGES; page += 1) {
+		const read = await listPosts({ ...query, page, perPage: MAX_POSTS_PER_PAGE })
+		held.push(...read.items)
+		if (held.length >= read.total || read.items.length === 0) {
+			return held
+		}
+	}
+	throw new Error('listing every post did not finish')
 }
 
 /**

--- a/frontend/src/content/fieldValues.ts
+++ b/frontend/src/content/fieldValues.ts
@@ -18,6 +18,18 @@ export function sameFieldValues(held: FieldValues, other: FieldValues): boolean 
 }
 
 /**
+ * Returns the field values that moved away from the ones the server last reported.
+ * @param held - The values the buffer holds.
+ * @param settled - The values the server last reported.
+ * @returns Only the keys whose value changed.
+ */
+export function changedFieldValues(held: FieldValues, settled: FieldValues): FieldValues {
+	return Object.fromEntries(
+		Object.entries(held).filter(([key, value]) => !sameValue(value, settled[key])),
+	)
+}
+
+/**
  * Reports whether two field values stand for the same thing.
  * @param held - The value one side holds.
  * @param other - The value the other side holds.

--- a/frontend/src/content/fieldValues.ts
+++ b/frontend/src/content/fieldValues.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/** The values of a type's declared fields, keyed by field key. */
+export type FieldValues = Record<string, unknown>
+
+/**
+ * Reports whether two sets of field values hold the same things.
+ * @param held - The values one side holds.
+ * @param other - The values the other side holds.
+ * @returns True when both sides declare the same keys and every key holds an equal value.
+ */
+export function sameFieldValues(held: FieldValues, other: FieldValues): boolean {
+	const keys = Object.keys(held)
+	if (keys.length !== Object.keys(other).length) {
+		return false
+	}
+	return keys.every((key) => sameValue(held[key], other[key]))
+}
+
+/**
+ * Reports whether two field values stand for the same thing.
+ * @param held - The value one side holds.
+ * @param other - The value the other side holds.
+ * @returns True when the values match, comparing relation lists by their ordered targets.
+ */
+function sameValue(held: unknown, other: unknown): boolean {
+	if (Array.isArray(held) || Array.isArray(other)) {
+		return (
+			Array.isArray(held) &&
+			Array.isArray(other) &&
+			held.length === other.length &&
+			held.every((target, i) => target === other[i])
+		)
+	}
+	return held === other
+}

--- a/frontend/src/content/types.ts
+++ b/frontend/src/content/types.ts
@@ -199,3 +199,99 @@ export async function deleteType(key: string): Promise<void> {
 		await refuse(response, 'removing a content type')
 	}
 }
+
+/**
+ * Returns the key a label reduces to.
+ * @param label - The name the operator typed.
+ * @returns The slug the label reduces to.
+ */
+export function slugifyKey(label: string): string {
+	return label
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+}
+
+/** What declaring a field needs. */
+export interface NewField {
+	key: string
+	label: string
+	kind: string
+	relatesTo?: string
+	many?: boolean
+	required?: boolean
+}
+
+/**
+ * Returns the fields a content type declares.
+ * @param typeKey - The type whose fields to read.
+ * @returns The declared fields.
+ */
+export async function listFields(typeKey: string): Promise<ContentField[]> {
+	const response = await fetch(`/api/types/${typeKey}/fields`)
+	if (!response.ok) {
+		await refuse(response, 'reading the fields')
+	}
+	const listed = z.object({ items: z.array(fieldSchema) }).parse(await response.json())
+	return listed.items.map(toField)
+}
+
+/**
+ * Declares a field on a content type.
+ * @param typeKey - The type declaring the field.
+ * @param asked - The field to declare.
+ * @returns The stored field.
+ */
+export async function createField(typeKey: string, asked: NewField): Promise<ContentField> {
+	const response = await fetch(`/api/types/${typeKey}/fields`, {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify({
+			key: asked.key,
+			label: asked.label,
+			kind: asked.kind,
+			relates_to: asked.relatesTo,
+			many: asked.many,
+			required: asked.required,
+		}),
+	})
+	if (!response.ok) {
+		await refuse(response, 'declaring the field')
+	}
+	return toField(fieldSchema.parse(await response.json()))
+}
+
+/**
+ * Carries a new label for a declared field.
+ * @param typeKey - The type declaring the field.
+ * @param key - The field to relabel.
+ * @param label - The label to carry.
+ * @returns The stored field.
+ */
+export async function renameField(
+	typeKey: string,
+	key: string,
+	label: string,
+): Promise<ContentField> {
+	const response = await fetch(`/api/types/${typeKey}/fields/${key}`, {
+		method: 'PATCH',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify({ label }),
+	})
+	if (!response.ok) {
+		await refuse(response, 'renaming the field')
+	}
+	return toField(fieldSchema.parse(await response.json()))
+}
+
+/**
+ * Removes a declared field and every value it held.
+ * @param typeKey - The type declaring the field.
+ * @param key - The field to remove.
+ */
+export async function deleteField(typeKey: string, key: string): Promise<void> {
+	const response = await fetch(`/api/types/${typeKey}/fields/${key}`, { method: 'DELETE' })
+	if (!response.ok) {
+		await refuse(response, 'deleting the field')
+	}
+}

--- a/frontend/src/content/types.ts
+++ b/frontend/src/content/types.ts
@@ -2,6 +2,15 @@
 
 import { z } from 'zod'
 
+const fieldSchema = z.object({
+	key: z.string(),
+	label: z.string(),
+	kind: z.string(),
+	relates_to: z.string().optional(),
+	many: z.boolean(),
+	required: z.boolean(),
+})
+
 const typeSchema = z.object({
 	key: z.string(),
 	singular_label: z.string(),
@@ -13,11 +22,22 @@ const typeSchema = z.object({
 	page_kind: z.string(),
 	default: z.boolean(),
 	active: z.boolean(),
+	fields: z.array(fieldSchema).optional(),
 })
 
 const typeListSchema = z.object({ items: z.array(typeSchema) })
 
 const refusalSchema = z.object({ error: z.string() })
+
+/** One typed field a content type declares. */
+export interface ContentField {
+	key: string
+	label: string
+	kind: string
+	relatesTo: string
+	many: boolean
+	required: boolean
+}
 
 /** A content type as the admin reads it. */
 export interface ContentType {
@@ -31,6 +51,7 @@ export interface ContentType {
 	pageKind: string
 	isDefault: boolean
 	active: boolean
+	fields: ContentField[]
 }
 
 /** What registering a type needs. */
@@ -67,6 +88,23 @@ function toType(row: z.infer<typeof typeSchema>): ContentType {
 		pageKind: row.page_kind,
 		isDefault: row.default,
 		active: row.active,
+		fields: (row.fields ?? []).map(toField),
+	}
+}
+
+/**
+ * Returns the admin view of one declared field.
+ * @param row - The field as the API answered it.
+ * @returns The field the admin reads.
+ */
+function toField(row: z.infer<typeof fieldSchema>): ContentField {
+	return {
+		key: row.key,
+		label: row.label,
+		kind: row.kind,
+		relatesTo: row.relates_to ?? '',
+		many: row.many,
+		required: row.required,
 	}
 }
 

--- a/frontend/src/content/useAutosave.ts
+++ b/frontend/src/content/useAutosave.ts
@@ -37,7 +37,7 @@ export function useAutosave(
 			}
 			void autosavePost(
 				postId,
-				{ title: held.title, content: held.content, excerpt: held.excerpt },
+				{ title: held.title, content: held.content, excerpt: held.excerpt, fields: held.fields },
 				held.version,
 				keepalive,
 			)

--- a/frontend/src/content/useContentType.ts
+++ b/frontend/src/content/useContentType.ts
@@ -19,6 +19,7 @@ const unknownType: ContentType = {
 	pageKind: 'single',
 	isDefault: false,
 	active: true,
+	fields: [],
 }
 
 /**

--- a/frontend/src/content/useEditorBuffer.ts
+++ b/frontend/src/content/useEditorBuffer.ts
@@ -18,6 +18,7 @@ export interface EditorBuffer {
 	slug: string
 	parentId: string | null
 	excerpt: string
+	fields: Record<string, unknown>
 	dirty: boolean
 	saving: boolean
 	version: string
@@ -28,7 +29,8 @@ export interface EditorBuffer {
 	setSlug: (slug: string) => void
 	setParentId: (parentId: string | null) => void
 	setExcerpt: (excerpt: string) => void
-	restore: (kept: { title: string, content: string, excerpt: string }) => void
+	setFields: (fields: Record<string, unknown>) => void
+	restore: (kept: { title: string, content: string, excerpt: string, fields: Record<string, unknown> }) => void
 	onInput: (blocks: Block[]) => void
 	onChange: (blocks: Block[]) => void
 	undo: () => void
@@ -52,6 +54,7 @@ export function useEditorBuffer(postId: string, stored: PostDetail): EditorBuffe
 	const [slug, setSlug] = useState(stored.slug)
 	const [parentId, setParentId] = useState(stored.parentId)
 	const [excerpt, setExcerpt] = useState(stored.excerpt)
+	const [fields, setFields] = useState(stored.fields)
 	const [version, setVersion] = useState(stored.updatedAt)
 	const [saved, setSaved] = useState({
 		title: stored.title,
@@ -60,6 +63,7 @@ export function useEditorBuffer(postId: string, stored: PostDetail): EditorBuffe
 		parentId: stored.parentId,
 		excerpt: stored.excerpt,
 		status: stored.status,
+		fields: stored.fields,
 	})
 	const history = useStateWithHistory<Block[]>(parse(stored.content))
 	const blocks = history.value as Block[]
@@ -91,11 +95,13 @@ export function useEditorBuffer(postId: string, stored: PostDetail): EditorBuffe
 			parentId: written.parentId,
 			excerpt: written.excerpt,
 			status: written.status,
+			fields: written.fields,
 		})
 		setStatus(written.status)
 		setSlug(written.slug)
 		setParentId(written.parentId)
 		setExcerpt(written.excerpt)
+		setFields(written.fields)
 		setVersion(written.updatedAt)
 	}
 	return {
@@ -107,13 +113,15 @@ export function useEditorBuffer(postId: string, stored: PostDetail): EditorBuffe
 		slug,
 		parentId,
 		excerpt,
+		fields,
 		dirty:
 			title !== saved.title ||
 			content !== saved.content ||
 			slug !== saved.slug ||
 			parentId !== saved.parentId ||
 			excerpt !== saved.excerpt ||
-			status !== saved.status,
+			status !== saved.status ||
+			!sameFields(fields, saved.fields),
 		saving: write.isPending,
 		version,
 		hasUndo: history.hasUndo,
@@ -123,20 +131,46 @@ export function useEditorBuffer(postId: string, stored: PostDetail): EditorBuffe
 		setSlug,
 		setParentId,
 		setExcerpt,
-		restore: (kept: { title: string, content: string, excerpt: string }) => {
+		setFields,
+		restore: (kept: {
+			title: string
+			content: string
+			excerpt: string
+			fields: Record<string, unknown>
+		}) => {
 			setTitle(kept.title)
 			setExcerpt(kept.excerpt)
+			setFields(kept.fields)
 			history.setValue(parse(kept.content), false)
 		},
 		onInput: (next: Block[]) => history.setValue(next, true),
 		onChange: (next: Block[]) => history.setValue(next, false),
 		undo: history.undo,
 		redo: history.redo,
-		save: () => write.mutate({ title, content, slug, excerpt, status, parent_id: parentId }),
+		save: () => write.mutate({ title, content, slug, excerpt, status, parent_id: parentId, fields }),
 		publish: () =>
-			write.mutate({ title, content, slug, excerpt, status: 'published', parent_id: parentId }),
+			write.mutate({
+				title,
+				content,
+				slug,
+				excerpt,
+				status: 'published',
+				parent_id: parentId,
+				fields,
+			}),
 		adoptVersion: setVersion,
 	}
+}
+
+/**
+ * Reports whether two sets of field values hold the same things.
+ * @param held - The values the buffer holds.
+ * @param saved - The values the server last reported.
+ * @returns True when nothing moved.
+ */
+function sameFields(held: Record<string, unknown>, saved: Record<string, unknown>): boolean {
+	const keys = Object.keys(held)
+	return keys.length === Object.keys(saved).length && keys.every((key) => held[key] === saved[key])
 }
 
 /**

--- a/frontend/src/content/useEditorBuffer.ts
+++ b/frontend/src/content/useEditorBuffer.ts
@@ -8,6 +8,7 @@ import { useMemo, useState } from 'react'
 
 import { savePost } from './api'
 import type { PostChanges, PostDetail, SaveOutcome } from './api'
+import { sameFieldValues } from './fieldValues'
 
 export interface EditorBuffer {
 	title: string
@@ -121,7 +122,7 @@ export function useEditorBuffer(postId: string, stored: PostDetail): EditorBuffe
 			parentId !== saved.parentId ||
 			excerpt !== saved.excerpt ||
 			status !== saved.status ||
-			!sameFields(fields, saved.fields),
+			!sameFieldValues(fields, saved.fields),
 		saving: write.isPending,
 		version,
 		hasUndo: history.hasUndo,
@@ -140,7 +141,7 @@ export function useEditorBuffer(postId: string, stored: PostDetail): EditorBuffe
 		}) => {
 			setTitle(kept.title)
 			setExcerpt(kept.excerpt)
-			setFields(kept.fields)
+			setFields({ ...fields, ...kept.fields })
 			history.setValue(parse(kept.content), false)
 		},
 		onInput: (next: Block[]) => history.setValue(next, true),
@@ -160,17 +161,6 @@ export function useEditorBuffer(postId: string, stored: PostDetail): EditorBuffe
 			}),
 		adoptVersion: setVersion,
 	}
-}
-
-/**
- * Reports whether two sets of field values hold the same things.
- * @param held - The values the buffer holds.
- * @param saved - The values the server last reported.
- * @returns True when nothing moved.
- */
-function sameFields(held: Record<string, unknown>, saved: Record<string, unknown>): boolean {
-	const keys = Object.keys(held)
-	return keys.length === Object.keys(saved).length && keys.every((key) => held[key] === saved[key])
 }
 
 /**

--- a/frontend/src/content/useEditorBuffer.ts
+++ b/frontend/src/content/useEditorBuffer.ts
@@ -8,7 +8,7 @@ import { useMemo, useState } from 'react'
 
 import { savePost } from './api'
 import type { PostChanges, PostDetail, SaveOutcome } from './api'
-import { sameFieldValues } from './fieldValues'
+import { changedFieldValues, sameFieldValues } from './fieldValues'
 
 export interface EditorBuffer {
 	title: string
@@ -148,7 +148,16 @@ export function useEditorBuffer(postId: string, stored: PostDetail): EditorBuffe
 		onChange: (next: Block[]) => history.setValue(next, false),
 		undo: history.undo,
 		redo: history.redo,
-		save: () => write.mutate({ title, content, slug, excerpt, status, parent_id: parentId, fields }),
+		save: () =>
+			write.mutate({
+				title,
+				content,
+				slug,
+				excerpt,
+				status,
+				parent_id: parentId,
+				fields: changedFieldValues(fields, saved.fields),
+			}),
 		publish: () =>
 			write.mutate({
 				title,
@@ -157,7 +166,7 @@ export function useEditorBuffer(postId: string, stored: PostDetail): EditorBuffe
 				excerpt,
 				status: 'published',
 				parent_id: parentId,
-				fields,
+				fields: changedFieldValues(fields, saved.fields),
 			}),
 		adoptVersion: setVersion,
 	}

--- a/frontend/src/test/editor-fields-autosave.test.tsx
+++ b/frontend/src/test/editor-fields-autosave.test.tsx
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { http, HttpResponse, server } from '@gophenberg/frontend-sdk/testing'
+import { act, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest'
+
+import { renderAt } from './render'
+import { storedPost } from './postFixture'
+
+const EDITOR_PATH = `/content/post/${storedPost.id}/edit`
+
+const AUTOSAVE_INTERVAL = 60000
+
+const autosaved: Record<string, unknown>[] = []
+
+const TYPE_WITH_FIELDS = {
+	key: 'post',
+	singular_label: 'Post',
+	plural_label: 'Posts',
+	route_word: '',
+	hierarchical: false,
+	revisions: true,
+	revision_cap: 100,
+	page_kind: 'single',
+	default: true,
+	active: true,
+	created_at: '2026-08-01T10:00:00Z',
+	updated_at: '2026-08-01T10:00:00Z',
+	fields: [{ key: 'color', label: 'Color', kind: 'text', many: false, required: false }],
+}
+
+beforeAll(async () => {
+	await import('../content/EditorScreen')
+}, 120000)
+
+beforeEach(() => {
+	autosaved.length = 0
+	vi.useFakeTimers({ shouldAdvanceTime: true })
+	server.use(
+		http.get('/api/types', () => HttpResponse.json({ items: [TYPE_WITH_FIELDS] })),
+		http.get(`/api/content/${storedPost.id}`, () =>
+			HttpResponse.json({ ...storedPost, fields: { color: 'red' } }),
+		),
+		http.get(`/api/content/${storedPost.id}/autosave`, () => HttpResponse.json({}, { status: 404 })),
+		http.post(`/api/content/${storedPost.id}/autosave`, async ({ request }) => {
+			autosaved.push((await request.json()) as Record<string, unknown>)
+			return HttpResponse.json({
+				target: 'autosave',
+				content_id: storedPost.id,
+				title: storedPost.title,
+				content: storedPost.content,
+				excerpt: '',
+				fields: { color: 'blue' },
+				saved_at: '2026-08-01T12:00:00Z',
+			})
+		}),
+	)
+})
+
+afterEach(() => {
+	vi.useRealTimers()
+})
+
+/**
+ * Advances the clock inside a React update.
+ * @param ms - The milliseconds to advance.
+ */
+async function tick(ms: number) {
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(ms)
+	})
+}
+
+test('parks the field values the buffer holds', async () => {
+	renderAt(EDITOR_PATH)
+	const control = await screen.findByLabelText('Color')
+
+	await userEvent.clear(control)
+	await userEvent.type(control, 'blue')
+	await tick(AUTOSAVE_INTERVAL)
+
+	await waitFor(() => expect(autosaved).toHaveLength(1))
+	expect(autosaved[0]).toMatchObject({ fields: { color: 'blue' } })
+})
+
+test('parks a field edit even when no word moved', async () => {
+	renderAt(EDITOR_PATH)
+	const control = await screen.findByLabelText('Color')
+
+	await userEvent.clear(control)
+	await userEvent.type(control, 'green')
+	await tick(AUTOSAVE_INTERVAL)
+
+	await waitFor(() => expect(autosaved).toHaveLength(1))
+	expect(autosaved[0]).toMatchObject({ title: storedPost.title, fields: { color: 'green' } })
+})
+
+test('brings the parked field values back when the buffer is restored', async () => {
+	const sent: Record<string, unknown>[] = []
+	server.use(
+		http.get(`/api/content/${storedPost.id}/autosave`, () =>
+			HttpResponse.json({
+				target: 'autosave',
+				content_id: storedPost.id,
+				title: storedPost.title,
+				content: storedPost.content,
+				excerpt: '',
+				fields: { color: 'parked' },
+				saved_at: '2026-08-01T12:00:00Z',
+			}),
+		),
+		http.patch(`/api/content/${storedPost.id}`, async ({ request }) => {
+			sent.push((await request.json()) as Record<string, unknown>)
+			return HttpResponse.json({ ...storedPost, fields: { color: 'parked' } })
+		}),
+	)
+	renderAt(EDITOR_PATH)
+
+	await userEvent.click(await screen.findByRole('button', { name: 'Restore' }))
+
+	await waitFor(() => expect(screen.getByLabelText('Color')).toHaveValue('parked'))
+	await userEvent.click(screen.getByRole('button', { name: 'Save draft' }))
+	await waitFor(() => expect(sent).toHaveLength(1))
+	expect(sent[0]).toMatchObject({ fields: { color: 'parked' } })
+})

--- a/frontend/src/test/editor-fields-relations.test.tsx
+++ b/frontend/src/test/editor-fields-relations.test.tsx
@@ -70,6 +70,28 @@ beforeEach(() => {
 	)
 })
 
+test('leaves a trashed item out of what a relation field may point at', async () => {
+	server.use(
+		http.get('/api/types', () => HttpResponse.json({ items: [typeDeclaring([ONE_CATEGORY])] })),
+		http.get('/api/content', () =>
+			HttpResponse.json({
+				items: [
+					{ ...storedPost, ...NEWS, type: 'category', slug: 'news' },
+					{ ...storedPost, ...GUIDES, type: 'category', slug: 'guides', status: 'trash' },
+				],
+				total: 2,
+			}),
+		),
+	)
+	renderAt(EDITOR_PATH)
+
+	const picker = await screen.findByLabelText('Category')
+	await userEvent.click(picker)
+
+	expect(await screen.findByRole('option', { name: 'News' })).toBeInTheDocument()
+	expect(screen.queryByRole('option', { name: 'Guides' })).not.toBeInTheDocument()
+})
+
 test('offers the items of the type a relation field points at', async () => {
 	server.use(http.get('/api/types', () => HttpResponse.json({ items: [typeDeclaring([ONE_CATEGORY])] })))
 	renderAt(EDITOR_PATH)

--- a/frontend/src/test/editor-fields-relations.test.tsx
+++ b/frontend/src/test/editor-fields-relations.test.tsx
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { http, HttpResponse, server } from '@gophenberg/frontend-sdk/testing'
+import { screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeAll, beforeEach, expect, test } from 'vitest'
+
+import { renderAt } from './render'
+import { storedPost } from './postFixture'
+
+const EDITOR_PATH = `/content/post/${storedPost.id}/edit`
+
+const NEWS = { id: '019fb000-0000-7000-8000-0000000000a1', title: 'News' }
+
+const GUIDES = { id: '019fb000-0000-7000-8000-0000000000a2', title: 'Guides' }
+
+/**
+ * Returns the post type declaring the given fields.
+ * @param fields - The field definitions the type declares.
+ * @returns The type as the registry answers it.
+ */
+function typeDeclaring(fields: unknown[]) {
+	return {
+		key: 'post',
+		singular_label: 'Post',
+		plural_label: 'Posts',
+		route_word: '',
+		hierarchical: false,
+		revisions: true,
+		revision_cap: 100,
+		page_kind: 'single',
+		default: true,
+		active: true,
+		created_at: '2026-08-01T10:00:00Z',
+		updated_at: '2026-08-01T10:00:00Z',
+		fields,
+	}
+}
+
+const ONE_CATEGORY = {
+	key: 'category',
+	label: 'Category',
+	kind: 'relation',
+	relates_to: 'category',
+	many: false,
+	required: false,
+}
+
+const MANY_CATEGORIES = { ...ONE_CATEGORY, key: 'categories', label: 'Categories', many: true }
+
+beforeAll(async () => {
+	await import('../content/EditorScreen')
+}, 120000)
+
+beforeEach(() => {
+	server.use(
+		http.get(`/api/content/${storedPost.id}`, () => HttpResponse.json(storedPost)),
+		http.get('/api/content', ({ request }) => {
+			if (new URL(request.url).searchParams.get('type') !== 'category') {
+				return HttpResponse.json({ items: [], total: 0 })
+			}
+			return HttpResponse.json({
+				items: [
+					{ ...storedPost, ...NEWS, type: 'category', slug: 'news' },
+					{ ...storedPost, ...GUIDES, type: 'category', slug: 'guides' },
+				],
+				total: 2,
+			})
+		}),
+	)
+})
+
+test('offers the items of the type a relation field points at', async () => {
+	server.use(http.get('/api/types', () => HttpResponse.json({ items: [typeDeclaring([ONE_CATEGORY])] })))
+	renderAt(EDITOR_PATH)
+
+	const picker = await screen.findByLabelText('Category')
+	await userEvent.click(picker)
+
+	expect(await screen.findByRole('option', { name: 'News' })).toBeInTheDocument()
+	expect(screen.getByRole('option', { name: 'Guides' })).toBeInTheDocument()
+})
+
+test('sends the target a relation field was pointed at', async () => {
+	const sent: Record<string, unknown>[] = []
+	server.use(
+		http.get('/api/types', () => HttpResponse.json({ items: [typeDeclaring([ONE_CATEGORY])] })),
+		http.patch(`/api/content/${storedPost.id}`, async ({ request }) => {
+			sent.push((await request.json()) as Record<string, unknown>)
+			return HttpResponse.json({ ...storedPost, fields: { category: [NEWS.id] } })
+		}),
+	)
+	renderAt(EDITOR_PATH)
+
+	await userEvent.click(await screen.findByLabelText('Category'))
+	await userEvent.click(await screen.findByRole('option', { name: 'News' }))
+	await userEvent.click(screen.getByRole('button', { name: 'Save draft' }))
+
+	await waitFor(() => expect(sent).toHaveLength(1))
+	expect(sent[0]).toMatchObject({ fields: { category: [NEWS.id] } })
+})
+
+test('shows the targets a many field already holds', async () => {
+	server.use(
+		http.get('/api/types', () => HttpResponse.json({ items: [typeDeclaring([MANY_CATEGORIES])] })),
+		http.get(`/api/content/${storedPost.id}`, () =>
+			HttpResponse.json({ ...storedPost, fields: { categories: [NEWS.id] } }),
+		),
+	)
+	renderAt(EDITOR_PATH)
+
+	const held = await screen.findByRole('list', { name: 'Categories' })
+
+	expect(await within(held).findByText('News')).toBeInTheDocument()
+})
+
+test('adds a second target to a many field', async () => {
+	const sent: Record<string, unknown>[] = []
+	server.use(
+		http.get('/api/types', () => HttpResponse.json({ items: [typeDeclaring([MANY_CATEGORIES])] })),
+		http.get(`/api/content/${storedPost.id}`, () =>
+			HttpResponse.json({ ...storedPost, fields: { categories: [NEWS.id] } }),
+		),
+		http.patch(`/api/content/${storedPost.id}`, async ({ request }) => {
+			sent.push((await request.json()) as Record<string, unknown>)
+			return HttpResponse.json({ ...storedPost, fields: { categories: [NEWS.id, GUIDES.id] } })
+		}),
+	)
+	renderAt(EDITOR_PATH)
+
+	await userEvent.click(await screen.findByLabelText('Add Categories'))
+	await userEvent.click(await screen.findByRole('option', { name: 'Guides' }))
+	await userEvent.click(screen.getByRole('button', { name: 'Save draft' }))
+
+	await waitFor(() => expect(sent).toHaveLength(1))
+	expect(sent[0]).toMatchObject({ fields: { categories: [NEWS.id, GUIDES.id] } })
+})
+
+test('takes a target off a many field', async () => {
+	const sent: Record<string, unknown>[] = []
+	server.use(
+		http.get('/api/types', () => HttpResponse.json({ items: [typeDeclaring([MANY_CATEGORIES])] })),
+		http.get(`/api/content/${storedPost.id}`, () =>
+			HttpResponse.json({ ...storedPost, fields: { categories: [NEWS.id] } }),
+		),
+		http.patch(`/api/content/${storedPost.id}`, async ({ request }) => {
+			sent.push((await request.json()) as Record<string, unknown>)
+			return HttpResponse.json({ ...storedPost, fields: { categories: [] } })
+		}),
+	)
+	renderAt(EDITOR_PATH)
+	const held = await screen.findByRole('list', { name: 'Categories' })
+
+	await userEvent.click(await within(held).findByRole('button', { name: 'Remove News' }))
+	await userEvent.click(screen.getByRole('button', { name: 'Save draft' }))
+
+	await waitFor(() => expect(sent).toHaveLength(1))
+	expect(sent[0]).toMatchObject({ fields: { categories: [] } })
+})
+
+test('leaves the item itself out of a relation to its own type', async () => {
+	const ownType = { ...ONE_CATEGORY, key: 'related', label: 'Related', relates_to: 'post' }
+	server.use(
+		http.get('/api/types', () => HttpResponse.json({ items: [typeDeclaring([ownType])] })),
+		http.get('/api/content', () =>
+			HttpResponse.json({
+				items: [storedPost, { ...storedPost, ...NEWS, slug: 'news' }],
+				total: 2,
+			}),
+		),
+	)
+	renderAt(EDITOR_PATH)
+
+	await userEvent.click(await screen.findByLabelText('Related'))
+
+	expect(await screen.findByRole('option', { name: 'News' })).toBeInTheDocument()
+	expect(screen.queryByRole('option', { name: storedPost.title })).not.toBeInTheDocument()
+})
+
+test('holds the media a media field was pointed at', async () => {
+	const sent: Record<string, unknown>[] = []
+	const mediaField = {
+		key: 'cover',
+		label: 'Cover',
+		kind: 'media',
+		relates_to: '',
+		many: false,
+		required: false,
+	}
+	server.use(
+		http.get('/api/types', () => HttpResponse.json({ items: [typeDeclaring([mediaField])] })),
+		http.get('/api/media', () =>
+			HttpResponse.json({
+				items: [
+					{
+						id: 12,
+						type: 'image',
+						file: '2026/08/shore.jpg',
+						title: 'Shore',
+						alt_text: 'A quiet shore',
+						caption: '',
+						mime_type: 'image/jpeg',
+						width: 1600,
+						height: 1000,
+						filesize: 254000,
+						sizes: {},
+						updated_at: storedPost.updated_at,
+					},
+				],
+				total: 1,
+			}),
+		),
+		http.patch(`/api/content/${storedPost.id}`, async ({ request }) => {
+			sent.push((await request.json()) as Record<string, unknown>)
+			return HttpResponse.json({ ...storedPost, fields: { cover: 12 } })
+		}),
+	)
+	renderAt(EDITOR_PATH)
+
+	await userEvent.click(await screen.findByRole('button', { name: 'Choose Cover' }))
+	await userEvent.click(await screen.findByText('Shore'))
+	await userEvent.click(screen.getByRole('button', { name: /^Select$/ }))
+	await userEvent.click(screen.getByRole('button', { name: 'Save draft' }))
+
+	await waitFor(() => expect(sent).toHaveLength(1))
+	expect(sent[0]).toMatchObject({ fields: { cover: 12 } })
+})
+
+test('clears the media a field held', async () => {
+	const sent: Record<string, unknown>[] = []
+	const mediaField = {
+		key: 'cover',
+		label: 'Cover',
+		kind: 'media',
+		relates_to: '',
+		many: false,
+		required: false,
+	}
+	server.use(
+		http.get('/api/types', () => HttpResponse.json({ items: [typeDeclaring([mediaField])] })),
+		http.get(`/api/content/${storedPost.id}`, () =>
+			HttpResponse.json({ ...storedPost, fields: { cover: 12 } }),
+		),
+		http.patch(`/api/content/${storedPost.id}`, async ({ request }) => {
+			sent.push((await request.json()) as Record<string, unknown>)
+			return HttpResponse.json({ ...storedPost, fields: {} })
+		}),
+	)
+	renderAt(EDITOR_PATH)
+
+	await userEvent.click(await screen.findByRole('button', { name: 'Clear Cover' }))
+	await userEvent.click(screen.getByRole('button', { name: 'Save draft' }))
+
+	await waitFor(() => expect(sent).toHaveLength(1))
+	expect(sent[0]).toMatchObject({ fields: { cover: null } })
+})
+
+test('shows none when the target held is no longer offered', async () => {
+	server.use(
+		http.get('/api/types', () => HttpResponse.json({ items: [typeDeclaring([ONE_CATEGORY])] })),
+		http.get(`/api/content/${storedPost.id}`, () =>
+			HttpResponse.json({ ...storedPost, fields: { category: ['019fb000-0000-7000-8000-0000000000ff'] } }),
+		),
+	)
+	renderAt(EDITOR_PATH)
+
+	const picker = await screen.findByLabelText('Category')
+	await userEvent.click(picker)
+
+	expect(await screen.findByRole('option', { name: 'News' })).toBeInTheDocument()
+	expect(picker).not.toHaveTextContent('019fb000')
+})
+
+test('adds nothing when the placeholder is chosen', async () => {
+	const sent: Record<string, unknown>[] = []
+	server.use(
+		http.get('/api/types', () => HttpResponse.json({ items: [typeDeclaring([MANY_CATEGORIES])] })),
+		http.get(`/api/content/${storedPost.id}`, () =>
+			HttpResponse.json({ ...storedPost, fields: { categories: [NEWS.id] } }),
+		),
+		http.patch(`/api/content/${storedPost.id}`, async ({ request }) => {
+			sent.push((await request.json()) as Record<string, unknown>)
+			return HttpResponse.json({ ...storedPost, fields: { categories: [NEWS.id] } })
+		}),
+	)
+	renderAt(EDITOR_PATH)
+
+	await userEvent.click(await screen.findByLabelText('Add Categories'))
+	await userEvent.click(await screen.findByRole('option', { name: 'Add Categories' }))
+	await userEvent.type(screen.getByRole('textbox', { name: 'Title' }), '!')
+	await userEvent.click(screen.getByRole('button', { name: 'Save draft' }))
+
+	await waitFor(() => expect(sent).toHaveLength(1))
+	expect(sent[0]).toMatchObject({ fields: { categories: [NEWS.id] } })
+})

--- a/frontend/src/test/editor-fields-relations.test.tsx
+++ b/frontend/src/test/editor-fields-relations.test.tsx
@@ -313,5 +313,5 @@ test('adds nothing when the placeholder is chosen', async () => {
 	await userEvent.click(screen.getByRole('button', { name: 'Save draft' }))
 
 	await waitFor(() => expect(sent).toHaveLength(1))
-	expect(sent[0]).toMatchObject({ fields: { categories: [NEWS.id] } })
+	expect(sent[0].fields).toEqual({})
 })

--- a/frontend/src/test/editor-fields.test.tsx
+++ b/frontend/src/test/editor-fields.test.tsx
@@ -88,11 +88,11 @@ test('sends the edited values when the post is saved', async () => {
 	expect(sent[0]).toMatchObject({ fields: { color: 'blue' } })
 })
 
-test('keeps the stored values when only the title moved', async () => {
-	const sent: unknown[] = []
+test('sends no field values when only the title moved', async () => {
+	const sent: Record<string, unknown>[] = []
 	server.use(
 		http.patch(`/api/content/${storedPost.id}`, async ({ request }) => {
-			sent.push(await request.json())
+			sent.push((await request.json()) as Record<string, unknown>)
 			return HttpResponse.json({ ...storedPost, fields: { color: 'red' } })
 		}),
 	)
@@ -103,7 +103,30 @@ test('keeps the stored values when only the title moved', async () => {
 	await userEvent.click(screen.getByRole('button', { name: 'Save draft' }))
 
 	await waitFor(() => expect(sent).toHaveLength(1))
-	expect(sent[0]).toMatchObject({ fields: { color: 'red' } })
+	expect(sent[0].fields).toEqual({})
+})
+
+test('sends no value for a field the type stopped declaring', async () => {
+	const sent: Record<string, unknown>[] = []
+	server.use(
+		http.get('/api/types', () =>
+			HttpResponse.json({ items: [{ ...TYPE_WITH_FIELDS, fields: [] }] }),
+		),
+		http.get(`/api/content/${storedPost.id}`, () =>
+			HttpResponse.json({ ...storedPost, fields: { color: 'red' } }),
+		),
+		http.patch(`/api/content/${storedPost.id}`, async ({ request }) => {
+			sent.push((await request.json()) as Record<string, unknown>)
+			return HttpResponse.json({ ...storedPost, fields: { color: 'red' } })
+		}),
+	)
+	renderAt(EDITOR_PATH)
+
+	await userEvent.type(await screen.findByRole('textbox', { name: 'Title' }), ' again')
+	await userEvent.click(screen.getByRole('button', { name: 'Save draft' }))
+
+	await waitFor(() => expect(sent).toHaveLength(1))
+	expect(sent[0].fields).toEqual({})
 })
 
 test('clears a number field when its control is emptied', async () => {

--- a/frontend/src/test/editor-fields.test.tsx
+++ b/frontend/src/test/editor-fields.test.tsx
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { http, HttpResponse, server } from '@gophenberg/frontend-sdk/testing'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeAll, beforeEach, expect, test } from 'vitest'
+
+import { renderAt } from './render'
+import { storedPost } from './postFixture'
+
+const EDITOR_PATH = `/content/post/${storedPost.id}/edit`
+
+const TYPE_WITH_FIELDS = {
+	key: 'post',
+	singular_label: 'Post',
+	plural_label: 'Posts',
+	route_word: '',
+	hierarchical: false,
+	revisions: true,
+	revision_cap: 100,
+	page_kind: 'single',
+	default: true,
+	active: true,
+	created_at: '2026-08-01T10:00:00Z',
+	updated_at: '2026-08-01T10:00:00Z',
+	fields: [
+		{ key: 'color', label: 'Color', kind: 'text', many: false, required: false },
+		{ key: 'doors', label: 'Doors', kind: 'number', many: false, required: false },
+		{ key: 'boxed', label: 'Boxed', kind: 'boolean', many: false, required: false },
+	],
+}
+
+beforeAll(async () => {
+	await import('../content/EditorScreen')
+}, 120000)
+
+beforeEach(() => {
+	server.use(
+		http.get('/api/types', () => HttpResponse.json({ items: [TYPE_WITH_FIELDS] })),
+		http.get(`/api/content/${storedPost.id}`, () =>
+			HttpResponse.json({ ...storedPost, fields: { color: 'red' } }),
+		),
+	)
+})
+
+test('shows a control for every scalar field the type declares', async () => {
+	renderAt(EDITOR_PATH)
+
+	expect(await screen.findByLabelText('Color')).toBeInTheDocument()
+	expect(screen.getByLabelText('Doors')).toBeInTheDocument()
+	expect(screen.getByLabelText('Boxed')).toBeInTheDocument()
+})
+
+test('shows the value the post holds', async () => {
+	renderAt(EDITOR_PATH)
+
+	expect(await screen.findByLabelText('Color')).toHaveValue('red')
+})
+
+test('shows no panel when the type declares no fields', async () => {
+	server.use(
+		http.get('/api/types', () =>
+			HttpResponse.json({ items: [{ ...TYPE_WITH_FIELDS, fields: [] }] }),
+		),
+	)
+	renderAt(EDITOR_PATH)
+	await screen.findByRole('tab', { name: 'Document' })
+
+	expect(screen.queryByLabelText('Color')).not.toBeInTheDocument()
+})
+
+test('sends the edited values when the post is saved', async () => {
+	const sent: unknown[] = []
+	server.use(
+		http.patch(`/api/content/${storedPost.id}`, async ({ request }) => {
+			sent.push(await request.json())
+			return HttpResponse.json({ ...storedPost, fields: { color: 'blue' } })
+		}),
+	)
+	renderAt(EDITOR_PATH)
+	const control = await screen.findByLabelText('Color')
+
+	await userEvent.clear(control)
+	await userEvent.type(control, 'blue')
+	await userEvent.click(screen.getByRole('button', { name: 'Save draft' }))
+
+	await waitFor(() => expect(sent).toHaveLength(1))
+	expect(sent[0]).toMatchObject({ fields: { color: 'blue' } })
+})
+
+test('keeps the stored values when only the title moved', async () => {
+	const sent: unknown[] = []
+	server.use(
+		http.patch(`/api/content/${storedPost.id}`, async ({ request }) => {
+			sent.push(await request.json())
+			return HttpResponse.json({ ...storedPost, fields: { color: 'red' } })
+		}),
+	)
+	renderAt(EDITOR_PATH)
+	await screen.findByLabelText('Color')
+
+	await userEvent.type(screen.getByRole('textbox', { name: 'Title' }), ' again')
+	await userEvent.click(screen.getByRole('button', { name: 'Save draft' }))
+
+	await waitFor(() => expect(sent).toHaveLength(1))
+	expect(sent[0]).toMatchObject({ fields: { color: 'red' } })
+})
+
+test('clears a number field when its control is emptied', async () => {
+	const sent: Record<string, unknown>[] = []
+	server.use(
+		http.get(`/api/content/${storedPost.id}`, () =>
+			HttpResponse.json({ ...storedPost, fields: { doors: 4 } }),
+		),
+		http.patch(`/api/content/${storedPost.id}`, async ({ request }) => {
+			sent.push((await request.json()) as Record<string, unknown>)
+			return HttpResponse.json({ ...storedPost, fields: {} })
+		}),
+	)
+	renderAt(EDITOR_PATH)
+	const control = await screen.findByLabelText('Doors')
+
+	await userEvent.clear(control)
+	await userEvent.click(screen.getByRole('button', { name: 'Save draft' }))
+
+	await waitFor(() => expect(sent).toHaveLength(1))
+	expect(sent[0].fields).toEqual({ doors: null })
+})

--- a/frontend/src/test/field-values.test.ts
+++ b/frontend/src/test/field-values.test.ts
@@ -2,7 +2,7 @@
 
 import { expect, test } from 'vitest'
 
-import { sameFieldValues } from '../content/fieldValues'
+import { changedFieldValues, sameFieldValues } from '../content/fieldValues'
 
 test('holds two sets of scalar values equal when every key matches', () => {
 	expect(sameFieldValues({ color: 'red', doors: 4 }, { color: 'red', doors: 4 })).toBe(true)
@@ -23,4 +23,13 @@ test('holds two relation lists equal when they name the same targets in order', 
 test('parts a relation list from a value that is no list', () => {
 	expect(sameFieldValues({ categories: ['a'] }, { categories: 'a' })).toBe(false)
 	expect(sameFieldValues({ categories: 'a' }, { categories: ['a'] })).toBe(false)
+})
+
+test('takes only the values that moved', () => {
+	const settled = { color: 'red', doors: 4, categories: ['a'] }
+
+	expect(changedFieldValues({ ...settled, color: 'blue' }, settled)).toEqual({ color: 'blue' })
+	expect(changedFieldValues(settled, settled)).toEqual({})
+	expect(changedFieldValues({ ...settled, categories: ['a'] }, settled)).toEqual({})
+	expect(changedFieldValues({ ...settled, color: null }, settled)).toEqual({ color: null })
 })

--- a/frontend/src/test/field-values.test.ts
+++ b/frontend/src/test/field-values.test.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, test } from 'vitest'
+
+import { sameFieldValues } from '../content/fieldValues'
+
+test('holds two sets of scalar values equal when every key matches', () => {
+	expect(sameFieldValues({ color: 'red', doors: 4 }, { color: 'red', doors: 4 })).toBe(true)
+	expect(sameFieldValues({ color: 'red' }, { color: 'blue' })).toBe(false)
+})
+
+test('parts two sets declaring different keys', () => {
+	expect(sameFieldValues({ color: 'red' }, { color: 'red', doors: 4 })).toBe(false)
+	expect(sameFieldValues({ color: 'red', doors: 4 }, { color: 'red' })).toBe(false)
+})
+
+test('holds two relation lists equal when they name the same targets in order', () => {
+	expect(sameFieldValues({ categories: ['a', 'b'] }, { categories: ['a', 'b'] })).toBe(true)
+	expect(sameFieldValues({ categories: ['a', 'b'] }, { categories: ['b', 'a'] })).toBe(false)
+	expect(sameFieldValues({ categories: ['a'] }, { categories: ['a', 'b'] })).toBe(false)
+})
+
+test('parts a relation list from a value that is no list', () => {
+	expect(sameFieldValues({ categories: ['a'] }, { categories: 'a' })).toBe(false)
+	expect(sameFieldValues({ categories: 'a' }, { categories: ['a'] })).toBe(false)
+})

--- a/frontend/src/test/fields-api.test.ts
+++ b/frontend/src/test/fields-api.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { http, HttpResponse, server } from '@gophenberg/frontend-sdk/testing'
+import { expect, test } from 'vitest'
+
+import { chosenOf, fieldsQueryKey } from '../content/FieldsDialog'
+import { createField, deleteField, listFields, renameField, slugifyKey } from '../content/types'
+
+const COLOR = { key: 'color', label: 'Color', kind: 'text', many: false, required: false }
+
+test('names the query a type is read for', () => {
+	expect(fieldsQueryKey('post')).toEqual(['content-fields', 'post'])
+})
+
+test('keeps the choice held when the select reported nothing it offers', () => {
+	const offered = [
+		{ label: 'Text', value: 'text' },
+		{ label: 'Number', value: 'number' },
+	]
+
+	expect(chosenOf(null, offered, offered[0])).toBe(offered[0])
+	expect(chosenOf({ value: null }, offered, offered[0])).toBe(offered[0])
+	expect(chosenOf({ value: 'nothing' }, offered, offered[0])).toBe(offered[0])
+	expect(chosenOf({ value: 'number' }, offered, offered[0])).toBe(offered[1])
+})
+
+test('reduces a label to the key it declares', () => {
+	expect(slugifyKey('Sold On')).toBe('sold-on')
+	expect(slugifyKey('  Colour!  ')).toBe('colour')
+})
+
+test('reads the fields a type declares', async () => {
+	server.use(http.get('/api/types/post/fields', () => HttpResponse.json({ items: [COLOR] })))
+
+	const held = await listFields('post')
+
+	expect(held).toEqual([
+		{ key: 'color', label: 'Color', kind: 'text', relatesTo: '', many: false, required: false },
+	])
+})
+
+test('carries the reason a field could not be read', async () => {
+	server.use(
+		http.get('/api/types/post/fields', () =>
+			HttpResponse.json({ error: 'content: type not found' }, { status: 404 }),
+		),
+	)
+
+	await expect(listFields('post')).rejects.toThrow('content: type not found')
+})
+
+test('carries the reason a field was refused', async () => {
+	server.use(
+		http.post('/api/types/post/fields', () =>
+			HttpResponse.json({ error: 'content: field key taken' }, { status: 422 }),
+		),
+	)
+
+	await expect(createField('post', { key: 'color', label: 'Color', kind: 'text' })).rejects.toThrow(
+		'content: field key taken',
+	)
+})
+
+test('carries the reason a rename was refused', async () => {
+	server.use(
+		http.patch('/api/types/post/fields/color', () =>
+			HttpResponse.json({ error: 'content: field not found' }, { status: 404 }),
+		),
+	)
+
+	await expect(renameField('post', 'color', 'Paint')).rejects.toThrow('content: field not found')
+})
+
+test('carries the reason a delete was refused', async () => {
+	server.use(
+		http.delete('/api/types/post/fields/color', () =>
+			HttpResponse.json({ error: 'content: field not found' }, { status: 404 }),
+		),
+	)
+
+	await expect(deleteField('post', 'color')).rejects.toThrow('content: field not found')
+})
+
+test('declares a relation field with the target it names', async () => {
+	const sent: unknown[] = []
+	server.use(
+		http.post('/api/types/post/fields', async ({ request }) => {
+			sent.push(await request.json())
+			return HttpResponse.json({ ...COLOR, kind: 'relation', relates_to: 'category', many: true })
+		}),
+	)
+
+	const held = await createField('post', {
+		key: 'categories',
+		label: 'Categories',
+		kind: 'relation',
+		relatesTo: 'category',
+		many: true,
+	})
+
+	expect(sent[0]).toMatchObject({ kind: 'relation', relates_to: 'category', many: true })
+	expect(held.relatesTo).toBe('category')
+})

--- a/frontend/src/test/fields-panel.test.ts
+++ b/frontend/src/test/fields-panel.test.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, test } from 'vitest'
+
+import { clearedEdits, editableFields, fieldDescriptors } from '../content/FieldsPanel'
+import type { ContentField } from '../content/types'
+
+/**
+ * Returns a declared field of the given kind.
+ * @param kind - The kind the field holds.
+ * @param required - Whether publishing demands a value.
+ * @returns The declared field.
+ */
+function declared(kind: string, required = false): ContentField {
+	return { key: `a-${kind}`, label: kind, kind, relatesTo: '', many: false, required }
+}
+
+test('writes an emptied control as the value that clears its key', () => {
+	expect(clearedEdits({ doors: undefined, 'sold-on': '', color: 'red', boxed: false })).toEqual({
+		doors: null,
+		'sold-on': null,
+		color: 'red',
+		boxed: false,
+	})
+})
+
+test('keeps a zero, which is a value rather than an empty control', () => {
+	expect(clearedEdits({ doors: 0 })).toEqual({ doors: 0 })
+})
+
+test('renders the kinds a control covers', () => {
+	const held = [declared('text'), declared('number'), declared('boolean'), declared('date')]
+
+	expect(editableFields(held)).toHaveLength(4)
+})
+
+test('leaves the kinds a picker owns to the part that builds them', () => {
+	const held = [declared('media'), declared('relation'), declared('text')]
+
+	expect(editableFields(held).map((field) => field.kind)).toEqual(['text'])
+})
+
+test('gives every kind its own field type', () => {
+	const held = [declared('text'), declared('number'), declared('boolean'), declared('date')]
+
+	expect(fieldDescriptors(held).map((descriptor) => descriptor.type)).toEqual([
+		'text',
+		'number',
+		'boolean',
+		'date',
+	])
+})
+
+test('marks a required field so the form can say so', () => {
+	expect(fieldDescriptors([declared('text', true)])[0].isValid).toEqual({ required: true })
+})

--- a/frontend/src/test/media-field.test.ts
+++ b/frontend/src/test/media-field.test.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, test } from 'vitest'
+
+import { mediaHeld, pickedMedia } from '../content/MediaField'
+
+test('reads the identity a media field holds', () => {
+	expect(mediaHeld(12)).toBe(12)
+})
+
+test('reads nothing when a media field holds no number', () => {
+	expect(mediaHeld(undefined)).toBeUndefined()
+	expect(mediaHeld('12')).toBeUndefined()
+})
+
+test('takes the first of the attachments the library reported', () => {
+	expect(pickedMedia([{ id: 12 }, { id: 13 }])).toBe(12)
+})
+
+test('takes the identity of the one attachment the library reported', () => {
+	expect(pickedMedia({ id: 12 })).toBe(12)
+})
+
+test('reports nothing when the library named no identity', () => {
+	expect(pickedMedia(undefined)).toBeNull()
+	expect(pickedMedia({ id: 'twelve' })).toBeNull()
+	expect(pickedMedia([])).toBeNull()
+})

--- a/frontend/src/test/postFixture.ts
+++ b/frontend/src/test/postFixture.ts
@@ -8,6 +8,7 @@ export const storedPost = {
 	excerpt: '',
 	content: '<!-- wp:paragraph -->\n<p>Stored words.</p>\n<!-- /wp:paragraph -->',
 	status: 'draft',
+	fields: {},
 	author_id: '019fb000-0000-7000-8000-0000000000ff',
 	author_name: 'Maria Perez',
 	published_at: null,

--- a/frontend/src/test/posts-api.test.ts
+++ b/frontend/src/test/posts-api.test.ts
@@ -3,7 +3,7 @@
 import { http, HttpResponse, server } from '@gophenberg/frontend-sdk/testing'
 import { expect, test } from 'vitest'
 
-import { fetchPostCounts, listPosts } from '../content/api'
+import { fetchPostCounts, listEveryPost, listPosts } from '../content/api'
 
 const ROW = {
 	id: '019fb000-0000-7000-8000-000000000001',
@@ -99,6 +99,48 @@ test('lists the type it was asked for', async () => {
 	await listPosts({ type: 'page' })
 
 	expect(new URLSearchParams(queries[0]).get('type')).toBe('page')
+})
+
+test('reads every post of a type, not just the first page', async () => {
+	const total = 130
+	const queries: string[] = []
+	server.use(
+		http.get('/api/content', ({ request }) => {
+			const params = new URL(request.url).searchParams
+			queries.push(params.toString())
+			const page = Number(params.get('page') ?? '1')
+			const perPage = Number(params.get('per_page'))
+			const held = Math.max(0, Math.min(perPage, total - (page - 1) * perPage))
+			return HttpResponse.json({
+				items: Array.from({ length: held }, (_, i) => ({
+					...ROW,
+					id: `019fb000-0000-7000-8000-${String((page - 1) * perPage + i).padStart(12, '0')}`,
+				})),
+				total,
+			})
+		}),
+	)
+
+	const held = await listEveryPost({ type: 'category' })
+
+	expect(held).toHaveLength(total)
+	expect(new Set(held.map((post) => post.id)).size).toBe(total)
+	expect(queries).toHaveLength(2)
+	expect(new URLSearchParams(queries[0]).get('per_page')).toBe('100')
+})
+
+test('stops reading pages when the listing reports nothing', async () => {
+	server.use(http.get('/api/content', () => HttpResponse.json({ items: [], total: 500 })))
+
+	await expect(listEveryPost({ type: 'category' })).resolves.toEqual([])
+})
+
+test('gives up when a listing never reaches the total it reports', async () => {
+	server.use(
+		http.get('/api/content', () => HttpResponse.json({ items: [ROW], total: Number.MAX_SAFE_INTEGER })),
+	)
+
+	await expect(listEveryPost({ type: 'category' })).rejects.toThrow(/did not finish/)
 })
 
 test('counts the type it was asked for', async () => {

--- a/frontend/src/test/posts-api.test.ts
+++ b/frontend/src/test/posts-api.test.ts
@@ -135,12 +135,14 @@ test('stops reading pages when the listing reports nothing', async () => {
 	await expect(listEveryPost({ type: 'category' })).resolves.toEqual([])
 })
 
-test('gives up when a listing never reaches the total it reports', async () => {
+test('stops at the reading ceiling when a listing never reaches its total', async () => {
 	server.use(
 		http.get('/api/content', () => HttpResponse.json({ items: [ROW], total: Number.MAX_SAFE_INTEGER })),
 	)
 
-	await expect(listEveryPost({ type: 'category' })).rejects.toThrow(/did not finish/)
+	const held = await listEveryPost({ type: 'category' })
+
+	expect(held).toHaveLength(100)
 })
 
 test('counts the type it was asked for', async () => {

--- a/frontend/src/test/relation-picker.test.ts
+++ b/frontend/src/test/relation-picker.test.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, test } from 'vitest'
+
+import { chosenTarget, targetsHeld } from '../content/RelationPicker'
+
+test('reads the targets a relation field holds', () => {
+	expect(targetsHeld(['a', 'b'])).toEqual(['a', 'b'])
+})
+
+test('reads no targets when the field holds something else', () => {
+	expect(targetsHeld(undefined)).toEqual([])
+	expect(targetsHeld('a')).toEqual([])
+	expect(targetsHeld([1, 'a'])).toEqual(['a'])
+})
+
+test('takes the target a select reported', () => {
+	expect(chosenTarget({ value: 'a' })).toEqual(['a'])
+})
+
+test('takes no target when the select reported none', () => {
+	expect(chosenTarget(null)).toEqual([])
+	expect(chosenTarget({ value: null })).toEqual([])
+	expect(chosenTarget({ value: '' })).toEqual([])
+})

--- a/frontend/src/test/types-fields.test.tsx
+++ b/frontend/src/test/types-fields.test.tsx
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { http, HttpResponse, server } from '@gophenberg/frontend-sdk/testing'
+import { screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, expect, test } from 'vitest'
+
+import { renderAt } from './render'
+
+const POST_TYPE = {
+	key: 'post',
+	singular_label: 'Post',
+	plural_label: 'Posts',
+	route_word: '',
+	hierarchical: false,
+	revisions: true,
+	revision_cap: 100,
+	page_kind: 'single',
+	default: true,
+	active: true,
+	fields: [],
+}
+
+const CATEGORY_TYPE = {
+	...POST_TYPE,
+	key: 'category',
+	singular_label: 'Category',
+	plural_label: 'Categories',
+	route_word: 'categories',
+	default: false,
+}
+
+const COLOR = { key: 'color', label: 'Color', kind: 'text', many: false, required: false }
+
+beforeEach(() => {
+	server.use(
+		http.get('/api/types', () => HttpResponse.json({ items: [POST_TYPE, CATEGORY_TYPE] })),
+		http.get('/api/types/post/fields', () => HttpResponse.json({ items: [] })),
+	)
+})
+
+/**
+ * Opens the fields view of the post type.
+ */
+async function openFields() {
+	renderAt('/content-types')
+	const table = await screen.findByRole('region', { name: 'Content Types' })
+	const posts = within(table).getByRole('row', { name: /Posts/ })
+	await userEvent.click(within(posts).getByRole('button', { name: 'Fields' }))
+}
+
+test('lists the fields a type declares', async () => {
+	server.use(http.get('/api/types/post/fields', () => HttpResponse.json({ items: [COLOR] })))
+
+	await openFields()
+
+	const held = await screen.findByRole('dialog')
+	expect(within(held).getByText('Color')).toBeInTheDocument()
+	expect(within(held).getByText('text')).toBeInTheDocument()
+})
+
+test('says when a type declares no fields yet', async () => {
+	await openFields()
+
+	const held = await screen.findByRole('dialog')
+	expect(within(held).getByText(/no fields yet/i)).toBeInTheDocument()
+})
+
+test('declares a field from the label it was given', async () => {
+	const sent: unknown[] = []
+	server.use(
+		http.post('/api/types/post/fields', async ({ request }) => {
+			sent.push(await request.json())
+			return HttpResponse.json(COLOR, { status: 201 })
+		}),
+	)
+	await openFields()
+	const held = await screen.findByRole('dialog')
+
+	await userEvent.type(within(held).getByLabelText('Name'), 'Color')
+	await userEvent.click(within(held).getByRole('button', { name: 'Add field' }))
+
+	await waitFor(() => expect(sent).toHaveLength(1))
+	expect(sent[0]).toMatchObject({ key: 'color', label: 'Color', kind: 'text' })
+})
+
+test('declares a relation field pointing at the type it names', async () => {
+	const sent: unknown[] = []
+	server.use(
+		http.post('/api/types/post/fields', async ({ request }) => {
+			sent.push(await request.json())
+			return HttpResponse.json(COLOR, { status: 201 })
+		}),
+	)
+	await openFields()
+	const held = await screen.findByRole('dialog')
+
+	await userEvent.type(within(held).getByLabelText('Name'), 'Categories')
+	await userEvent.click(within(held).getByLabelText('Kind'))
+	await userEvent.click(await screen.findByRole('option', { name: 'Relation' }))
+	await userEvent.click(within(held).getByLabelText('Points at'))
+	await userEvent.click(await screen.findByRole('option', { name: 'Categories' }))
+	await userEvent.click(within(held).getByRole('button', { name: 'Add field' }))
+
+	await waitFor(() => expect(sent).toHaveLength(1))
+	expect(sent[0]).toMatchObject({ kind: 'relation', relates_to: 'category' })
+})
+
+test('relabels a field without touching its key', async () => {
+	const sent: unknown[] = []
+	server.use(
+		http.get('/api/types/post/fields', () => HttpResponse.json({ items: [COLOR] })),
+		http.patch('/api/types/post/fields/color', async ({ request }) => {
+			sent.push(await request.json())
+			return HttpResponse.json({ ...COLOR, label: 'Paint' })
+		}),
+	)
+	await openFields()
+	const held = await screen.findByRole('dialog')
+
+	await userEvent.click(within(held).getByRole('button', { name: 'Rename Color' }))
+	const renaming = await screen.findByRole('dialog', { name: /rename/i })
+	await userEvent.clear(within(renaming).getByLabelText('Name'))
+	await userEvent.type(within(renaming).getByLabelText('Name'), 'Paint')
+	await userEvent.click(within(renaming).getByRole('button', { name: 'Rename' }))
+
+	await waitFor(() => expect(sent).toHaveLength(1))
+	expect(sent[0]).toEqual({ label: 'Paint' })
+})
+
+test('states what a delete sweeps before it sweeps it', async () => {
+	server.use(http.get('/api/types/post/fields', () => HttpResponse.json({ items: [COLOR] })))
+	await openFields()
+	const held = await screen.findByRole('dialog')
+
+	await userEvent.click(within(held).getByRole('button', { name: 'Delete Color' }))
+
+	const confirming = await screen.findByRole('dialog', { name: /delete/i })
+	expect(within(confirming).getByText(/every value/i)).toBeInTheDocument()
+})
+
+test('deletes a field once the sweep is confirmed', async () => {
+	let asked = ''
+	server.use(
+		http.get('/api/types/post/fields', () => HttpResponse.json({ items: [COLOR] })),
+		http.delete('/api/types/post/fields/color', ({ request }) => {
+			asked = new URL(request.url).pathname
+			return new HttpResponse(null, { status: 204 })
+		}),
+	)
+	await openFields()
+	const held = await screen.findByRole('dialog')
+
+	await userEvent.click(within(held).getByRole('button', { name: 'Delete Color' }))
+	const confirming = await screen.findByRole('dialog', { name: /delete/i })
+	await userEvent.click(within(confirming).getByRole('button', { name: 'Delete the field' }))
+
+	await waitFor(() => expect(asked).toBe('/api/types/post/fields/color'))
+})
+
+test('sweeps nothing when the delete is dismissed', async () => {
+	let asked = ''
+	server.use(
+		http.get('/api/types/post/fields', () => HttpResponse.json({ items: [COLOR] })),
+		http.delete('/api/types/post/fields/color', () => {
+			asked = 'called'
+			return new HttpResponse(null, { status: 204 })
+		}),
+	)
+	await openFields()
+	const held = await screen.findByRole('dialog')
+
+	await userEvent.click(within(held).getByRole('button', { name: 'Delete Color' }))
+	const confirming = await screen.findByRole('dialog', { name: /delete/i })
+	await userEvent.click(within(confirming).getByRole('button', { name: 'Keep it' }))
+
+	expect(asked).toBe('')
+})
+
+test('carries the reason the registry refused a field', async () => {
+	server.use(
+		http.post('/api/types/post/fields', () =>
+			HttpResponse.json({ error: 'content: field key taken' }, { status: 422 }),
+		),
+	)
+	await openFields()
+	const held = await screen.findByRole('dialog')
+
+	await userEvent.type(within(held).getByLabelText('Name'), 'Color')
+	await userEvent.click(within(held).getByRole('button', { name: 'Add field' }))
+
+	expect(await screen.findByText(/field key taken/)).toBeInTheDocument()
+})
+
+test('carries the reason a rename was refused', async () => {
+	server.use(
+		http.get('/api/types/post/fields', () => HttpResponse.json({ items: [COLOR] })),
+		http.patch('/api/types/post/fields/color', () =>
+			HttpResponse.json({ error: 'content: field not found' }, { status: 404 }),
+		),
+	)
+	await openFields()
+	const held = await screen.findByRole('dialog')
+
+	await userEvent.click(within(held).getByRole('button', { name: 'Rename Color' }))
+	const renaming = await screen.findByRole('dialog', { name: /rename/i })
+	await userEvent.click(within(renaming).getByRole('button', { name: 'Rename' }))
+
+	expect(await screen.findByText(/field not found/)).toBeInTheDocument()
+})
+
+test('carries the reason a delete was refused', async () => {
+	server.use(
+		http.get('/api/types/post/fields', () => HttpResponse.json({ items: [COLOR] })),
+		http.delete('/api/types/post/fields/color', () =>
+			HttpResponse.json({ error: 'content: field not found' }, { status: 404 }),
+		),
+	)
+	await openFields()
+	const held = await screen.findByRole('dialog')
+
+	await userEvent.click(within(held).getByRole('button', { name: 'Delete Color' }))
+	const confirming = await screen.findByRole('dialog', { name: /delete/i })
+	await userEvent.click(within(confirming).getByRole('button', { name: 'Delete the field' }))
+
+	expect(await screen.findByText(/field not found/)).toBeInTheDocument()
+})
+
+test('keeps a rename from being sent when it is dismissed', async () => {
+	const sent: unknown[] = []
+	server.use(
+		http.get('/api/types/post/fields', () => HttpResponse.json({ items: [COLOR] })),
+		http.patch('/api/types/post/fields/color', async ({ request }) => {
+			sent.push(await request.json())
+			return HttpResponse.json(COLOR)
+		}),
+	)
+	await openFields()
+	const held = await screen.findByRole('dialog')
+
+	await userEvent.click(within(held).getByRole('button', { name: 'Rename Color' }))
+	const renaming = await screen.findByRole('dialog', { name: /rename/i })
+	await userEvent.click(within(renaming).getByRole('button', { name: 'Keep it' }))
+
+	expect(sent).toHaveLength(0)
+})
+
+test('points a relation at the first type offered when none is chosen', async () => {
+	const sent: unknown[] = []
+	server.use(
+		http.post('/api/types/post/fields', async ({ request }) => {
+			sent.push(await request.json())
+			return HttpResponse.json(COLOR, { status: 201 })
+		}),
+	)
+	await openFields()
+	const held = await screen.findByRole('dialog')
+
+	await userEvent.type(within(held).getByLabelText('Name'), 'Related')
+	await userEvent.click(within(held).getByLabelText('Kind'))
+	await userEvent.click(await screen.findByRole('option', { name: 'Relation' }))
+	await userEvent.click(within(held).getByRole('button', { name: 'Add field' }))
+
+	await waitFor(() => expect(sent).toHaveLength(1))
+	expect(sent[0]).toMatchObject({ kind: 'relation', relates_to: 'post', many: true })
+})

--- a/internal/content/content.go
+++ b/internal/content/content.go
@@ -43,6 +43,7 @@ type Content struct {
 	Excerpt     string
 	Status      Status
 	AuthorID    uuid.UUID
+	Fields      Values
 	PublishedAt *time.Time
 	CreatedAt   time.Time
 	UpdatedAt   time.Time

--- a/internal/content/content.go
+++ b/internal/content/content.go
@@ -44,6 +44,7 @@ type Content struct {
 	Status      Status
 	AuthorID    uuid.UUID
 	Fields      Values
+	Relations   Relations
 	PublishedAt *time.Time
 	CreatedAt   time.Time
 	UpdatedAt   time.Time

--- a/internal/content/fields.go
+++ b/internal/content/fields.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package content
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+// ErrFieldNotFound reports that the type declares no field under the key.
+var ErrFieldNotFound = errors.New("content: field not found")
+
+// ErrFieldTaken reports that the type already declares a field under the key.
+var ErrFieldTaken = errors.New("content: field key taken")
+
+// ErrInvalidFieldKey reports that a field key is not a lowercase word.
+var ErrInvalidFieldKey = errors.New("content: invalid field key")
+
+// ErrInvalidFieldLabel reports that a field carries no label.
+var ErrInvalidFieldLabel = errors.New("content: invalid field label")
+
+// ErrInvalidFieldKind reports that a field kind is not one the CMS holds.
+var ErrInvalidFieldKind = errors.New("content: invalid field kind")
+
+// ErrRelationNeedsTarget reports that a relation field names no target type.
+var ErrRelationNeedsTarget = errors.New("content: a relation field needs a target type")
+
+// ErrFieldNotRelational reports that only a relation field takes a target or many.
+var ErrFieldNotRelational = errors.New("content: only a relation field takes a target or many")
+
+// ErrTargetUnknown reports that a relation field targets an unregistered type.
+var ErrTargetUnknown = errors.New("content: relation target unknown")
+
+// ErrTypeTargeted reports that a relation field of another type still targets the type.
+var ErrTypeTargeted = errors.New("content: a field still targets the type")
+
+// FieldKind is the shape of value a field holds.
+type FieldKind string
+
+// The field kinds a content type declares.
+const (
+	FieldKindText     FieldKind = "text"
+	FieldKindNumber   FieldKind = "number"
+	FieldKindBoolean  FieldKind = "boolean"
+	FieldKindDate     FieldKind = "date"
+	FieldKindMedia    FieldKind = "media"
+	FieldKindRelation FieldKind = "relation"
+)
+
+// Field describes one typed field a content type declares.
+type Field struct {
+	ID        int
+	TypeKey   string
+	Key       string
+	Label     string
+	Kind      FieldKind
+	RelatesTo string
+	Many      bool
+	Required  bool
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// NewField returns a field definition ready to store, or the reason it is not one.
+func NewField(f Field) (Field, error) {
+	f.TypeKey = strings.TrimSpace(f.TypeKey)
+	f.Key = strings.TrimSpace(f.Key)
+	f.Label = strings.TrimSpace(f.Label)
+	f.RelatesTo = strings.TrimSpace(f.RelatesTo)
+	now := time.Now().UTC()
+	f.CreatedAt, f.UpdatedAt = now, now
+	if err := f.Validate(); err != nil {
+		return Field{}, err
+	}
+	return f, nil
+}
+
+// Validate reports whether the field definition may be stored.
+func (f Field) Validate() error {
+	if !typeWord.MatchString(f.Key) {
+		return ErrInvalidFieldKey
+	}
+	if f.Label == "" {
+		return ErrInvalidFieldLabel
+	}
+	if !validFieldKind(f.Kind) {
+		return ErrInvalidFieldKind
+	}
+	return f.validateRelation()
+}
+
+// validFieldKind reports whether the CMS holds values of the kind.
+func validFieldKind(kind FieldKind) bool {
+	switch kind {
+	case FieldKindText, FieldKindNumber, FieldKindBoolean, FieldKindDate, FieldKindMedia, FieldKindRelation:
+		return true
+	default:
+		return false
+	}
+}
+
+// validateRelation reports whether the relation shape matches the kind.
+func (f Field) validateRelation() error {
+	if f.Kind != FieldKindRelation {
+		if f.RelatesTo != "" || f.Many {
+			return ErrFieldNotRelational
+		}
+		return nil
+	}
+	if f.RelatesTo == "" {
+		return ErrRelationNeedsTarget
+	}
+	if !typeWord.MatchString(f.RelatesTo) {
+		return ErrInvalidKey
+	}
+	return nil
+}

--- a/internal/content/fields_test.go
+++ b/internal/content/fields_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package content_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gopherium/gophenberg/internal/content"
+)
+
+func TestNewFieldTrimsAndStamps(t *testing.T) {
+	t.Parallel()
+
+	f, err := content.NewField(content.Field{
+		TypeKey: " post ",
+		Key:     " color ",
+		Label:   " Color ",
+		Kind:    content.FieldKindText,
+	})
+
+	if err != nil {
+		t.Fatalf("NewField() error = %v, want nil", err)
+	}
+	if f.TypeKey != "post" || f.Key != "color" || f.Label != "Color" {
+		t.Errorf("NewField() = %q %q %q, want the trimmed words", f.TypeKey, f.Key, f.Label)
+	}
+	if f.CreatedAt.IsZero() || !f.CreatedAt.Equal(f.UpdatedAt) {
+		t.Errorf("NewField() stamps = %v and %v, want one fresh pair", f.CreatedAt, f.UpdatedAt)
+	}
+}
+
+func TestNewFieldAcceptsEveryScalarKind(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range []content.FieldKind{
+		content.FieldKindText, content.FieldKindNumber, content.FieldKindBoolean,
+		content.FieldKindDate, content.FieldKindMedia,
+	} {
+		if _, err := content.NewField(content.Field{
+			TypeKey: "post", Key: "held", Label: "Held", Kind: kind,
+		}); err != nil {
+			t.Errorf("NewField(%q) error = %v, want the kind accepted", kind, err)
+		}
+	}
+}
+
+func TestNewFieldRefusesABadKey(t *testing.T) {
+	t.Parallel()
+
+	_, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "3d-Color", Label: "Color", Kind: content.FieldKindText,
+	})
+
+	if !errors.Is(err, content.ErrInvalidFieldKey) {
+		t.Fatalf("NewField() error = %v, want %v", err, content.ErrInvalidFieldKey)
+	}
+}
+
+func TestNewFieldRefusesAMissingLabel(t *testing.T) {
+	t.Parallel()
+
+	_, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "color", Kind: content.FieldKindText,
+	})
+
+	if !errors.Is(err, content.ErrInvalidFieldLabel) {
+		t.Fatalf("NewField() error = %v, want %v", err, content.ErrInvalidFieldLabel)
+	}
+}
+
+func TestNewFieldRefusesAnUnknownKind(t *testing.T) {
+	t.Parallel()
+
+	_, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "taste", Label: "Taste", Kind: "flavor",
+	})
+
+	if !errors.Is(err, content.ErrInvalidFieldKind) {
+		t.Fatalf("NewField() error = %v, want %v", err, content.ErrInvalidFieldKind)
+	}
+}
+
+func TestNewFieldRefusesARelationWithoutATarget(t *testing.T) {
+	t.Parallel()
+
+	_, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "engine", Label: "Engine", Kind: content.FieldKindRelation,
+	})
+
+	if !errors.Is(err, content.ErrRelationNeedsTarget) {
+		t.Fatalf("NewField() error = %v, want %v", err, content.ErrRelationNeedsTarget)
+	}
+}
+
+func TestNewFieldRefusesATargetOnAScalar(t *testing.T) {
+	t.Parallel()
+
+	_, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "color", Label: "Color",
+		Kind: content.FieldKindText, RelatesTo: "category",
+	})
+
+	if !errors.Is(err, content.ErrFieldNotRelational) {
+		t.Fatalf("NewField() error = %v, want %v", err, content.ErrFieldNotRelational)
+	}
+}
+
+func TestNewFieldRefusesManyOnAScalar(t *testing.T) {
+	t.Parallel()
+
+	_, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "color", Label: "Color",
+		Kind: content.FieldKindText, Many: true,
+	})
+
+	if !errors.Is(err, content.ErrFieldNotRelational) {
+		t.Fatalf("NewField() error = %v, want %v", err, content.ErrFieldNotRelational)
+	}
+}
+
+func TestNewFieldAcceptsAManyRelation(t *testing.T) {
+	t.Parallel()
+
+	f, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "categories", Label: "Categories",
+		Kind: content.FieldKindRelation, RelatesTo: "category", Many: true, Required: true,
+	})
+
+	if err != nil {
+		t.Fatalf("NewField() error = %v, want nil", err)
+	}
+	if f.RelatesTo != "category" || !f.Many || !f.Required {
+		t.Errorf("NewField() = %+v, want the relation shape kept", f)
+	}
+}
+
+func TestNewFieldRefusesABadTargetWord(t *testing.T) {
+	t.Parallel()
+
+	_, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "engine", Label: "Engine",
+		Kind: content.FieldKindRelation, RelatesTo: "Engine Types",
+	})
+
+	if !errors.Is(err, content.ErrInvalidKey) {
+		t.Fatalf("NewField() error = %v, want %v", err, content.ErrInvalidKey)
+	}
+}

--- a/internal/content/registry.go
+++ b/internal/content/registry.go
@@ -4,7 +4,9 @@ package content
 
 import (
 	"context"
+	"fmt"
 	"sync"
+	"time"
 )
 
 // Registry answers which content types the CMS holds, caching what it reads.
@@ -174,11 +176,107 @@ func (r *Registry) Delete(ctx context.Context, key string) error {
 	if t.Default {
 		return ErrDefaultRequired
 	}
+	if err := r.untargeted(ctx, key); err != nil {
+		return err
+	}
 	if err := r.store.Delete(ctx, key); err != nil {
 		return err
 	}
 	r.invalidate()
 	return nil
+}
+
+// untargeted reports whether another type's relation field still points at the type.
+func (r *Registry) untargeted(ctx context.Context, key string) error {
+	types, err := r.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, stored := range types {
+		if stored.Key == key {
+			continue
+		}
+		for _, f := range stored.Fields {
+			if f.RelatesTo == key {
+				return fmt.Errorf("%w (%s on %s)", ErrTypeTargeted, f.Key, stored.Key)
+			}
+		}
+	}
+	return nil
+}
+
+// CreateField declares the field on its type, or reports why the registry refuses it.
+func (r *Registry) CreateField(ctx context.Context, f Field) (Field, error) {
+	if err := f.Validate(); err != nil {
+		return Field{}, err
+	}
+	t, err := r.ByKey(ctx, f.TypeKey)
+	if err != nil {
+		return Field{}, err
+	}
+	if f.Kind == FieldKindRelation {
+		if _, err := r.ByKey(ctx, f.RelatesTo); err != nil {
+			return Field{}, ErrTargetUnknown
+		}
+	}
+	if _, err := fieldOf(t, f.Key); err == nil {
+		return Field{}, ErrFieldTaken
+	}
+	created, err := r.store.CreateField(ctx, f)
+	if err != nil {
+		return Field{}, err
+	}
+	r.invalidate()
+	return created, nil
+}
+
+// UpdateField carries the field's label and required flag, keeping its shape.
+func (r *Registry) UpdateField(ctx context.Context, f Field) (Field, error) {
+	t, err := r.ByKey(ctx, f.TypeKey)
+	if err != nil {
+		return Field{}, err
+	}
+	stored, err := fieldOf(t, f.Key)
+	if err != nil {
+		return Field{}, err
+	}
+	stored.Label, stored.Required = f.Label, f.Required
+	stored.UpdatedAt = time.Now().UTC()
+	if err := stored.Validate(); err != nil {
+		return Field{}, err
+	}
+	updated, err := r.store.UpdateField(ctx, stored)
+	if err != nil {
+		return Field{}, err
+	}
+	r.invalidate()
+	return updated, nil
+}
+
+// DeleteField removes the field and its values, or reports it missing.
+func (r *Registry) DeleteField(ctx context.Context, typeKey, key string) error {
+	t, err := r.ByKey(ctx, typeKey)
+	if err != nil {
+		return err
+	}
+	if _, err := fieldOf(t, key); err != nil {
+		return err
+	}
+	if err := r.store.DeleteField(ctx, typeKey, key); err != nil {
+		return err
+	}
+	r.invalidate()
+	return nil
+}
+
+// fieldOf returns the declared field carrying the key, or [ErrFieldNotFound].
+func fieldOf(t Type, key string) (Field, error) {
+	for _, f := range t.Fields {
+		if f.Key == key {
+			return f, nil
+		}
+	}
+	return Field{}, ErrFieldNotFound
 }
 
 // load fills the cache when it is cold, reading again when a write lands mid read.

--- a/internal/content/registry_fields_test.go
+++ b/internal/content/registry_fields_test.go
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package content_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gopherium/gophenberg/internal/content"
+)
+
+// CreateField stores a field on its type.
+func (s *fakeTypeStore) CreateField(_ context.Context, f content.Field) (content.Field, error) {
+	for i, stored := range s.types {
+		if stored.Key != f.TypeKey {
+			continue
+		}
+		f.ID = s.nextFieldID()
+		s.types[i].Fields = append(s.types[i].Fields, f)
+		return f, nil
+	}
+	return content.Field{}, content.ErrTypeNotFound
+}
+
+// UpdateField stores the edited field on its type.
+func (s *fakeTypeStore) UpdateField(_ context.Context, f content.Field) (content.Field, error) {
+	for i, stored := range s.types {
+		if stored.Key != f.TypeKey {
+			continue
+		}
+		for j, held := range stored.Fields {
+			if held.Key == f.Key {
+				f.ID = held.ID
+				s.types[i].Fields[j] = f
+				return f, nil
+			}
+		}
+	}
+	return content.Field{}, content.ErrFieldNotFound
+}
+
+// DeleteField removes the field from its type.
+func (s *fakeTypeStore) DeleteField(_ context.Context, typeKey, key string) error {
+	for i, stored := range s.types {
+		if stored.Key != typeKey {
+			continue
+		}
+		for j, held := range stored.Fields {
+			if held.Key == key {
+				s.types[i].Fields = append(stored.Fields[:j], stored.Fields[j+1:]...)
+				return nil
+			}
+		}
+	}
+	return content.ErrFieldNotFound
+}
+
+// nextFieldID hands out a fresh definition identity.
+func (s *fakeTypeStore) nextFieldID() int {
+	s.fieldIDs++
+	return s.fieldIDs
+}
+
+// colorField returns a text field ready to declare on the post type.
+func colorField(t *testing.T) content.Field {
+	t.Helper()
+	built, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "color", Label: "Color", Kind: content.FieldKindText,
+	})
+	if err != nil {
+		t.Fatalf("NewField() error = %v, want nil", err)
+	}
+	return built
+}
+
+func TestRegistryDeclaresAFieldOnAType(t *testing.T) {
+	t.Parallel()
+
+	registry := content.NewRegistry(newFakeTypeStore())
+
+	created, err := registry.CreateField(t.Context(), colorField(t))
+
+	if err != nil {
+		t.Fatalf("CreateField() error = %v, want nil", err)
+	}
+	if created.Key != "color" {
+		t.Errorf("CreateField() key = %q, want %q", created.Key, "color")
+	}
+	held, err := registry.ByKey(t.Context(), "post")
+	if err != nil {
+		t.Fatalf("ByKey() error = %v, want nil", err)
+	}
+	if len(held.Fields) != 1 || held.Fields[0].Key != "color" {
+		t.Errorf("ByKey() fields = %+v, want the declared field listed", held.Fields)
+	}
+}
+
+func TestRegistryRefusesAFieldOnAnUnknownType(t *testing.T) {
+	t.Parallel()
+
+	registry := content.NewRegistry(newFakeTypeStore())
+	f := colorField(t)
+	f.TypeKey = "car"
+
+	_, err := registry.CreateField(t.Context(), f)
+
+	if !errors.Is(err, content.ErrTypeNotFound) {
+		t.Fatalf("CreateField() error = %v, want %v", err, content.ErrTypeNotFound)
+	}
+}
+
+func TestRegistryRefusesATakenFieldKey(t *testing.T) {
+	t.Parallel()
+
+	registry := content.NewRegistry(newFakeTypeStore())
+	if _, err := registry.CreateField(t.Context(), colorField(t)); err != nil {
+		t.Fatalf("declaring the first field: %v, want nil", err)
+	}
+
+	_, err := registry.CreateField(t.Context(), colorField(t))
+
+	if !errors.Is(err, content.ErrFieldTaken) {
+		t.Fatalf("CreateField() error = %v, want %v", err, content.ErrFieldTaken)
+	}
+}
+
+func TestRegistryRefusesARelationToAnUnknownTarget(t *testing.T) {
+	t.Parallel()
+
+	registry := content.NewRegistry(newFakeTypeStore())
+	f, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "engine", Label: "Engine",
+		Kind: content.FieldKindRelation, RelatesTo: "engine-type",
+	})
+	if err != nil {
+		t.Fatalf("NewField() error = %v, want nil", err)
+	}
+
+	_, err = registry.CreateField(t.Context(), f)
+
+	if !errors.Is(err, content.ErrTargetUnknown) {
+		t.Fatalf("CreateField() error = %v, want %v", err, content.ErrTargetUnknown)
+	}
+}
+
+func TestRegistryRefusesAMalformedField(t *testing.T) {
+	t.Parallel()
+
+	registry := content.NewRegistry(newFakeTypeStore())
+
+	_, err := registry.CreateField(t.Context(), content.Field{
+		TypeKey: "post", Key: "taste", Label: "Taste", Kind: "flavor",
+	})
+
+	if !errors.Is(err, content.ErrInvalidFieldKind) {
+		t.Fatalf("CreateField() error = %v, want %v", err, content.ErrInvalidFieldKind)
+	}
+}
+
+func TestRegistryRelabelsAFieldKeepingItsShape(t *testing.T) {
+	t.Parallel()
+
+	registry := content.NewRegistry(newFakeTypeStore())
+	if _, err := registry.CreateField(t.Context(), colorField(t)); err != nil {
+		t.Fatalf("declaring the field: %v, want nil", err)
+	}
+	edit := colorField(t)
+	edit.Label, edit.Kind, edit.Required = "Paint", content.FieldKindNumber, true
+
+	updated, err := registry.UpdateField(t.Context(), edit)
+
+	if err != nil {
+		t.Fatalf("UpdateField() error = %v, want nil", err)
+	}
+	if updated.Label != "Paint" || !updated.Required {
+		t.Errorf("UpdateField() = %+v, want the label and the flag carried", updated)
+	}
+	if updated.Kind != content.FieldKindText {
+		t.Errorf("UpdateField() kind = %q, want the stored kind kept", updated.Kind)
+	}
+}
+
+func TestRegistryRefusesRelabelingAnUnknownField(t *testing.T) {
+	t.Parallel()
+
+	registry := content.NewRegistry(newFakeTypeStore())
+
+	_, err := registry.UpdateField(t.Context(), colorField(t))
+
+	if !errors.Is(err, content.ErrFieldNotFound) {
+		t.Fatalf("UpdateField() error = %v, want %v", err, content.ErrFieldNotFound)
+	}
+}
+
+func TestRegistryDeletesAField(t *testing.T) {
+	t.Parallel()
+
+	registry := content.NewRegistry(newFakeTypeStore())
+	if _, err := registry.CreateField(t.Context(), colorField(t)); err != nil {
+		t.Fatalf("declaring the field: %v, want nil", err)
+	}
+
+	if err := registry.DeleteField(t.Context(), "post", "color"); err != nil {
+		t.Fatalf("DeleteField() error = %v, want nil", err)
+	}
+
+	held, err := registry.ByKey(t.Context(), "post")
+	if err != nil {
+		t.Fatalf("ByKey() error = %v, want nil", err)
+	}
+	if len(held.Fields) != 0 {
+		t.Errorf("ByKey() fields = %+v, want the field gone", held.Fields)
+	}
+}
+
+func TestRegistryRefusesDeletingAnUnknownField(t *testing.T) {
+	t.Parallel()
+
+	registry := content.NewRegistry(newFakeTypeStore())
+
+	err := registry.DeleteField(t.Context(), "post", "color")
+
+	if !errors.Is(err, content.ErrFieldNotFound) {
+		t.Fatalf("DeleteField() error = %v, want %v", err, content.ErrFieldNotFound)
+	}
+}
+
+func TestRegistryKeepsATypeAFieldTargets(t *testing.T) {
+	t.Parallel()
+
+	registry := content.NewRegistry(newFakeTypeStore())
+	if _, err := registry.Create(t.Context(), carType(t)); err != nil {
+		t.Fatalf("registering the car type: %v, want nil", err)
+	}
+	f, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "cars", Label: "Cars",
+		Kind: content.FieldKindRelation, RelatesTo: "car", Many: true,
+	})
+	if err != nil {
+		t.Fatalf("NewField() error = %v, want nil", err)
+	}
+	if _, err := registry.CreateField(t.Context(), f); err != nil {
+		t.Fatalf("declaring the relation: %v, want nil", err)
+	}
+
+	err = registry.Delete(t.Context(), "car")
+
+	if !errors.Is(err, content.ErrTypeTargeted) {
+		t.Fatalf("Delete() error = %v, want %v", err, content.ErrTypeTargeted)
+	}
+}
+
+func TestRegistryLetsASelfTargetingTypeGo(t *testing.T) {
+	t.Parallel()
+
+	registry := content.NewRegistry(newFakeTypeStore())
+	if _, err := registry.Create(t.Context(), carType(t)); err != nil {
+		t.Fatalf("registering the car type: %v, want nil", err)
+	}
+	f, err := content.NewField(content.Field{
+		TypeKey: "car", Key: "sibling", Label: "Sibling",
+		Kind: content.FieldKindRelation, RelatesTo: "car",
+	})
+	if err != nil {
+		t.Fatalf("NewField() error = %v, want nil", err)
+	}
+	if _, err := registry.CreateField(t.Context(), f); err != nil {
+		t.Fatalf("declaring the relation: %v, want nil", err)
+	}
+
+	if err := registry.Delete(t.Context(), "car"); err != nil {
+		t.Fatalf("Delete() error = %v, want the self targeting type released", err)
+	}
+}

--- a/internal/content/registry_test.go
+++ b/internal/content/registry_test.go
@@ -17,6 +17,7 @@ var errStoreDown = errors.New("the registry is unreachable")
 // fakeTypeStore holds content types in memory and counts what it was asked to read.
 type fakeTypeStore struct {
 	types     []content.Type
+	fieldIDs  int
 	listCalls int
 	listErr   error
 	createErr error

--- a/internal/content/registry_test.go
+++ b/internal/content/registry_test.go
@@ -359,17 +359,20 @@ func TestRegistryLetsTheDefaultLeaveTheRootWhileStayingDefault(t *testing.T) {
 	}
 }
 
-func TestRegistryRefusesAnArchivePageKind(t *testing.T) {
+func TestRegistryRegistersAnArchivePageKind(t *testing.T) {
 	t.Parallel()
 
 	registry := content.NewRegistry(newFakeTypeStore())
 	car := carType(t)
 	car.PageKind = content.PageKindArchive
 
-	_, err := registry.Create(t.Context(), car)
+	created, err := registry.Create(t.Context(), car)
 
-	if !errors.Is(err, content.ErrPageKindUnavailable) {
-		t.Errorf("Create() error = %v, want %v", err, content.ErrPageKindUnavailable)
+	if err != nil {
+		t.Fatalf("Create() error = %v, want the archive page kind registered", err)
+	}
+	if created.PageKind != content.PageKindArchive {
+		t.Errorf("Create() page kind = %q, want %q", created.PageKind, content.PageKindArchive)
 	}
 }
 

--- a/internal/content/relations.go
+++ b/internal/content/relations.go
@@ -24,6 +24,16 @@ var ErrTargetType = errors.New("content: target is not the type the field points
 // Relations holds the items a content item points at, keyed by field key.
 type Relations map[string][]uuid.UUID
 
+// Target names one item a relation field points at, as a public reader sees it.
+type Target struct {
+	ID    uuid.UUID
+	Title string
+	Path  string
+}
+
+// Targets holds the items a content item points at, named and addressed, keyed by field key.
+type Targets map[string][]Target
+
 // SplitValues divides a patch into the scalar values and the targets its type declares.
 func SplitValues(patch Values, fields []Field) (Values, Relations, error) {
 	declared := make(map[string]Field, len(fields))

--- a/internal/content/relations.go
+++ b/internal/content/relations.go
@@ -18,6 +18,9 @@ var ErrRepeatedTarget = errors.New("content: repeated target")
 // ErrTargetNotFound reports that a relation names an item nothing holds.
 var ErrTargetNotFound = errors.New("content: target not found")
 
+// ErrSelfTarget reports that a relation field points an item at itself.
+var ErrSelfTarget = errors.New("content: an item cannot point at itself")
+
 // ErrTargetType reports that a relation names an item of the wrong type.
 var ErrTargetType = errors.New("content: target is not the type the field points at")
 
@@ -99,6 +102,18 @@ func targetID(f Field, raw any) (uuid.UUID, error) {
 		return uuid.Nil, fmt.Errorf("%w: %s holds identities", ErrFieldShape, f.Key)
 	}
 	return target, nil
+}
+
+// SelfTargeted reports whether any relation field of the item points at the item itself.
+func (c Content) SelfTargeted() error {
+	for key, targets := range c.Relations {
+		for _, target := range targets {
+			if target == c.ID {
+				return fmt.Errorf("%w: %s", ErrSelfTarget, key)
+			}
+		}
+	}
+	return nil
 }
 
 // Merge returns the stored targets with the patch applied, where a named field replaces its targets.

--- a/internal/content/relations.go
+++ b/internal/content/relations.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package content
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// ErrTooManyTargets reports that a relation field holding one was given more.
+var ErrTooManyTargets = errors.New("content: field holds one target")
+
+// ErrRepeatedTarget reports that a relation field was given the same target twice.
+var ErrRepeatedTarget = errors.New("content: repeated target")
+
+// ErrTargetNotFound reports that a relation names an item nothing holds.
+var ErrTargetNotFound = errors.New("content: target not found")
+
+// ErrTargetType reports that a relation names an item of the wrong type.
+var ErrTargetType = errors.New("content: target is not the type the field points at")
+
+// Relations holds the items a content item points at, keyed by field key.
+type Relations map[string][]uuid.UUID
+
+// SplitValues divides a patch into the scalar values and the targets its type declares.
+func SplitValues(patch Values, fields []Field) (Values, Relations, error) {
+	declared := make(map[string]Field, len(fields))
+	for _, f := range fields {
+		declared[f.Key] = f
+	}
+	scalars := make(Values, len(patch))
+	relations := make(Relations)
+	for key, value := range patch {
+		f, found := declared[key]
+		if !found {
+			return nil, nil, fmt.Errorf("%w: %s", ErrUnknownField, key)
+		}
+		if f.Kind != FieldKindRelation {
+			scalars[key] = value
+			continue
+		}
+		targets, err := targetsOf(f, value)
+		if err != nil {
+			return nil, nil, err
+		}
+		relations[key] = targets
+	}
+	return scalars, relations, nil
+}
+
+// targetsOf returns the identities a relation value names, or the reason it names none.
+func targetsOf(f Field, value any) ([]uuid.UUID, error) {
+	if value == nil {
+		return []uuid.UUID{}, nil
+	}
+	listed, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s holds a list of targets", ErrFieldShape, f.Key)
+	}
+	if !f.Many && len(listed) > 1 {
+		return nil, fmt.Errorf("%w: %s", ErrTooManyTargets, f.Key)
+	}
+	targets := make([]uuid.UUID, 0, len(listed))
+	held := make(map[uuid.UUID]bool, len(listed))
+	for _, raw := range listed {
+		target, err := targetID(f, raw)
+		if err != nil {
+			return nil, err
+		}
+		if held[target] {
+			return nil, fmt.Errorf("%w: %s", ErrRepeatedTarget, f.Key)
+		}
+		held[target] = true
+		targets = append(targets, target)
+	}
+	return targets, nil
+}
+
+// targetID returns the identity a listed target names.
+func targetID(f Field, raw any) (uuid.UUID, error) {
+	written, ok := raw.(string)
+	if !ok {
+		return uuid.Nil, fmt.Errorf("%w: %s holds identities", ErrFieldShape, f.Key)
+	}
+	target, err := uuid.Parse(written)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("%w: %s holds identities", ErrFieldShape, f.Key)
+	}
+	return target, nil
+}
+
+// Merge returns the stored targets with the patch applied, where a named field replaces its targets.
+func (r Relations) Merge(patch Relations) Relations {
+	merged := make(Relations, len(r)+len(patch))
+	for key, targets := range r {
+		merged[key] = targets
+	}
+	for key, targets := range patch {
+		merged[key] = targets
+	}
+	return merged
+}
+
+// Filled reports whether every required field of the type holds a value.
+func Filled(values Values, relations Relations, fields []Field) error {
+	for _, f := range fields {
+		if !f.Required {
+			continue
+		}
+		if unfilled(values, relations, f) {
+			return fmt.Errorf("%w: %s", ErrFieldRequired, f.Key)
+		}
+	}
+	return nil
+}
+
+// unfilled reports whether the field stands empty on the item.
+func unfilled(values Values, relations Relations, f Field) bool {
+	if f.Kind == FieldKindRelation {
+		return len(relations[f.Key]) == 0
+	}
+	return empty(values[f.Key])
+}

--- a/internal/content/relations_test.go
+++ b/internal/content/relations_test.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package content_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/gopherium/gophenberg/internal/content"
+)
+
+// relatable returns a text field and a many relation field to split a patch against.
+func relatable(t *testing.T, many bool) []content.Field {
+	t.Helper()
+	color, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "color", Label: "Color", Kind: content.FieldKindText,
+	})
+	if err != nil {
+		t.Fatalf("NewField() error = %v, want nil", err)
+	}
+	categories, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "categories", Label: "Categories",
+		Kind: content.FieldKindRelation, RelatesTo: "category", Many: many,
+	})
+	if err != nil {
+		t.Fatalf("NewField() error = %v, want nil", err)
+	}
+	return []content.Field{color, categories}
+}
+
+func TestSplitValuesDividesScalarsFromTargets(t *testing.T) {
+	t.Parallel()
+
+	first, second := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
+	patch := content.Values{
+		"color":      "red",
+		"categories": []any{first.String(), second.String()},
+	}
+
+	scalars, relations, err := content.SplitValues(patch, relatable(t, true))
+
+	if err != nil {
+		t.Fatalf("SplitValues() error = %v, want nil", err)
+	}
+	if len(scalars) != 1 || scalars["color"] != "red" {
+		t.Errorf("SplitValues() scalars = %v, want the text value alone", scalars)
+	}
+	held := relations["categories"]
+	if len(held) != 2 || held[0] != first || held[1] != second {
+		t.Errorf("SplitValues() relations = %v, want both targets in order", held)
+	}
+}
+
+func TestSplitValuesReadsANullAsAClearedRelation(t *testing.T) {
+	t.Parallel()
+
+	patch := content.Values{"categories": nil}
+
+	_, relations, err := content.SplitValues(patch, relatable(t, true))
+
+	if err != nil {
+		t.Fatalf("SplitValues() error = %v, want nil", err)
+	}
+	held, named := relations["categories"]
+	if !named || len(held) != 0 {
+		t.Errorf("SplitValues() relations = %v, want the field named with no targets", relations)
+	}
+}
+
+func TestSplitValuesRefusesAnUnknownKey(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := content.SplitValues(content.Values{"finish": "matte"}, relatable(t, true))
+
+	if !errors.Is(err, content.ErrUnknownField) {
+		t.Fatalf("SplitValues() error = %v, want %v", err, content.ErrUnknownField)
+	}
+}
+
+func TestSplitValuesRefusesATargetThatIsNotAList(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := content.SplitValues(content.Values{"categories": "news"}, relatable(t, true))
+
+	if !errors.Is(err, content.ErrFieldShape) {
+		t.Fatalf("SplitValues() error = %v, want %v", err, content.ErrFieldShape)
+	}
+}
+
+func TestSplitValuesRefusesATargetThatIsNotAnIdentity(t *testing.T) {
+	t.Parallel()
+
+	patch := content.Values{"categories": []any{"news"}}
+
+	_, _, err := content.SplitValues(patch, relatable(t, true))
+
+	if !errors.Is(err, content.ErrFieldShape) {
+		t.Fatalf("SplitValues() error = %v, want %v", err, content.ErrFieldShape)
+	}
+}
+
+func TestSplitValuesRefusesASecondTargetOnAOneField(t *testing.T) {
+	t.Parallel()
+
+	patch := content.Values{
+		"categories": []any{uuid.Must(uuid.NewV7()).String(), uuid.Must(uuid.NewV7()).String()},
+	}
+
+	_, _, err := content.SplitValues(patch, relatable(t, false))
+
+	if !errors.Is(err, content.ErrTooManyTargets) {
+		t.Fatalf("SplitValues() error = %v, want %v", err, content.ErrTooManyTargets)
+	}
+	if !strings.Contains(err.Error(), "categories") {
+		t.Errorf("SplitValues() error = %q, want the field named", err)
+	}
+}
+
+func TestSplitValuesAcceptsOneTargetOnAOneField(t *testing.T) {
+	t.Parallel()
+
+	patch := content.Values{"categories": []any{uuid.Must(uuid.NewV7()).String()}}
+
+	_, relations, err := content.SplitValues(patch, relatable(t, false))
+
+	if err != nil {
+		t.Fatalf("SplitValues() error = %v, want nil", err)
+	}
+	if len(relations["categories"]) != 1 {
+		t.Errorf("SplitValues() relations = %v, want the one target", relations)
+	}
+}
+
+func TestSplitValuesRefusesARepeatedTarget(t *testing.T) {
+	t.Parallel()
+
+	same := uuid.Must(uuid.NewV7()).String()
+	patch := content.Values{"categories": []any{same, same}}
+
+	_, _, err := content.SplitValues(patch, relatable(t, true))
+
+	if !errors.Is(err, content.ErrRepeatedTarget) {
+		t.Fatalf("SplitValues() error = %v, want %v", err, content.ErrRepeatedTarget)
+	}
+}
+
+func TestRelationsMergeReplacesANamedField(t *testing.T) {
+	t.Parallel()
+
+	first, second := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
+	stored := content.Relations{"categories": {first}, "series": {second}}
+
+	merged := stored.Merge(content.Relations{"categories": {second}})
+
+	if len(merged["categories"]) != 1 || merged["categories"][0] != second {
+		t.Errorf("Merge() categories = %v, want the named field replaced", merged["categories"])
+	}
+	if len(merged["series"]) != 1 || merged["series"][0] != second {
+		t.Errorf("Merge() series = %v, want the absent field left alone", merged["series"])
+	}
+}
+
+func TestRelationsMergeLeavesTheStoredTargetsAlone(t *testing.T) {
+	t.Parallel()
+
+	first, second := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
+	stored := content.Relations{"categories": {first}}
+
+	stored.Merge(content.Relations{"categories": {second}})
+
+	if stored["categories"][0] != first {
+		t.Errorf("the stored targets hold %v, want the merge to have left them alone", stored["categories"])
+	}
+}
+
+func TestFilledCountsAnEmptyRelationAsEmpty(t *testing.T) {
+	t.Parallel()
+
+	required, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "engine", Label: "Engine",
+		Kind: content.FieldKindRelation, RelatesTo: "engine-type", Required: true,
+	})
+	if err != nil {
+		t.Fatalf("NewField() error = %v, want nil", err)
+	}
+	fields := []content.Field{required}
+
+	for name, held := range map[string]content.Relations{
+		"the field is absent": {},
+		"the field is empty":  {"engine": {}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := content.Filled(content.Values{}, held, fields)
+
+			if !errors.Is(err, content.ErrFieldRequired) {
+				t.Fatalf("Filled() error = %v, want %v", err, content.ErrFieldRequired)
+			}
+		})
+	}
+}
+
+func TestFilledAcceptsAHeldTarget(t *testing.T) {
+	t.Parallel()
+
+	required, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "engine", Label: "Engine",
+		Kind: content.FieldKindRelation, RelatesTo: "engine-type", Required: true,
+	})
+	if err != nil {
+		t.Fatalf("NewField() error = %v, want nil", err)
+	}
+	held := content.Relations{"engine": {uuid.Must(uuid.NewV7())}}
+
+	if err := content.Filled(content.Values{}, held, []content.Field{required}); err != nil {
+		t.Fatalf("Filled() error = %v, want a held target to count as filled", err)
+	}
+}

--- a/internal/content/relations_test.go
+++ b/internal/content/relations_test.go
@@ -220,3 +220,30 @@ func TestFilledAcceptsAHeldTarget(t *testing.T) {
 		t.Fatalf("Filled() error = %v, want a held target to count as filled", err)
 	}
 }
+
+func TestSelfTargetedRefusesAnItemPointingAtItself(t *testing.T) {
+	t.Parallel()
+
+	held := content.Content{ID: uuid.Must(uuid.NewV7()), Type: content.TypePost}
+	held.Relations = content.Relations{"related": {held.ID}}
+
+	err := held.SelfTargeted()
+
+	if !errors.Is(err, content.ErrSelfTarget) {
+		t.Fatalf("SelfTargeted() error = %v, want %v", err, content.ErrSelfTarget)
+	}
+	if !strings.Contains(err.Error(), "related") {
+		t.Errorf("SelfTargeted() error = %q, want the field named", err)
+	}
+}
+
+func TestSelfTargetedAcceptsAnotherItemOfItsOwnType(t *testing.T) {
+	t.Parallel()
+
+	held := content.Content{ID: uuid.Must(uuid.NewV7()), Type: content.TypePost}
+	held.Relations = content.Relations{"related": {uuid.Must(uuid.NewV7())}}
+
+	if err := held.SelfTargeted(); err != nil {
+		t.Fatalf("SelfTargeted() error = %v, want a sibling of the same type accepted", err)
+	}
+}

--- a/internal/content/resolver.go
+++ b/internal/content/resolver.go
@@ -20,6 +20,7 @@ type Kind string
 const (
 	KindItem    Kind = "item"
 	KindArchive Kind = "archive"
+	KindTerm    Kind = "term"
 )
 
 // Address is what a public address holds.
@@ -35,9 +36,10 @@ type AddressReader interface {
 	PublishedByPath(ctx context.Context, path string) (Content, error)
 }
 
-// TypeReader answers which type answers under a route word.
+// TypeReader answers which type answers under a route word and which carries a key.
 type TypeReader interface {
 	ByRouteWord(ctx context.Context, word string) (Type, error)
+	ByKey(ctx context.Context, key string) (Type, error)
 }
 
 // Resolver answers what a public address holds.
@@ -56,12 +58,33 @@ func (r *Resolver) Resolve(ctx context.Context, raw string) (Address, error) {
 	address := tidy(raw)
 	item, err := r.content.PublishedByPath(ctx, address)
 	if err == nil {
-		return Address{Kind: KindItem, Item: item}, nil
+		return r.itemAt(ctx, item, 1)
 	}
 	if !errors.Is(err, ErrNotFound) {
 		return Address{}, err
 	}
 	return r.archiveAt(ctx, address)
+}
+
+// itemAt returns what an item answers with, which is a term page when its type lists its pointers.
+func (r *Resolver) itemAt(ctx context.Context, item Content, page int) (Address, error) {
+	listed, err := r.types.ByKey(ctx, item.Type)
+	if errors.Is(err, ErrTypeNotFound) {
+		return Address{}, ErrNotFound
+	}
+	if err != nil {
+		return Address{}, err
+	}
+	if !listed.Active {
+		return Address{}, ErrNotFound
+	}
+	if listed.PageKind == PageKindArchive {
+		return Address{Kind: KindTerm, Type: listed, Item: item, Page: page}, nil
+	}
+	if page > 1 {
+		return Address{}, ErrNotFound
+	}
+	return Address{Kind: KindItem, Type: listed, Item: item}, nil
 }
 
 // tidy returns the address a request carries without its surrounding slashes.
@@ -76,13 +99,35 @@ func (r *Resolver) archiveAt(ctx context.Context, address string) (Address, erro
 		return Address{}, err
 	}
 	listed, err := r.types.ByRouteWord(ctx, word)
-	if errors.Is(err, ErrTypeNotFound) {
+	if err == nil {
+		return Address{Kind: KindArchive, Type: listed, Page: page}, nil
+	}
+	if !errors.Is(err, ErrTypeNotFound) {
+		return Address{}, err
+	}
+	if word == address {
+		return Address{}, ErrNotFound
+	}
+	return r.pagedItemAt(ctx, word, page)
+}
+
+// pagedItemAt returns the term page an address asks for behind the page word.
+func (r *Resolver) pagedItemAt(ctx context.Context, address string, page int) (Address, error) {
+	item, err := r.content.PublishedByPath(ctx, address)
+	if errors.Is(err, ErrNotFound) {
 		return Address{}, ErrNotFound
 	}
 	if err != nil {
 		return Address{}, err
 	}
-	return Address{Kind: KindArchive, Type: listed, Page: page}, nil
+	held, err := r.itemAt(ctx, item, page)
+	if err != nil {
+		return Address{}, err
+	}
+	if held.Kind != KindTerm {
+		return Address{}, ErrNotFound
+	}
+	return held, nil
 }
 
 // listingAt returns the route word an address lists and the page it asks for.

--- a/internal/content/resolver_terms_test.go
+++ b/internal/content/resolver_terms_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package content_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gopherium/gophenberg/internal/content"
+)
+
+// termType returns a content type whose items list what points at them.
+func termType() content.Type {
+	return content.Type{
+		Key: "category", SingularLabel: "Category", PluralLabel: "Categories",
+		RouteWord: "categories", Revisions: true, RevisionCap: 100,
+		PageKind: content.PageKindArchive, Active: true,
+	}
+}
+
+// newTermResolver returns a resolver over a registry holding the post and category types.
+func newTermResolver(t *testing.T, store *fakeAddresses) *content.Resolver {
+	t.Helper()
+	types := newFakeTypeStore()
+	types.types = append(types.types, termType())
+	return content.NewResolver(store, content.NewRegistry(types))
+}
+
+func TestResolveAnswersATermPageForAnArchiveKindItem(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeAddresses()
+	held := store.hold("category", "categories/news")
+	resolver := newTermResolver(t, store)
+
+	answer, err := resolver.Resolve(t.Context(), "/categories/news")
+
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want nil", err)
+	}
+	if answer.Kind != content.KindTerm {
+		t.Fatalf("Resolve() kind = %q, want %q", answer.Kind, content.KindTerm)
+	}
+	if answer.Item.ID != held.ID || answer.Type.Key != "category" || answer.Page != 1 {
+		t.Errorf("Resolve() = %+v, want the item, its type and the first page", answer)
+	}
+}
+
+func TestResolveAnswersATermPageBehindThePageWord(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeAddresses()
+	held := store.hold("category", "categories/news")
+	resolver := newTermResolver(t, store)
+
+	answer, err := resolver.Resolve(t.Context(), "/categories/news/page/2")
+
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want nil", err)
+	}
+	if answer.Kind != content.KindTerm || answer.Item.ID != held.ID || answer.Page != 2 {
+		t.Errorf("Resolve() = %+v, want the item's second page", answer)
+	}
+}
+
+func TestResolveKeepsASingleItemOffThePageWord(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeAddresses()
+	store.hold(content.TypePost, "hello-world")
+	resolver := newTermResolver(t, store)
+
+	_, err := resolver.Resolve(t.Context(), "/hello-world/page/2")
+
+	if !errors.Is(err, content.ErrNotFound) {
+		t.Fatalf("Resolve() error = %v, want %v", err, content.ErrNotFound)
+	}
+}
+
+func TestResolveAnswersTheArchiveOfATermType(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeAddresses()
+	resolver := newTermResolver(t, store)
+
+	answer, err := resolver.Resolve(t.Context(), "/categories")
+
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want nil", err)
+	}
+	if answer.Kind != content.KindArchive || answer.Type.Key != "category" {
+		t.Errorf("Resolve() = %+v, want the archive listing the terms themselves", answer)
+	}
+}
+
+func TestResolveNamesTheTypeOfASingleItem(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeAddresses()
+	store.hold(content.TypePost, "hello-world")
+	resolver := newTermResolver(t, store)
+
+	answer, err := resolver.Resolve(t.Context(), "/hello-world")
+
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want nil", err)
+	}
+	if answer.Kind != content.KindItem || answer.Type.Key != content.TypePost {
+		t.Errorf("Resolve() = %+v, want the item with its type named", answer)
+	}
+}
+
+func TestNewTypeAcceptsTheArchivePageKind(t *testing.T) {
+	t.Parallel()
+
+	held := termType()
+
+	if err := held.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want the archive page kind accepted", err)
+	}
+}
+
+func TestResolveKeepsASingleItemOffTheFirstPageWord(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeAddresses()
+	store.hold(content.TypePost, "hello-world")
+	resolver := newTermResolver(t, store)
+
+	_, err := resolver.Resolve(t.Context(), "/hello-world/page/1")
+
+	if !errors.Is(err, content.ErrNotFound) {
+		t.Fatalf("Resolve() error = %v, want %v", err, content.ErrNotFound)
+	}
+}
+
+func TestResolveHidesAnItemOfAClosedType(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeAddresses()
+	store.hold("category", "categories/news")
+	types := newFakeTypeStore()
+	closed := termType()
+	closed.Active = false
+	types.types = append(types.types, closed)
+	resolver := content.NewResolver(store, content.NewRegistry(types))
+
+	_, err := resolver.Resolve(t.Context(), "/categories/news")
+
+	if !errors.Is(err, content.ErrNotFound) {
+		t.Fatalf("Resolve() error = %v, want a closed type to serve nothing", err)
+	}
+}

--- a/internal/content/revision_test.go
+++ b/internal/content/revision_test.go
@@ -50,6 +50,27 @@ func TestNewRevisionSnapshotsTheEditableContent(t *testing.T) {
 	}
 }
 
+func TestNewRevisionKeepsItsOwnFieldValues(t *testing.T) {
+	t.Parallel()
+
+	author := uuid.Must(uuid.NewV7())
+	p, err := content.New(postType(), nil, "Snapshot Me", author)
+	if err != nil {
+		t.Fatalf("New() error = %v, want nil", err)
+	}
+	p.Fields = content.Values{"color": "red"}
+
+	revision, err := content.NewRevision(p, content.RevisionKindRevision, author)
+
+	if err != nil {
+		t.Fatalf("NewRevision() error = %v, want nil", err)
+	}
+	p.Fields["color"] = "blue"
+	if revision.Fields["color"] != "red" {
+		t.Errorf("the revision holds %v, want the value the item held when it was snapshotted", revision.Fields["color"])
+	}
+}
+
 func TestNewRevisionCarriesTheAutosaveKind(t *testing.T) {
 	t.Parallel()
 

--- a/internal/content/store.go
+++ b/internal/content/store.go
@@ -53,7 +53,7 @@ func NewRevision(c Content, kind RevisionKind, authorID uuid.UUID) (Revision, er
 		Title:     c.Title,
 		Content:   c.Content,
 		Excerpt:   c.Excerpt,
-		Fields:    c.Fields,
+		Fields:    c.Fields.Merge(nil),
 		CreatedAt: time.Now().UTC(),
 	}, nil
 }

--- a/internal/content/store.go
+++ b/internal/content/store.go
@@ -35,6 +35,7 @@ type Revision struct {
 	Title     string
 	Content   string
 	Excerpt   string
+	Fields    Values
 	CreatedAt time.Time
 }
 
@@ -52,6 +53,7 @@ func NewRevision(c Content, kind RevisionKind, authorID uuid.UUID) (Revision, er
 		Title:     c.Title,
 		Content:   c.Content,
 		Excerpt:   c.Excerpt,
+		Fields:    c.Fields,
 		CreatedAt: time.Now().UTC(),
 	}, nil
 }

--- a/internal/content/store.go
+++ b/internal/content/store.go
@@ -121,6 +121,8 @@ type Store interface {
 	Children(ctx context.Context, id uuid.UUID) (int, error)
 	Depth(ctx context.Context, id uuid.UUID) (int, error)
 	List(ctx context.Context, f Filter) ([]Content, int, error)
+	RelatedTo(ctx context.Context, target uuid.UUID, page, perPage int) ([]Content, int, error)
+	TargetsOf(ctx context.Context, from uuid.UUID) (Targets, error)
 	Update(
 		ctx context.Context, c Content, expectedUpdatedAt time.Time, snapshot *Revision, revisionCap int,
 	) (Content, error)

--- a/internal/content/types.go
+++ b/internal/content/types.go
@@ -84,17 +84,21 @@ type Type struct {
 	PageKind      PageKind
 	Default       bool
 	Active        bool
+	Fields        []Field
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 }
 
-// TypeStore persists the content type registry.
+// TypeStore persists the content type registry and its field definitions.
 type TypeStore interface {
 	List(ctx context.Context) ([]Type, error)
 	ByKey(ctx context.Context, key string) (Type, error)
 	Create(ctx context.Context, t Type) (Type, error)
 	Update(ctx context.Context, t Type) (Type, error)
 	Delete(ctx context.Context, key string) error
+	CreateField(ctx context.Context, f Field) (Field, error)
+	UpdateField(ctx context.Context, f Field) (Field, error)
+	DeleteField(ctx context.Context, typeKey, key string) error
 }
 
 // NewType returns a content type ready to store, or the reason it is not one.

--- a/internal/content/types.go
+++ b/internal/content/types.go
@@ -50,16 +50,13 @@ var ErrInvalidLabel = errors.New("content: invalid type label")
 // ErrInvalidPageKind reports that a page kind is not one the CMS renders.
 var ErrInvalidPageKind = errors.New("content: invalid page kind")
 
-// ErrPageKindUnavailable reports that a page kind waits for relation fields.
-var ErrPageKindUnavailable = errors.New("content: archive pages wait for relation fields")
-
 // ErrInvalidRevisionCap reports that a revision cap is not a number of rows.
 var ErrInvalidRevisionCap = errors.New("content: invalid revision cap")
 
 // PageKind is what the public page of one content item renders.
 type PageKind string
 
-// The page kinds a content type declares. Archive waits for relation fields.
+// The page kinds a content type declares.
 const (
 	PageKindSingle  PageKind = "single"
 	PageKindArchive PageKind = "archive"
@@ -142,13 +139,11 @@ func (t Type) Validate() error {
 	return t.validateRouteWord()
 }
 
-// validatePageKind reports whether the CMS renders the type's item page today.
+// validatePageKind reports whether the CMS renders the type's item page.
 func (t Type) validatePageKind() error {
 	switch t.PageKind {
-	case PageKindSingle:
+	case PageKindSingle, PageKindArchive:
 		return nil
-	case PageKindArchive:
-		return ErrPageKindUnavailable
 	default:
 		return ErrInvalidPageKind
 	}

--- a/internal/content/values.go
+++ b/internal/content/values.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package content
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrUnknownField reports that the type declares no field under the key.
+var ErrUnknownField = errors.New("content: unknown field")
+
+// ErrFieldShape reports that a value is not the kind its field holds.
+var ErrFieldShape = errors.New("content: wrong kind of value")
+
+// ErrFieldRequired reports that a field must hold a value before publishing.
+var ErrFieldRequired = errors.New("content: field is required")
+
+// ErrRelationValuesWait reports that relation values wait for the relation table.
+var ErrRelationValuesWait = errors.New("content: relation values wait for the relation table")
+
+// dateLayout is how a date field writes a day.
+const dateLayout = "2006-01-02"
+
+// Values holds a content item's scalar field values keyed by field key.
+type Values map[string]any
+
+// Validate reports whether every value matches the kind its field declares.
+func (v Values) Validate(fields []Field) error {
+	declared := make(map[string]Field, len(fields))
+	for _, f := range fields {
+		declared[f.Key] = f
+	}
+	for key, value := range v {
+		f, found := declared[key]
+		if !found {
+			return fmt.Errorf("%w: %s", ErrUnknownField, key)
+		}
+		if f.Kind == FieldKindRelation {
+			return fmt.Errorf("%w: %s", ErrRelationValuesWait, key)
+		}
+		if value == nil {
+			continue
+		}
+		if !holdsKind(value, f.Kind) {
+			return fmt.Errorf("%w: %s holds %s", ErrFieldShape, key, f.Kind)
+		}
+	}
+	return nil
+}
+
+// holdsKind reports whether the value carries the shape the kind stores.
+func holdsKind(value any, kind FieldKind) bool {
+	switch kind {
+	case FieldKindText:
+		_, ok := value.(string)
+		return ok
+	case FieldKindNumber, FieldKindMedia:
+		return isNumber(value)
+	case FieldKindBoolean:
+		_, ok := value.(bool)
+		return ok
+	case FieldKindDate:
+		return isDay(value)
+	default:
+		return false
+	}
+}
+
+// isNumber reports whether the value is a number, however it was decoded.
+func isNumber(value any) bool {
+	switch value.(type) {
+	case float64, float32, int, int32, int64:
+		return true
+	default:
+		return false
+	}
+}
+
+// isDay reports whether the value is a day written as a date.
+func isDay(value any) bool {
+	written, ok := value.(string)
+	if !ok {
+		return false
+	}
+	_, err := time.Parse(dateLayout, written)
+	return err == nil
+}
+
+// Merge returns the stored values with the patch applied, where a nil value clears its key.
+func (v Values) Merge(patch Values) Values {
+	merged := make(Values, len(v)+len(patch))
+	for key, value := range v {
+		merged[key] = value
+	}
+	for key, value := range patch {
+		if value == nil {
+			delete(merged, key)
+			continue
+		}
+		merged[key] = value
+	}
+	return merged
+}
+
+// Filled reports whether every required field holds a value.
+func (v Values) Filled(fields []Field) error {
+	for _, f := range fields {
+		if !f.Required {
+			continue
+		}
+		if empty(v[f.Key]) {
+			return fmt.Errorf("%w: %s", ErrFieldRequired, f.Key)
+		}
+	}
+	return nil
+}
+
+// empty reports whether a value stands for a field nobody filled in.
+func empty(value any) bool {
+	if value == nil {
+		return true
+	}
+	written, ok := value.(string)
+	return ok && written == ""
+}

--- a/internal/content/values.go
+++ b/internal/content/values.go
@@ -17,9 +17,6 @@ var ErrFieldShape = errors.New("content: wrong kind of value")
 // ErrFieldRequired reports that a field must hold a value before publishing.
 var ErrFieldRequired = errors.New("content: field is required")
 
-// ErrRelationValuesWait reports that relation values wait for the relation table.
-var ErrRelationValuesWait = errors.New("content: relation values wait for the relation table")
-
 // dateLayout is how a date field writes a day.
 const dateLayout = "2006-01-02"
 
@@ -38,7 +35,7 @@ func (v Values) Validate(fields []Field) error {
 			return fmt.Errorf("%w: %s", ErrUnknownField, key)
 		}
 		if f.Kind == FieldKindRelation {
-			return fmt.Errorf("%w: %s", ErrRelationValuesWait, key)
+			return fmt.Errorf("%w: %s holds targets rather than a value", ErrFieldShape, key)
 		}
 		if value == nil {
 			continue
@@ -102,19 +99,6 @@ func (v Values) Merge(patch Values) Values {
 		merged[key] = value
 	}
 	return merged
-}
-
-// Filled reports whether every required field holds a value.
-func (v Values) Filled(fields []Field) error {
-	for _, f := range fields {
-		if !f.Required {
-			continue
-		}
-		if empty(v[f.Key]) {
-			return fmt.Errorf("%w: %s", ErrFieldRequired, f.Key)
-		}
-	}
-	return nil
 }
 
 // empty reports whether a value stands for a field nobody filled in.

--- a/internal/content/values_test.go
+++ b/internal/content/values_test.go
@@ -119,7 +119,7 @@ func TestValuesAcceptAClearedKey(t *testing.T) {
 	}
 }
 
-func TestValuesRefuseARelationUntilTheRowsExist(t *testing.T) {
+func TestValuesRefuseTargetsAmongTheScalars(t *testing.T) {
 	t.Parallel()
 
 	relation, err := content.NewField(content.Field{
@@ -129,12 +129,12 @@ func TestValuesRefuseARelationUntilTheRowsExist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewField() error = %v, want nil", err)
 	}
-	held := content.Values{"categories": []any{float64(1)}}
+	held := content.Values{"categories": []any{"019fb000-0000-7000-8000-000000000001"}}
 
 	err = held.Validate([]content.Field{relation})
 
-	if !errors.Is(err, content.ErrRelationValuesWait) {
-		t.Fatalf("Validate() error = %v, want %v", err, content.ErrRelationValuesWait)
+	if !errors.Is(err, content.ErrFieldShape) {
+		t.Fatalf("Validate() error = %v, want %v", err, content.ErrFieldShape)
 	}
 }
 
@@ -185,7 +185,7 @@ func TestValuesFilledPassesWhenNothingIsRequired(t *testing.T) {
 
 	held := content.Values{}
 
-	if err := held.Filled(declared(t)); err != nil {
+	if err := content.Filled(held, nil, declared(t)); err != nil {
 		t.Fatalf("Filled() error = %v, want nil", err)
 	}
 }
@@ -203,7 +203,7 @@ func TestValuesFilledRefusesAnEmptyRequiredField(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			err := held.Filled([]content.Field{required})
+			err := content.Filled(held, nil, []content.Field{required})
 
 			if !errors.Is(err, content.ErrFieldRequired) {
 				t.Fatalf("Filled() error = %v, want %v", err, content.ErrFieldRequired)
@@ -227,7 +227,7 @@ func TestValuesFilledAcceptsAFalseFlag(t *testing.T) {
 	}
 	held := content.Values{"boxed": false}
 
-	if err := held.Filled([]content.Field{flag}); err != nil {
+	if err := content.Filled(held, nil, []content.Field{flag}); err != nil {
 		t.Fatalf("Filled() error = %v, want a false flag to count as filled", err)
 	}
 }
@@ -244,7 +244,7 @@ func TestValuesFilledAcceptsAZero(t *testing.T) {
 	}
 	held := content.Values{"doors": float64(0)}
 
-	if err := held.Filled([]content.Field{count}); err != nil {
+	if err := content.Filled(held, nil, []content.Field{count}); err != nil {
 		t.Fatalf("Filled() error = %v, want a zero to count as filled", err)
 	}
 }

--- a/internal/content/values_test.go
+++ b/internal/content/values_test.go
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package content_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gopherium/gophenberg/internal/content"
+)
+
+// declared returns the field definitions a values test validates against.
+func declared(t *testing.T) []content.Field {
+	t.Helper()
+	kinds := map[string]content.FieldKind{
+		"color":   content.FieldKindText,
+		"doors":   content.FieldKindNumber,
+		"boxed":   content.FieldKindBoolean,
+		"sold-on": content.FieldKindDate,
+		"cover":   content.FieldKindMedia,
+	}
+	fields := make([]content.Field, 0, len(kinds))
+	for key, kind := range kinds {
+		built, err := content.NewField(content.Field{
+			TypeKey: "post", Key: key, Label: strings.ToUpper(key), Kind: kind,
+		})
+		if err != nil {
+			t.Fatalf("NewField(%q) error = %v, want nil", key, err)
+		}
+		fields = append(fields, built)
+	}
+	return fields
+}
+
+func TestValuesAcceptEveryScalarShape(t *testing.T) {
+	t.Parallel()
+
+	held := content.Values{
+		"color":   "red",
+		"doors":   float64(4),
+		"boxed":   true,
+		"sold-on": "2026-08-14",
+		"cover":   float64(12),
+	}
+
+	if err := held.Validate(declared(t)); err != nil {
+		t.Fatalf("Validate() error = %v, want the shapes accepted", err)
+	}
+}
+
+func TestValuesAcceptAWholeNumberWrittenInGo(t *testing.T) {
+	t.Parallel()
+
+	held := content.Values{"doors": 4}
+
+	if err := held.Validate(declared(t)); err != nil {
+		t.Fatalf("Validate() error = %v, want an int accepted as a number", err)
+	}
+}
+
+func TestValuesRefuseAnUnknownKey(t *testing.T) {
+	t.Parallel()
+
+	held := content.Values{"finish": "matte"}
+
+	err := held.Validate(declared(t))
+
+	if !errors.Is(err, content.ErrUnknownField) {
+		t.Fatalf("Validate() error = %v, want %v", err, content.ErrUnknownField)
+	}
+	if !strings.Contains(err.Error(), "finish") {
+		t.Errorf("Validate() error = %q, want the key named", err)
+	}
+}
+
+func TestValuesRefuseTheWrongShape(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]content.Values{
+		"a word where a number belongs":   {"doors": "many"},
+		"a number where a word belongs":   {"color": float64(3)},
+		"a word where a flag belongs":     {"boxed": "yes"},
+		"a word that is not a date":       {"sold-on": "the fourteenth"},
+		"a word where a media id belongs": {"cover": "12"},
+	}
+	for name, held := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := held.Validate(declared(t))
+
+			if !errors.Is(err, content.ErrFieldShape) {
+				t.Fatalf("Validate() error = %v, want %v", err, content.ErrFieldShape)
+			}
+		})
+	}
+}
+
+func TestValuesNameTheFieldThatHoldsTheWrongShape(t *testing.T) {
+	t.Parallel()
+
+	held := content.Values{"doors": "many"}
+
+	err := held.Validate(declared(t))
+
+	if !strings.Contains(err.Error(), "doors") {
+		t.Errorf("Validate() error = %q, want the field named", err)
+	}
+}
+
+func TestValuesAcceptAClearedKey(t *testing.T) {
+	t.Parallel()
+
+	held := content.Values{"color": nil}
+
+	if err := held.Validate(declared(t)); err != nil {
+		t.Fatalf("Validate() error = %v, want a cleared value accepted", err)
+	}
+}
+
+func TestValuesRefuseARelationUntilTheRowsExist(t *testing.T) {
+	t.Parallel()
+
+	relation, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "categories", Label: "Categories",
+		Kind: content.FieldKindRelation, RelatesTo: "category", Many: true,
+	})
+	if err != nil {
+		t.Fatalf("NewField() error = %v, want nil", err)
+	}
+	held := content.Values{"categories": []any{float64(1)}}
+
+	err = held.Validate([]content.Field{relation})
+
+	if !errors.Is(err, content.ErrRelationValuesWait) {
+		t.Fatalf("Validate() error = %v, want %v", err, content.ErrRelationValuesWait)
+	}
+}
+
+func TestValuesMergeSetsAndClears(t *testing.T) {
+	t.Parallel()
+
+	stored := content.Values{"color": "red", "doors": float64(4)}
+
+	merged := stored.Merge(content.Values{"color": "blue", "boxed": true, "doors": nil})
+
+	want := content.Values{"color": "blue", "boxed": true}
+	if len(merged) != len(want) {
+		t.Fatalf("Merge() = %v, want %v", merged, want)
+	}
+	for key, value := range want {
+		if merged[key] != value {
+			t.Errorf("Merge()[%q] = %v, want %v", key, merged[key], value)
+		}
+	}
+}
+
+func TestValuesMergeLeavesTheStoredValuesAlone(t *testing.T) {
+	t.Parallel()
+
+	stored := content.Values{"color": "red"}
+
+	stored.Merge(content.Values{"color": "blue"})
+
+	if stored["color"] != "red" {
+		t.Errorf("the stored values hold %v, want the merge to have left them alone", stored["color"])
+	}
+}
+
+func TestValuesMergeOverNothingHolds(t *testing.T) {
+	t.Parallel()
+
+	var stored content.Values
+
+	merged := stored.Merge(content.Values{"color": "blue"})
+
+	if merged["color"] != "blue" {
+		t.Errorf("Merge() = %v, want the patch held", merged)
+	}
+}
+
+func TestValuesFilledPassesWhenNothingIsRequired(t *testing.T) {
+	t.Parallel()
+
+	held := content.Values{}
+
+	if err := held.Filled(declared(t)); err != nil {
+		t.Fatalf("Filled() error = %v, want nil", err)
+	}
+}
+
+func TestValuesFilledRefusesAnEmptyRequiredField(t *testing.T) {
+	t.Parallel()
+
+	required := requiredColor(t)
+	tests := map[string]content.Values{
+		"the key is absent": {},
+		"the key is null":   {"color": nil},
+		"the key is empty":  {"color": ""},
+	}
+	for name, held := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := held.Filled([]content.Field{required})
+
+			if !errors.Is(err, content.ErrFieldRequired) {
+				t.Fatalf("Filled() error = %v, want %v", err, content.ErrFieldRequired)
+			}
+			if !strings.Contains(err.Error(), "color") {
+				t.Errorf("Filled() error = %q, want the field named", err)
+			}
+		})
+	}
+}
+
+func TestValuesFilledAcceptsAFalseFlag(t *testing.T) {
+	t.Parallel()
+
+	flag, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "boxed", Label: "Boxed",
+		Kind: content.FieldKindBoolean, Required: true,
+	})
+	if err != nil {
+		t.Fatalf("NewField() error = %v, want nil", err)
+	}
+	held := content.Values{"boxed": false}
+
+	if err := held.Filled([]content.Field{flag}); err != nil {
+		t.Fatalf("Filled() error = %v, want a false flag to count as filled", err)
+	}
+}
+
+func TestValuesFilledAcceptsAZero(t *testing.T) {
+	t.Parallel()
+
+	count, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "doors", Label: "Doors",
+		Kind: content.FieldKindNumber, Required: true,
+	})
+	if err != nil {
+		t.Fatalf("NewField() error = %v, want nil", err)
+	}
+	held := content.Values{"doors": float64(0)}
+
+	if err := held.Filled([]content.Field{count}); err != nil {
+		t.Fatalf("Filled() error = %v, want a zero to count as filled", err)
+	}
+}
+
+// requiredColor returns a required text field to test the publish gate against.
+func requiredColor(t *testing.T) content.Field {
+	t.Helper()
+	built, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "color", Label: "Color",
+		Kind: content.FieldKindText, Required: true,
+	})
+	if err != nil {
+		t.Fatalf("NewField() error = %v, want nil", err)
+	}
+	return built
+}

--- a/internal/postgres/content.go
+++ b/internal/postgres/content.go
@@ -126,7 +126,12 @@ func byID(ctx context.Context, queries *db.Queries, id uuid.UUID) (content.Conte
 	if err != nil {
 		return content.Content{}, fmt.Errorf("postgres: get content: %w", err)
 	}
-	return toContent(row), nil
+	held := toContent(row)
+	held.Relations, err = readRelations(ctx, queries, id)
+	if err != nil {
+		return content.Content{}, err
+	}
+	return held, nil
 }
 
 // storedValues returns the values a write holds, never nil so the column stays an object.
@@ -267,6 +272,13 @@ func (s *ContentStore) update(
 			return err
 		}
 		updated = toContent(row)
+		if err := writeRelations(ctx, queries, c); err != nil {
+			return err
+		}
+		updated.Relations, err = readRelations(ctx, queries, c.ID)
+		if err != nil {
+			return err
+		}
 		if err := queries.MoveDescendants(ctx, db.MoveDescendantsParams{
 			ID:        c.ID,
 			Path:      path,
@@ -302,6 +314,12 @@ func updateFailure(err error) error {
 	if errors.Is(err, content.ErrNotFound) || errors.Is(err, content.ErrConflict) || isSlugTaken(err) {
 		return err
 	}
+	if errors.Is(err, content.ErrTargetNotFound) || errors.Is(err, content.ErrTargetType) {
+		return err
+	}
+	if isTargetGone(err) {
+		return content.ErrTargetNotFound
+	}
 	return fmt.Errorf("postgres: update content: %w", err)
 }
 
@@ -331,7 +349,11 @@ func (s *ContentStore) Trash(ctx context.Context, id uuid.UUID, updatedAt time.T
 			return err
 		}
 		trashed = toContent(row)
-		return nil
+		if err := queries.RefreshRelationVisibility(ctx, id); err != nil {
+			return err
+		}
+		trashed.Relations, err = readRelations(ctx, queries, id)
+		return err
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -384,7 +406,15 @@ func (s *ContentStore) Restore(ctx context.Context, id uuid.UUID, updatedAt time
 	if err != nil {
 		return content.Content{}, fmt.Errorf("postgres: restore content: %w", err)
 	}
-	return toContent(row), nil
+	if err := s.queries.RefreshRelationVisibility(ctx, id); err != nil {
+		return content.Content{}, fmt.Errorf("postgres: refresh relation visibility: %w", err)
+	}
+	restored := toContent(row)
+	restored.Relations, err = readRelations(ctx, s.queries, id)
+	if err != nil {
+		return content.Content{}, err
+	}
+	return restored, nil
 }
 
 // Counts returns the number of items of the type in each status.

--- a/internal/postgres/content.go
+++ b/internal/postgres/content.go
@@ -394,27 +394,45 @@ func leavable(ctx context.Context, queries *db.Queries, id uuid.UUID) error {
 // Restore returns a trashed content item to draft. It recovers the original
 // slug, or leaves the trashed one in place when the original is taken.
 func (s *ContentStore) Restore(ctx context.Context, id uuid.UUID, updatedAt time.Time) (content.Content, error) {
-	row, err := s.queries.RestoreContent(ctx, db.RestoreContentParams{ID: id, UpdatedAt: updatedAt})
-	if isSlugTaken(err) {
-		row, err = s.queries.RestoreContentKeepingSlug(
-			ctx, db.RestoreContentKeepingSlugParams{ID: id, UpdatedAt: updatedAt},
-		)
-	}
+	var restored content.Content
+	err := pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
+		queries := s.queries.WithTx(tx)
+		row, err := restoredRow(ctx, queries, tx, id, updatedAt)
+		if err != nil {
+			return err
+		}
+		restored = toContent(row)
+		if err := queries.RefreshRelationVisibility(ctx, id); err != nil {
+			return err
+		}
+		restored.Relations, err = readRelations(ctx, queries, id)
+		return err
+	})
 	if errors.Is(err, pgx.ErrNoRows) {
 		return content.Content{}, content.ErrNotFound
 	}
 	if err != nil {
 		return content.Content{}, fmt.Errorf("postgres: restore content: %w", err)
 	}
-	if err := s.queries.RefreshRelationVisibility(ctx, id); err != nil {
-		return content.Content{}, fmt.Errorf("postgres: refresh relation visibility: %w", err)
-	}
-	restored := toContent(row)
-	restored.Relations, err = readRelations(ctx, s.queries, id)
-	if err != nil {
-		return content.Content{}, err
-	}
 	return restored, nil
+}
+
+// restoredRow returns the item to draft under its original slug, or under the trashed one when that is taken.
+func restoredRow(
+	ctx context.Context, queries *db.Queries, tx pgx.Tx, id uuid.UUID, updatedAt time.Time,
+) (db.CoreContent, error) {
+	var row db.CoreContent
+	err := pgx.BeginFunc(ctx, tx, func(attempt pgx.Tx) error {
+		var taken error
+		row, taken = queries.WithTx(attempt).RestoreContent(
+			ctx, db.RestoreContentParams{ID: id, UpdatedAt: updatedAt},
+		)
+		return taken
+	})
+	if !isSlugTaken(err) {
+		return row, err
+	}
+	return queries.RestoreContentKeepingSlug(ctx, db.RestoreContentKeepingSlugParams{ID: id, UpdatedAt: updatedAt})
 }
 
 // Counts returns the number of items of the type in each status.

--- a/internal/postgres/content.go
+++ b/internal/postgres/content.go
@@ -129,6 +129,14 @@ func byID(ctx context.Context, queries *db.Queries, id uuid.UUID) (content.Conte
 	return toContent(row), nil
 }
 
+// storedValues returns the values a write holds, never nil so the column stays an object.
+func storedValues(v content.Values) content.Values {
+	if v == nil {
+		return content.Values{}
+	}
+	return v
+}
+
 // toContent maps a stored row to a domain content item with UTC timestamps.
 func toContent(row db.CoreContent) content.Content {
 	return content.Content{
@@ -142,6 +150,7 @@ func toContent(row db.CoreContent) content.Content {
 		Content:     row.Content,
 		Excerpt:     row.Excerpt,
 		AuthorID:    row.AuthorID,
+		Fields:      row.Fields,
 		PublishedAt: utcOrNil(row.PublishedAt),
 		CreatedAt:   row.CreatedAt.UTC(),
 		UpdatedAt:   row.UpdatedAt.UTC(),
@@ -249,6 +258,7 @@ func (s *ContentStore) update(
 			Title:             c.Title,
 			Content:           c.Content,
 			Excerpt:           c.Excerpt,
+			Fields:            storedValues(c.Fields),
 			PublishedAt:       c.PublishedAt,
 			UpdatedAt:         c.UpdatedAt,
 			ExpectedUpdatedAt: expectedUpdatedAt,

--- a/internal/postgres/content.go
+++ b/internal/postgres/content.go
@@ -254,6 +254,9 @@ func (s *ContentStore) update(
 		if _, err := tx.Exec(ctx, deferAddressCheck); err != nil {
 			return err
 		}
+		if err := valuesDeclared(ctx, queries, c); err != nil {
+			return err
+		}
 		row, err := writeContent(ctx, queries, db.UpdateContentParams{
 			ID:                c.ID,
 			ParentID:          c.ParentID,
@@ -309,9 +312,33 @@ func writeContent(ctx context.Context, queries *db.Queries, p db.UpdateContentPa
 	return db.CoreContent{}, content.ErrConflict
 }
 
+// valuesDeclared refuses a value whose field the type no longer declares.
+func valuesDeclared(ctx context.Context, queries *db.Queries, c content.Content) error {
+	if len(c.Fields) == 0 {
+		return nil
+	}
+	keys, err := queries.LockFieldKeysOfType(ctx, c.Type)
+	if err != nil {
+		return err
+	}
+	declared := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		declared[key] = true
+	}
+	for key := range c.Fields {
+		if !declared[key] {
+			return fmt.Errorf("%w: %s", content.ErrUnknownField, key)
+		}
+	}
+	return nil
+}
+
 // updateFailure returns the refusal the update carries, and wraps anything else.
 func updateFailure(err error) error {
 	if errors.Is(err, content.ErrNotFound) || errors.Is(err, content.ErrConflict) || isSlugTaken(err) {
+		return err
+	}
+	if errors.Is(err, content.ErrUnknownField) {
 		return err
 	}
 	if errors.Is(err, content.ErrTargetNotFound) || errors.Is(err, content.ErrTargetType) {

--- a/internal/postgres/content_fields_migration_test.go
+++ b/internal/postgres/content_fields_migration_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres_test
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+)
+
+// insertField stores a field definition row with the given shape.
+func insertField(db *sql.DB, typeKey, key, kind string, relatesTo *string, many bool) error {
+	now := time.Now().UTC()
+	_, err := db.Exec(
+		`INSERT INTO core.content_fields
+		(type_key, key, label, kind, relates_to, many, required, created_at, updated_at)
+		VALUES ($1, $2, 'A Field', $3, $4, $5, false, $6, $6)`,
+		typeKey, key, kind, relatesTo, many, now,
+	)
+	return err
+}
+
+func TestFieldMigrationsHoldOneKeyPerType(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	if err := insertField(db, "post", "color", "text", nil, false); err != nil {
+		t.Fatalf("inserting the first field: %v, want nil", err)
+	}
+
+	err := insertField(db, "post", "color", "number", nil, false)
+
+	if code := pgErrorCode(err); code != uniqueViolation {
+		t.Fatalf("a taken field key: %v with code %q, want %q", err, code, uniqueViolation)
+	}
+}
+
+func TestFieldMigrationsRejectAnUnknownKind(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+
+	err := insertField(db, "post", "taste", "flavor", nil, false)
+
+	if code := pgErrorCode(err); code != checkViolation {
+		t.Fatalf("an unknown kind: %v with code %q, want %q", err, code, checkViolation)
+	}
+}
+
+func TestFieldMigrationsTieARelationToATarget(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+
+	err := insertField(db, "post", "engine", "relation", nil, false)
+
+	if code := pgErrorCode(err); code != checkViolation {
+		t.Fatalf("a relation without a target: %v with code %q, want %q", err, code, checkViolation)
+	}
+}
+
+func TestFieldMigrationsKeepTargetsOffScalars(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	target := "post"
+
+	err := insertField(db, "post", "color", "text", &target, false)
+
+	if code := pgErrorCode(err); code != checkViolation {
+		t.Fatalf("a scalar with a target: %v with code %q, want %q", err, code, checkViolation)
+	}
+}
+
+func TestFieldMigrationsKeepManyForRelations(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+
+	err := insertField(db, "post", "color", "text", nil, true)
+
+	if code := pgErrorCode(err); code != checkViolation {
+		t.Fatalf("many on a scalar: %v with code %q, want %q", err, code, checkViolation)
+	}
+}
+
+func TestFieldMigrationsFollowTheirType(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	if err := insertType(db, "car", "cars", false); err != nil {
+		t.Fatalf("inserting the type: %v, want nil", err)
+	}
+	if err := insertField(db, "car", "color", "text", nil, false); err != nil {
+		t.Fatalf("inserting the field: %v, want nil", err)
+	}
+
+	if _, err := db.Exec(`DELETE FROM core.content_types WHERE key = 'car'`); err != nil {
+		t.Fatalf("deleting the empty type: %v, want the cascade to carry its fields", err)
+	}
+
+	var remaining int
+	if err := db.QueryRow(
+		`SELECT count(*) FROM core.content_fields WHERE type_key = 'car'`,
+	).Scan(&remaining); err != nil {
+		t.Fatalf("counting the fields: %v, want nil", err)
+	}
+	if remaining != 0 {
+		t.Errorf("the deleted type keeps %d fields, want them gone with it", remaining)
+	}
+}
+
+func TestFieldMigrationsGiveContentAFieldsColumn(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	author := insertAuthor(t, db)
+	if err := insertContent(db, author, "draft", "hello-world", nil); err != nil {
+		t.Fatalf("inserting content: %v, want nil", err)
+	}
+
+	var stored string
+	err := db.QueryRow(`SELECT fields FROM core.content WHERE slug = 'hello-world'`).Scan(&stored)
+
+	if err != nil {
+		t.Fatalf("reading the fields column: %v, want it present", err)
+	}
+	if stored != "{}" {
+		t.Errorf("a fresh row holds %q, want the empty object", stored)
+	}
+}
+
+func TestFieldMigrationsGiveRevisionsAFieldsColumn(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+
+	var stored string
+	err := db.QueryRow(
+		`SELECT column_default FROM information_schema.columns
+		WHERE table_schema = 'core' AND table_name = 'content_revisions' AND column_name = 'fields'`,
+	).Scan(&stored)
+
+	if err != nil {
+		t.Fatalf("reading the revisions fields column: %v, want it present", err)
+	}
+	if stored != "'{}'::jsonb" {
+		t.Errorf("the revisions fields column defaults to %q, want the empty object", stored)
+	}
+}

--- a/internal/postgres/content_relations_migration_test.go
+++ b/internal/postgres/content_relations_migration_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres_test
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// insertRelation stores one relation row pointing from one item at another.
+func insertRelation(db *sql.DB, fromID uuid.UUID, fieldID int, toID uuid.UUID) error {
+	_, err := db.Exec(
+		`INSERT INTO core.content_relations (from_id, field_id, to_id, position, sort_at, visible)
+		VALUES ($1, $2, $3, 1, $4, true)`,
+		fromID, fieldID, toID, time.Now().UTC(),
+	)
+	return err
+}
+
+// relatableContent stores two posts and a relation field, returning both ids and the field id.
+func relatableContent(t *testing.T, db *sql.DB) (uuid.UUID, uuid.UUID, int) {
+	t.Helper()
+	author := insertAuthor(t, db)
+	if err := insertContent(db, author, "draft", "from-post", nil); err != nil {
+		t.Fatalf("inserting the pointing item: %v, want nil", err)
+	}
+	if err := insertContent(db, author, "draft", "to-post", nil); err != nil {
+		t.Fatalf("inserting the target: %v, want nil", err)
+	}
+	target := "post"
+	if err := insertField(db, "post", "related", "relation", &target, true); err != nil {
+		t.Fatalf("inserting the field: %v, want nil", err)
+	}
+	var fromID, toID uuid.UUID
+	var fieldID int
+	if err := db.QueryRow(`SELECT id FROM core.content WHERE slug = 'from-post'`).Scan(&fromID); err != nil {
+		t.Fatalf("reading the pointing item: %v, want nil", err)
+	}
+	if err := db.QueryRow(`SELECT id FROM core.content WHERE slug = 'to-post'`).Scan(&toID); err != nil {
+		t.Fatalf("reading the target: %v, want nil", err)
+	}
+	if err := db.QueryRow(
+		`SELECT id FROM core.content_fields WHERE type_key = 'post' AND key = 'related'`,
+	).Scan(&fieldID); err != nil {
+		t.Fatalf("reading the field: %v, want nil", err)
+	}
+	return fromID, toID, fieldID
+}
+
+func TestRelationMigrationsHoldOneRowPerTarget(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	fromID, toID, fieldID := relatableContent(t, db)
+	if err := insertRelation(db, fromID, fieldID, toID); err != nil {
+		t.Fatalf("inserting the first relation: %v, want nil", err)
+	}
+
+	err := insertRelation(db, fromID, fieldID, toID)
+
+	if code := pgErrorCode(err); code != uniqueViolation {
+		t.Fatalf("the same target twice: %v with code %q, want %q", err, code, uniqueViolation)
+	}
+}
+
+func TestRelationMigrationsRefuseAnUnstoredTarget(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	fromID, _, fieldID := relatableContent(t, db)
+
+	err := insertRelation(db, fromID, fieldID, uuid.Must(uuid.NewV7()))
+
+	if code := pgErrorCode(err); code != foreignKeyViolation {
+		t.Fatalf("an unstored target: %v with code %q, want %q", err, code, foreignKeyViolation)
+	}
+}
+
+func TestRelationMigrationsFollowADeletedTarget(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	fromID, toID, fieldID := relatableContent(t, db)
+	if err := insertRelation(db, fromID, fieldID, toID); err != nil {
+		t.Fatalf("inserting the relation: %v, want nil", err)
+	}
+
+	if _, err := db.Exec(`DELETE FROM core.content WHERE id = $1`, toID); err != nil {
+		t.Fatalf("deleting the target: %v, want the cascade to carry its relations", err)
+	}
+
+	var held int
+	if err := db.QueryRow(`SELECT count(*) FROM core.content_relations`).Scan(&held); err != nil {
+		t.Fatalf("counting the relations: %v, want nil", err)
+	}
+	if held != 0 {
+		t.Errorf("the deleted target keeps %d relations, want them gone with it", held)
+	}
+}
+
+func TestRelationMigrationsFollowADeletedField(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	fromID, toID, fieldID := relatableContent(t, db)
+	if err := insertRelation(db, fromID, fieldID, toID); err != nil {
+		t.Fatalf("inserting the relation: %v, want nil", err)
+	}
+
+	if _, err := db.Exec(`DELETE FROM core.content_fields WHERE id = $1`, fieldID); err != nil {
+		t.Fatalf("deleting the field: %v, want the cascade to carry its relations", err)
+	}
+
+	var held int
+	if err := db.QueryRow(`SELECT count(*) FROM core.content_relations`).Scan(&held); err != nil {
+		t.Fatalf("counting the relations: %v, want nil", err)
+	}
+	if held != 0 {
+		t.Errorf("the deleted field keeps %d relations, want them gone with it", held)
+	}
+}
+
+func TestRelationMigrationsServeTheTargetScanFromAnIndex(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	_, toID, _ := relatableContent(t, db)
+
+	if _, err := db.Exec(`SET enable_seqscan = off; SET enable_bitmapscan = off`); err != nil {
+		t.Fatalf("asking the planner for an ordered index scan: %v, want nil", err)
+	}
+	rows, err := db.Query(
+		`EXPLAIN (FORMAT TEXT) SELECT from_id FROM core.content_relations
+		WHERE to_id = $1 AND visible ORDER BY sort_at DESC, from_id LIMIT 20`,
+		toID,
+	)
+	if err != nil {
+		t.Fatalf("planning the term page scan: %v, want nil", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	plan := ""
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("reading the plan: %v, want nil", err)
+		}
+		plan += line + "\n"
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading the plan: %v, want nil", err)
+	}
+	if !strings.Contains(plan, "content_relations_target_idx") {
+		t.Errorf("the term page plan is %q, want the target index able to serve it", plan)
+	}
+	if strings.Contains(plan, "Sort") {
+		t.Errorf("the term page plan is %q, want a range scan rather than a sort", plan)
+	}
+}

--- a/internal/postgres/content_relations_migration_test.go
+++ b/internal/postgres/content_relations_migration_test.go
@@ -124,20 +124,19 @@ func TestRelationMigrationsFollowADeletedField(t *testing.T) {
 	}
 }
 
-func TestRelationMigrationsServeTheTargetScanFromAnIndex(t *testing.T) {
+func TestRelationMigrationsServeTheTermPageFromAnIndex(t *testing.T) {
 	t.Parallel()
 
 	db := newTestDB(t)
-	_, toID, _ := relatableContent(t, db)
-
-	if _, err := db.Exec(`SET enable_seqscan = off; SET enable_bitmapscan = off`); err != nil {
-		t.Fatalf("asking the planner for an ordered index scan: %v, want nil", err)
+	fromID, toID, fieldID := relatableContent(t, db)
+	if err := insertRelation(db, fromID, fieldID, toID); err != nil {
+		t.Fatalf("inserting the relation: %v, want nil", err)
 	}
-	rows, err := db.Query(
-		`EXPLAIN (FORMAT TEXT) SELECT from_id FROM core.content_relations
-		WHERE to_id = $1 AND visible ORDER BY sort_at DESC, from_id LIMIT 20`,
-		toID,
-	)
+
+	if _, err := db.Exec(`SET enable_seqscan = off`); err != nil {
+		t.Fatalf("asking the planner for an index: %v, want nil", err)
+	}
+	rows, err := db.Query(`EXPLAIN (FORMAT TEXT) `+termPageQuery, toID, 20, 0)
 	if err != nil {
 		t.Fatalf("planning the term page scan: %v, want nil", err)
 	}
@@ -155,9 +154,24 @@ func TestRelationMigrationsServeTheTargetScanFromAnIndex(t *testing.T) {
 		t.Fatalf("reading the plan: %v, want nil", err)
 	}
 	if !strings.Contains(plan, "content_relations_target_idx") {
-		t.Errorf("the term page plan is %q, want the target index able to serve it", plan)
+		t.Errorf("the term page plan is %q, want the target index to find the pointers", plan)
 	}
-	if strings.Contains(plan, "Sort") {
-		t.Errorf("the term page plan is %q, want a range scan rather than a sort", plan)
+	if strings.Contains(plan, "Seq Scan on content c") {
+		t.Errorf("the term page plan is %q, want the page limited before the rows are read", plan)
 	}
 }
+
+// termPageQuery is the listing a term page runs, as internal/postgres/queries.sql holds it.
+const termPageQuery = `SELECT c.id, c.type, c.status, c.slug, c.title, c.excerpt,
+    c.author_id, c.published_at, c.created_at, c.updated_at, c.parent_id, c.path, c.fields
+FROM (
+    SELECT DISTINCT r.sort_at, r.from_id
+    FROM core.content_relations r
+    JOIN core.content pointing ON pointing.id = r.from_id
+    JOIN core.content_types pointer ON pointer.key = pointing.type
+    WHERE r.to_id = $1 AND r.visible AND pointer.active
+    ORDER BY r.sort_at DESC, r.from_id
+    LIMIT $2 OFFSET $3
+) held
+JOIN core.content c ON c.id = held.from_id
+ORDER BY held.sort_at DESC, held.from_id`

--- a/internal/postgres/content_relations_test.go
+++ b/internal/postgres/content_relations_test.go
@@ -321,3 +321,133 @@ func TestContentStoreRefusesATargetDeletedMidWrite(t *testing.T) {
 		t.Fatalf("Update() error = %v, want %v", err, content.ErrTargetNotFound)
 	}
 }
+
+// publishItem takes stored content public and returns it.
+func publishItem(t *testing.T, store *postgres.ContentStore, c content.Content) content.Content {
+	t.Helper()
+	version := c.UpdatedAt
+	if err := c.Transition(content.StatusPublished); err != nil {
+		t.Fatalf("Transition() error = %v, want nil", err)
+	}
+	published, err := store.Update(t.Context(), c, version, nil, 0)
+	if err != nil {
+		t.Fatalf("publishing %q: %v, want nil", c.Title, err)
+	}
+	return published
+}
+
+func TestContentStoreListsWhatPointsAtATerm(t *testing.T) {
+	t.Parallel()
+
+	store, author, _ := relatingStore(t)
+	news := publishItem(t, store, storedCategory(t, store, "News", author))
+	first := publishItem(t, store, fileUnder(t, store, mustCreate(t, store, "First", author), news.ID))
+	second := publishItem(t, store, fileUnder(t, store, mustCreate(t, store, "Second", author), news.ID))
+
+	items, total, err := store.RelatedTo(t.Context(), news.ID, 1, 20)
+
+	if err != nil {
+		t.Fatalf("RelatedTo() error = %v, want nil", err)
+	}
+	if total != 2 || len(items) != 2 {
+		t.Fatalf("RelatedTo() = %d items of %d, want both pointers", len(items), total)
+	}
+	if items[0].ID != second.ID || items[1].ID != first.ID {
+		t.Errorf("RelatedTo() = %q then %q, want the newest first", items[0].Title, items[1].Title)
+	}
+}
+
+func TestContentStoreLeavesADraftOffATerm(t *testing.T) {
+	t.Parallel()
+
+	store, author, _ := relatingStore(t)
+	news := publishItem(t, store, storedCategory(t, store, "News", author))
+	fileUnder(t, store, mustCreate(t, store, "Not yet", author), news.ID)
+
+	items, total, err := store.RelatedTo(t.Context(), news.ID, 1, 20)
+
+	if err != nil {
+		t.Fatalf("RelatedTo() error = %v, want nil", err)
+	}
+	if total != 0 || len(items) != 0 {
+		t.Errorf("RelatedTo() = %d items of %d, want a draft left off the term page", len(items), total)
+	}
+}
+
+func TestContentStoreListsAnItemFiledTwiceOnce(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := relatingStore(t)
+	types := postgres.NewTypeStore(pool)
+	series, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "series", Label: "Series",
+		Kind: content.FieldKindRelation, RelatesTo: "category",
+	})
+	if err != nil {
+		t.Fatalf("NewField() error = %v, want nil", err)
+	}
+	if _, err := types.CreateField(t.Context(), series); err != nil {
+		t.Fatalf("declaring the second relation: %v, want nil", err)
+	}
+	news := publishItem(t, store, storedCategory(t, store, "News", author))
+	post := fileUnder(t, store, mustCreate(t, store, "Hello world", author), news.ID)
+	version := post.UpdatedAt
+	post.Relations = content.Relations{"categories": {news.ID}, "series": {news.ID}}
+	post.UpdatedAt = time.Now().UTC()
+	filed, err := store.Update(t.Context(), post, version, nil, 0)
+	if err != nil {
+		t.Fatalf("filing through both fields: %v, want nil", err)
+	}
+	publishItem(t, store, filed)
+
+	items, total, err := store.RelatedTo(t.Context(), news.ID, 1, 20)
+
+	if err != nil {
+		t.Fatalf("RelatedTo() error = %v, want nil", err)
+	}
+	if total != 1 || len(items) != 1 {
+		t.Errorf("RelatedTo() = %d items of %d, want an item filed twice listed once", len(items), total)
+	}
+}
+
+func TestContentStoreLeavesAnInactiveTypeOffATerm(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := relatingStore(t)
+	types := postgres.NewTypeStore(pool)
+	news := publishItem(t, store, storedCategory(t, store, "News", author))
+	publishItem(t, store, fileUnder(t, store, mustCreate(t, store, "Hello world", author), news.ID))
+	closed := postType()
+	closed.Active, closed.Default, closed.RouteWord = false, false, "posts"
+	closed.UpdatedAt = time.Now().UTC()
+	if _, err := types.Update(t.Context(), closed); err != nil {
+		t.Fatalf("closing the post type: %v, want nil", err)
+	}
+
+	items, total, err := store.RelatedTo(t.Context(), news.ID, 1, 20)
+
+	if err != nil {
+		t.Fatalf("RelatedTo() error = %v, want nil", err)
+	}
+	if total != 0 || len(items) != 0 {
+		t.Errorf("RelatedTo() = %d items of %d, want a closed type off the term page", len(items), total)
+	}
+}
+
+func TestContentStorePagesATerm(t *testing.T) {
+	t.Parallel()
+
+	store, author, _ := relatingStore(t)
+	news := publishItem(t, store, storedCategory(t, store, "News", author))
+	oldest := publishItem(t, store, fileUnder(t, store, mustCreate(t, store, "Oldest", author), news.ID))
+	publishItem(t, store, fileUnder(t, store, mustCreate(t, store, "Newest", author), news.ID))
+
+	items, total, err := store.RelatedTo(t.Context(), news.ID, 2, 1)
+
+	if err != nil {
+		t.Fatalf("RelatedTo() error = %v, want nil", err)
+	}
+	if total != 2 || len(items) != 1 || items[0].ID != oldest.ID {
+		t.Errorf("RelatedTo() page 2 = %d items of %d, want the older pointer alone", len(items), total)
+	}
+}

--- a/internal/postgres/content_relations_test.go
+++ b/internal/postgres/content_relations_test.go
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gopherium/gophenberg/internal/content"
+	"github.com/gopherium/gophenberg/internal/postgres"
+)
+
+// categoryType returns a content type items may be filed under.
+func categoryType() content.Type {
+	return content.Type{
+		Key: "category", SingularLabel: "Category", PluralLabel: "Categories",
+		RouteWord: "categories", Revisions: true, RevisionCap: 100,
+		PageKind: content.PageKindSingle, Active: true,
+	}
+}
+
+// relatingStore returns a store, an author, the pool, and a post type carrying a relation field.
+func relatingStore(t *testing.T) (*postgres.ContentStore, uuid.UUID, *pgxpool.Pool) {
+	t.Helper()
+	store, author, pool := newContentStoreWithPool(t)
+	types := postgres.NewTypeStore(pool)
+	if _, err := types.Create(t.Context(), categoryType()); err != nil {
+		t.Fatalf("registering the category type: %v, want nil", err)
+	}
+	built, err := content.NewField(content.Field{
+		TypeKey: "post", Key: "categories", Label: "Categories",
+		Kind: content.FieldKindRelation, RelatesTo: "category", Many: true,
+	})
+	if err != nil {
+		t.Fatalf("NewField() error = %v, want nil", err)
+	}
+	if _, err := types.CreateField(t.Context(), built); err != nil {
+		t.Fatalf("declaring the relation: %v, want nil", err)
+	}
+	return store, author, pool
+}
+
+// storedCategory stores one category item and returns it.
+func storedCategory(t *testing.T, store *postgres.ContentStore, title string, author uuid.UUID) content.Content {
+	t.Helper()
+	built, err := content.New(categoryType(), nil, title, author)
+	if err != nil {
+		t.Fatalf("New(%q) error = %v, want nil", title, err)
+	}
+	created, err := store.Create(t.Context(), built)
+	if err != nil {
+		t.Fatalf("Create(%q) error = %v, want nil", title, err)
+	}
+	return created
+}
+
+// fileUnder points the post's categories at the targets and stores it.
+func fileUnder(
+	t *testing.T, store *postgres.ContentStore, post content.Content, targets ...uuid.UUID,
+) content.Content {
+	t.Helper()
+	version := post.UpdatedAt
+	post.Relations = content.Relations{"categories": targets}
+	post.UpdatedAt = time.Now().UTC()
+	updated, err := store.Update(t.Context(), post, version, nil, 0)
+	if err != nil {
+		t.Fatalf("filing the post: %v, want nil", err)
+	}
+	return updated
+}
+
+// visibilityOf reads the denormalized pair the term page scans.
+func visibilityOf(t *testing.T, pool *pgxpool.Pool, fromID uuid.UUID) (bool, time.Time) {
+	t.Helper()
+	var visible bool
+	var sortAt time.Time
+	err := pool.QueryRow(
+		t.Context(), `SELECT visible, sort_at FROM core.content_relations WHERE from_id = $1`, fromID,
+	).Scan(&visible, &sortAt)
+	if err != nil {
+		t.Fatalf("reading the relation row: %v, want nil", err)
+	}
+	return visible, sortAt
+}
+
+func TestContentStoreCarriesRelations(t *testing.T) {
+	t.Parallel()
+
+	store, author, _ := relatingStore(t)
+	news := storedCategory(t, store, "News", author)
+	guides := storedCategory(t, store, "Guides", author)
+	post := mustCreate(t, store, "Hello world", author)
+
+	updated := fileUnder(t, store, post, guides.ID, news.ID)
+
+	held := updated.Relations["categories"]
+	if len(held) != 2 || held[0] != guides.ID || held[1] != news.ID {
+		t.Fatalf("Update() relations = %v, want both targets in the order given", held)
+	}
+	read, err := store.ByID(t.Context(), post.ID)
+	if err != nil {
+		t.Fatalf("ByID() error = %v, want nil", err)
+	}
+	stored := read.Relations["categories"]
+	if len(stored) != 2 || stored[0] != guides.ID || stored[1] != news.ID {
+		t.Errorf("ByID() relations = %v, want the author's order kept", stored)
+	}
+}
+
+func TestContentStoreReplacesTheTargetsItHeld(t *testing.T) {
+	t.Parallel()
+
+	store, author, _ := relatingStore(t)
+	news := storedCategory(t, store, "News", author)
+	guides := storedCategory(t, store, "Guides", author)
+	post := fileUnder(t, store, mustCreate(t, store, "Hello world", author), news.ID)
+
+	updated := fileUnder(t, store, post, guides.ID)
+
+	held := updated.Relations["categories"]
+	if len(held) != 1 || held[0] != guides.ID {
+		t.Errorf("Update() relations = %v, want the targets replaced", held)
+	}
+}
+
+func TestContentStoreClearsTheTargetsItHeld(t *testing.T) {
+	t.Parallel()
+
+	store, author, _ := relatingStore(t)
+	news := storedCategory(t, store, "News", author)
+	post := fileUnder(t, store, mustCreate(t, store, "Hello world", author), news.ID)
+
+	updated := fileUnder(t, store, post)
+
+	if len(updated.Relations["categories"]) != 0 {
+		t.Errorf("Update() relations = %v, want the field cleared", updated.Relations)
+	}
+}
+
+func TestContentStoreRefusesATargetOfTheWrongType(t *testing.T) {
+	t.Parallel()
+
+	store, author, _ := relatingStore(t)
+	other := mustCreate(t, store, "Second post", author)
+	post := mustCreate(t, store, "Hello world", author)
+	post.Relations = content.Relations{"categories": {other.ID}}
+	post.UpdatedAt = time.Now().UTC()
+
+	_, err := store.Update(t.Context(), post, post.CreatedAt, nil, 0)
+
+	if !errors.Is(err, content.ErrTargetType) {
+		t.Fatalf("Update() error = %v, want %v", err, content.ErrTargetType)
+	}
+}
+
+func TestContentStoreRefusesATargetNothingHolds(t *testing.T) {
+	t.Parallel()
+
+	store, author, _ := relatingStore(t)
+	post := mustCreate(t, store, "Hello world", author)
+	post.Relations = content.Relations{"categories": {uuid.Must(uuid.NewV7())}}
+	post.UpdatedAt = time.Now().UTC()
+
+	_, err := store.Update(t.Context(), post, post.CreatedAt, nil, 0)
+
+	if !errors.Is(err, content.ErrTargetNotFound) {
+		t.Fatalf("Update() error = %v, want %v", err, content.ErrTargetNotFound)
+	}
+}
+
+func TestContentStoreHidesTheRelationsOfADraft(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := relatingStore(t)
+	news := storedCategory(t, store, "News", author)
+	post := fileUnder(t, store, mustCreate(t, store, "Hello world", author), news.ID)
+
+	visible, sortAt := visibilityOf(t, pool, post.ID)
+
+	if visible {
+		t.Errorf("the relation of a draft is visible, want it hidden until the item is published")
+	}
+	if !sortAt.Equal(post.CreatedAt) {
+		t.Errorf("sort_at = %v, want the unpublished item's created stamp %v", sortAt, post.CreatedAt)
+	}
+}
+
+func TestContentStoreShowsTheRelationsOfAPublishedItem(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := relatingStore(t)
+	news := storedCategory(t, store, "News", author)
+	post := fileUnder(t, store, mustCreate(t, store, "Hello world", author), news.ID)
+	version := post.UpdatedAt
+	if err := post.Transition(content.StatusPublished); err != nil {
+		t.Fatalf("Transition() error = %v, want nil", err)
+	}
+
+	published, err := store.Update(t.Context(), post, version, nil, 0)
+	if err != nil {
+		t.Fatalf("publishing: %v, want nil", err)
+	}
+
+	visible, sortAt := visibilityOf(t, pool, post.ID)
+	if !visible {
+		t.Errorf("the relation of a published item is hidden, want it on the term page")
+	}
+	if !sortAt.Equal(*published.PublishedAt) {
+		t.Errorf("sort_at = %v, want the published stamp %v", sortAt, *published.PublishedAt)
+	}
+}
+
+func TestContentStoreHidesTheRelationsOfATrashedItem(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := relatingStore(t)
+	news := storedCategory(t, store, "News", author)
+	post := fileUnder(t, store, mustCreate(t, store, "Hello world", author), news.ID)
+	version := post.UpdatedAt
+	if err := post.Transition(content.StatusPublished); err != nil {
+		t.Fatalf("Transition() error = %v, want nil", err)
+	}
+	if _, err := store.Update(t.Context(), post, version, nil, 0); err != nil {
+		t.Fatalf("publishing: %v, want nil", err)
+	}
+
+	if _, err := store.Trash(t.Context(), post.ID, time.Now().UTC()); err != nil {
+		t.Fatalf("Trash() error = %v, want nil", err)
+	}
+
+	if visible, _ := visibilityOf(t, pool, post.ID); visible {
+		t.Errorf("the relation of a trashed item is visible, want it off the term page")
+	}
+}
+
+func TestContentStoreHidesTheRelationsOfARestoredDraft(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := relatingStore(t)
+	news := storedCategory(t, store, "News", author)
+	post := fileUnder(t, store, mustCreate(t, store, "Hello world", author), news.ID)
+	trashed, err := store.Trash(t.Context(), post.ID, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("Trash() error = %v, want nil", err)
+	}
+	if _, err := pool.Exec(
+		t.Context(), `UPDATE core.content_relations SET visible = true WHERE from_id = $1`, post.ID,
+	); err != nil {
+		t.Fatalf("planting a visible relation: %v, want nil", err)
+	}
+	if visible, _ := visibilityOf(t, pool, post.ID); !visible {
+		t.Fatal("the planted relation is hidden, want the test to start from the state the restore must clear")
+	}
+
+	if _, err := store.Restore(t.Context(), post.ID, trashed.UpdatedAt); err != nil {
+		t.Fatalf("Restore() error = %v, want nil", err)
+	}
+
+	if visible, _ := visibilityOf(t, pool, post.ID); visible {
+		t.Errorf("the relation of a restored draft is visible, want the restore to have hidden it")
+	}
+}
+
+func TestContentStoreAnswersTrashWithItsRelations(t *testing.T) {
+	t.Parallel()
+
+	store, author, _ := relatingStore(t)
+	news := storedCategory(t, store, "News", author)
+	post := fileUnder(t, store, mustCreate(t, store, "Hello world", author), news.ID)
+
+	trashed, err := store.Trash(t.Context(), post.ID, time.Now().UTC())
+
+	if err != nil {
+		t.Fatalf("Trash() error = %v, want nil", err)
+	}
+	if held := trashed.Relations["categories"]; len(held) != 1 || held[0] != news.ID {
+		t.Errorf("Trash() relations = %v, want the targets the item still holds", trashed.Relations)
+	}
+}
+
+func TestContentStoreAnswersRestoreWithItsRelations(t *testing.T) {
+	t.Parallel()
+
+	store, author, _ := relatingStore(t)
+	news := storedCategory(t, store, "News", author)
+	post := fileUnder(t, store, mustCreate(t, store, "Hello world", author), news.ID)
+	trashed, err := store.Trash(t.Context(), post.ID, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("Trash() error = %v, want nil", err)
+	}
+
+	restored, err := store.Restore(t.Context(), post.ID, trashed.UpdatedAt)
+
+	if err != nil {
+		t.Fatalf("Restore() error = %v, want nil", err)
+	}
+	if held := restored.Relations["categories"]; len(held) != 1 || held[0] != news.ID {
+		t.Errorf("Restore() relations = %v, want the targets the item still holds", restored.Relations)
+	}
+}
+
+func TestContentStoreRefusesATargetDeletedMidWrite(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := relatingStore(t)
+	news := storedCategory(t, store, "News", author)
+	post := mustCreate(t, store, "Hello world", author)
+	post.Relations = content.Relations{"categories": {news.ID}}
+	post.UpdatedAt = time.Now().UTC()
+	if _, err := pool.Exec(t.Context(), `DELETE FROM core.content WHERE id = $1`, news.ID); err != nil {
+		t.Fatalf("removing the target: %v, want nil", err)
+	}
+
+	_, err := store.Update(t.Context(), post, post.CreatedAt, nil, 0)
+
+	if !errors.Is(err, content.ErrTargetNotFound) {
+		t.Fatalf("Update() error = %v, want %v", err, content.ErrTargetNotFound)
+	}
+}

--- a/internal/postgres/content_values_test.go
+++ b/internal/postgres/content_values_test.go
@@ -3,16 +3,32 @@
 package postgres_test
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+
 	"github.com/gopherium/gophenberg/internal/content"
+	"github.com/gopherium/gophenberg/internal/postgres"
 )
+
+// declareField adds a field definition to the post type so its items may hold values under the key.
+func declareField(t *testing.T, pool *pgxpool.Pool, key string, kind content.FieldKind) {
+	t.Helper()
+	types := postgres.NewTypeStore(pool)
+	if _, err := types.CreateField(t.Context(), fieldOn(t, "post", key, kind, "")); err != nil {
+		t.Fatalf("declaring the %q field: %v, want nil", key, err)
+	}
+}
 
 func TestContentStoreCarriesFieldValues(t *testing.T) {
 	t.Parallel()
 
-	store, author, _ := newContentStoreWithPool(t)
+	store, author, pool := newContentStoreWithPool(t)
+	declareField(t, pool, "color", content.FieldKindText)
+	declareField(t, pool, "doors", content.FieldKindNumber)
 	created := mustCreate(t, store, "Hello world", author)
 	created.Fields = content.Values{"color": "red", "doors": float64(4)}
 	created.UpdatedAt = time.Now().UTC()
@@ -34,6 +50,104 @@ func TestContentStoreCarriesFieldValues(t *testing.T) {
 	}
 }
 
+func TestContentStoreRefusesAValueWhoseFieldIsGone(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := newContentStoreWithPool(t)
+	declareField(t, pool, "color", content.FieldKindText)
+	created := mustCreate(t, store, "Hello world", author)
+	created.Fields = content.Values{"color": "red"}
+	created.UpdatedAt = time.Now().UTC()
+	if err := postgres.NewTypeStore(pool).DeleteField(t.Context(), "post", "color"); err != nil {
+		t.Fatalf("deleting the field: %v, want nil", err)
+	}
+
+	_, err := store.Update(t.Context(), created, created.CreatedAt, nil, 0)
+
+	if !errors.Is(err, content.ErrUnknownField) {
+		t.Fatalf("Update() error = %v, want %v", err, content.ErrUnknownField)
+	}
+}
+
+func TestContentStoreWaitsForAFieldDeletionInFlight(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := newContentStoreWithPool(t)
+	declareField(t, pool, "color", content.FieldKindText)
+	created := mustCreate(t, store, "Hello world", author)
+	created.Fields = content.Values{"color": "red"}
+	created.UpdatedAt = time.Now().UTC()
+	removing, err := pool.Begin(t.Context())
+	if err != nil {
+		t.Fatalf("opening the removing transaction: %v, want nil", err)
+	}
+	defer func() { _ = removing.Rollback(context.Background()) }()
+	if _, err := removing.Exec(
+		t.Context(), `DELETE FROM core.content_fields WHERE type_key = 'post' AND key = 'color'`,
+	); err != nil {
+		t.Fatalf("removing the definition: %v, want nil", err)
+	}
+	written := make(chan error, 1)
+
+	go func() {
+		_, err := store.Update(context.Background(), created, created.CreatedAt, nil, 0)
+		written <- err
+	}()
+
+	select {
+	case err := <-written:
+		t.Fatalf("Update() returned %v while the definition was being removed, want it waiting", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+	if err := removing.Commit(t.Context()); err != nil {
+		t.Fatalf("committing the removal: %v, want nil", err)
+	}
+	if err := <-written; !errors.Is(err, content.ErrUnknownField) {
+		t.Fatalf("Update() error = %v, want %v once the field was gone", err, content.ErrUnknownField)
+	}
+}
+
+func TestTypeStoreDeleteFieldWaitsForAContentWriteHoldingTheDefinition(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := newContentStoreWithPool(t)
+	declareField(t, pool, "color", content.FieldKindText)
+	created := mustCreate(t, store, "Hello world", author)
+	held, err := pool.Begin(t.Context())
+	if err != nil {
+		t.Fatalf("opening the holding transaction: %v, want nil", err)
+	}
+	defer func() { _ = held.Rollback(context.Background()) }()
+	if _, err := held.Exec(
+		t.Context(), `SELECT key FROM core.content_fields WHERE type_key = 'post' FOR KEY SHARE`,
+	); err != nil {
+		t.Fatalf("holding the field definitions: %v, want nil", err)
+	}
+	swept := make(chan error, 1)
+
+	go func() { swept <- postgres.NewTypeStore(pool).DeleteField(context.Background(), "post", "color") }()
+
+	select {
+	case err := <-swept:
+		t.Fatalf("DeleteField() returned %v while a content write held the definitions, want it waiting", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+	created.Fields = content.Values{"color": "red"}
+	created.UpdatedAt = time.Now().UTC()
+	if _, err := store.Update(t.Context(), created, created.CreatedAt, nil, 0); err != nil {
+		t.Fatalf("writing the value: %v, want nil", err)
+	}
+	if err := held.Commit(t.Context()); err != nil {
+		t.Fatalf("committing the holding transaction: %v, want nil", err)
+	}
+	if err := <-swept; err != nil {
+		t.Fatalf("DeleteField() error = %v, want nil once the write finished", err)
+	}
+	if got := storedFields(t, pool, created.Slug); got != `{}` {
+		t.Errorf("the item holds %s, want the sweep to have caught the value the write added", got)
+	}
+}
+
 func TestContentStoreStartsWithNoFieldValues(t *testing.T) {
 	t.Parallel()
 
@@ -49,7 +163,8 @@ func TestContentStoreStartsWithNoFieldValues(t *testing.T) {
 func TestContentStoreSnapshotsFieldValues(t *testing.T) {
 	t.Parallel()
 
-	store, author, _ := newContentStoreWithPool(t)
+	store, author, pool := newContentStoreWithPool(t)
+	declareField(t, pool, "color", content.FieldKindText)
 	created := mustCreate(t, store, "Hello world", author)
 	created.Fields = content.Values{"color": "red"}
 	created.UpdatedAt = time.Now().UTC()

--- a/internal/postgres/content_values_test.go
+++ b/internal/postgres/content_values_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gopherium/gophenberg/internal/content"
+)
+
+func TestContentStoreCarriesFieldValues(t *testing.T) {
+	t.Parallel()
+
+	store, author, _ := newContentStoreWithPool(t)
+	created := mustCreate(t, store, "Hello world", author)
+	created.Fields = content.Values{"color": "red", "doors": float64(4)}
+	created.UpdatedAt = time.Now().UTC()
+
+	updated, err := store.Update(t.Context(), created, created.CreatedAt, nil, 0)
+
+	if err != nil {
+		t.Fatalf("Update() error = %v, want nil", err)
+	}
+	if updated.Fields["color"] != "red" {
+		t.Errorf("Update() fields = %v, want the values carried back", updated.Fields)
+	}
+	held, err := store.ByID(t.Context(), created.ID)
+	if err != nil {
+		t.Fatalf("ByID() error = %v, want nil", err)
+	}
+	if held.Fields["color"] != "red" || held.Fields["doors"] != float64(4) {
+		t.Errorf("ByID() fields = %v, want both values stored", held.Fields)
+	}
+}
+
+func TestContentStoreStartsWithNoFieldValues(t *testing.T) {
+	t.Parallel()
+
+	store, author, _ := newContentStoreWithPool(t)
+
+	created := mustCreate(t, store, "Hello world", author)
+
+	if len(created.Fields) != 0 {
+		t.Errorf("Create() fields = %v, want a fresh item to hold none", created.Fields)
+	}
+}
+
+func TestContentStoreSnapshotsFieldValues(t *testing.T) {
+	t.Parallel()
+
+	store, author, _ := newContentStoreWithPool(t)
+	created := mustCreate(t, store, "Hello world", author)
+	created.Fields = content.Values{"color": "red"}
+	created.UpdatedAt = time.Now().UTC()
+	stored, err := store.Update(t.Context(), created, created.CreatedAt, nil, 0)
+	if err != nil {
+		t.Fatalf("filling the field: %v, want nil", err)
+	}
+	snapshot, err := content.NewRevision(stored, content.RevisionKindRevision, author)
+	if err != nil {
+		t.Fatalf("NewRevision() error = %v, want nil", err)
+	}
+	edited := stored
+	edited.Fields = content.Values{"color": "blue"}
+	edited.UpdatedAt = time.Now().UTC()
+
+	if _, err := store.Update(t.Context(), edited, stored.UpdatedAt, &snapshot, 100); err != nil {
+		t.Fatalf("Update() error = %v, want nil", err)
+	}
+
+	revisions, err := store.Revisions(t.Context(), created.ID)
+	if err != nil {
+		t.Fatalf("Revisions() error = %v, want nil", err)
+	}
+	if len(revisions) != 1 {
+		t.Fatalf("Revisions() = %d, want the snapshot stored", len(revisions))
+	}
+	held, err := store.RevisionByID(t.Context(), created.ID, revisions[0].ID)
+	if err != nil {
+		t.Fatalf("Revision() error = %v, want nil", err)
+	}
+	if held.Fields["color"] != "red" {
+		t.Errorf("Revision() fields = %v, want the values as they stood", held.Fields)
+	}
+}
+
+func TestContentStoreParksFieldValuesInAnAutosave(t *testing.T) {
+	t.Parallel()
+
+	store, author, _ := newContentStoreWithPool(t)
+	created := mustCreate(t, store, "Hello world", author)
+	buffer := created
+	buffer.Fields = content.Values{"color": "red"}
+	autosave, err := content.NewRevision(buffer, content.RevisionKindAutosave, author)
+	if err != nil {
+		t.Fatalf("NewRevision() error = %v, want nil", err)
+	}
+
+	saved, err := store.SaveAutosave(t.Context(), autosave)
+
+	if err != nil {
+		t.Fatalf("SaveAutosave() error = %v, want nil", err)
+	}
+	if saved.Fields["color"] != "red" {
+		t.Errorf("SaveAutosave() fields = %v, want the buffer's values", saved.Fields)
+	}
+	held, err := store.Autosave(t.Context(), created.ID, author)
+	if err != nil {
+		t.Fatalf("Autosave() error = %v, want nil", err)
+	}
+	if held.Fields["color"] != "red" {
+		t.Errorf("Autosave() fields = %v, want the parked values", held.Fields)
+	}
+}

--- a/internal/postgres/db/models.go
+++ b/internal/postgres/db/models.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/gopherium/gophenberg/internal/content"
 	"github.com/gopherium/gophenberg/internal/media"
 )
 
@@ -25,7 +26,7 @@ type CoreContent struct {
 	UpdatedAt   time.Time
 	ParentID    *uuid.UUID
 	Path        string
-	Fields      []byte
+	Fields      content.Values
 }
 
 type CoreContentField struct {
@@ -50,7 +51,7 @@ type CoreContentRevision struct {
 	Content   string
 	Excerpt   string
 	CreatedAt time.Time
-	Fields    []byte
+	Fields    content.Values
 }
 
 type CoreContentType struct {

--- a/internal/postgres/db/models.go
+++ b/internal/postgres/db/models.go
@@ -42,6 +42,15 @@ type CoreContentField struct {
 	UpdatedAt time.Time
 }
 
+type CoreContentRelation struct {
+	FromID   uuid.UUID
+	FieldID  int32
+	ToID     uuid.UUID
+	Position int32
+	SortAt   time.Time
+	Visible  bool
+}
+
 type CoreContentRevision struct {
 	ID        uuid.UUID
 	ContentID uuid.UUID

--- a/internal/postgres/db/models.go
+++ b/internal/postgres/db/models.go
@@ -25,6 +25,20 @@ type CoreContent struct {
 	UpdatedAt   time.Time
 	ParentID    *uuid.UUID
 	Path        string
+	Fields      []byte
+}
+
+type CoreContentField struct {
+	ID        int32
+	TypeKey   string
+	Key       string
+	Label     string
+	Kind      string
+	RelatesTo *string
+	Many      bool
+	Required  bool
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 type CoreContentRevision struct {
@@ -36,6 +50,7 @@ type CoreContentRevision struct {
 	Content   string
 	Excerpt   string
 	CreatedAt time.Time
+	Fields    []byte
 }
 
 type CoreContentType struct {

--- a/internal/postgres/db/queries.sql.go
+++ b/internal/postgres/db/queries.sql.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/gopherium/gophenberg/internal/content"
 	"github.com/gopherium/gophenberg/internal/media"
 )
 
@@ -411,10 +412,10 @@ func (q *Queries) CreateMedia(ctx context.Context, arg CreateMediaParams) (CoreM
 
 const createRevision = `-- name: CreateRevision :exec
 INSERT INTO core.content_revisions (
-    id, content_id, kind, author_id, title, content, excerpt, created_at
+    id, content_id, kind, author_id, title, content, excerpt, fields, created_at
 )
 VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
+    $1, $2, $3, $4, $5, $6, $7, $8, $9
 )
 `
 
@@ -426,6 +427,7 @@ type CreateRevisionParams struct {
 	Title     string
 	Content   string
 	Excerpt   string
+	Fields    content.Values
 	CreatedAt time.Time
 }
 
@@ -438,6 +440,7 @@ func (q *Queries) CreateRevision(ctx context.Context, arg CreateRevisionParams) 
 		arg.Title,
 		arg.Content,
 		arg.Excerpt,
+		arg.Fields,
 		arg.CreatedAt,
 	)
 	return err
@@ -548,7 +551,7 @@ func (q *Queries) DeleteRevision(ctx context.Context, arg DeleteRevisionParams) 
 }
 
 const getAutosave = `-- name: GetAutosave :one
-SELECT r.id, r.content_id, r.kind, r.author_id, r.title, r.content, r.excerpt, r.created_at
+SELECT r.id, r.content_id, r.kind, r.author_id, r.title, r.content, r.excerpt, r.fields, r.created_at
 FROM core.content_revisions r
 WHERE r.content_id = $1 AND r.author_id = $2 AND r.kind = 'autosave'
 `
@@ -566,6 +569,7 @@ type GetAutosaveRow struct {
 	Title     string
 	Content   string
 	Excerpt   string
+	Fields    content.Values
 	CreatedAt time.Time
 }
 
@@ -580,6 +584,7 @@ func (q *Queries) GetAutosave(ctx context.Context, arg GetAutosaveParams) (GetAu
 		&i.Title,
 		&i.Content,
 		&i.Excerpt,
+		&i.Fields,
 		&i.CreatedAt,
 	)
 	return i, err
@@ -701,7 +706,7 @@ func (q *Queries) GetPublishedContentByPath(ctx context.Context, path string) (C
 }
 
 const getRevision = `-- name: GetRevision :one
-SELECT r.id, r.content_id, r.kind, r.author_id, r.title, r.content, r.excerpt, r.created_at
+SELECT r.id, r.content_id, r.kind, r.author_id, r.title, r.content, r.excerpt, r.fields, r.created_at
 FROM core.content_revisions r
 WHERE r.content_id = $1 AND r.id = $2
 `
@@ -719,6 +724,7 @@ type GetRevisionRow struct {
 	Title     string
 	Content   string
 	Excerpt   string
+	Fields    content.Values
 	CreatedAt time.Time
 }
 
@@ -733,6 +739,7 @@ func (q *Queries) GetRevision(ctx context.Context, arg GetRevisionParams) (GetRe
 		&i.Title,
 		&i.Content,
 		&i.Excerpt,
+		&i.Fields,
 		&i.CreatedAt,
 	)
 	return i, err
@@ -794,7 +801,7 @@ type ListContentRow struct {
 	UpdatedAt   time.Time
 	ParentID    *uuid.UUID
 	Path        string
-	Fields      []byte
+	Fields      content.Values
 }
 
 func (q *Queries) ListContent(ctx context.Context, arg ListContentParams) ([]ListContentRow, error) {
@@ -1408,8 +1415,9 @@ func (q *Queries) TrashContent(ctx context.Context, arg TrashContentParams) (Cor
 const updateContent = `-- name: UpdateContent :one
 UPDATE core.content AS p
 SET status = $1, slug = $2, path = $3, parent_id = $4, title = $5,
-    content = $6, excerpt = $7, published_at = $8, updated_at = $9
-WHERE p.id = $10 AND p.updated_at = $11
+    content = $6, excerpt = $7, fields = $8, published_at = $9,
+    updated_at = $10
+WHERE p.id = $11 AND p.updated_at = $12
 RETURNING p.id, p.type, p.status, p.slug, p.title, p.content, p.excerpt,
     p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields
 `
@@ -1422,6 +1430,7 @@ type UpdateContentParams struct {
 	Title             string
 	Content           string
 	Excerpt           string
+	Fields            content.Values
 	PublishedAt       *time.Time
 	UpdatedAt         time.Time
 	ID                uuid.UUID
@@ -1437,6 +1446,7 @@ func (q *Queries) UpdateContent(ctx context.Context, arg UpdateContentParams) (C
 		arg.Title,
 		arg.Content,
 		arg.Excerpt,
+		arg.Fields,
 		arg.PublishedAt,
 		arg.UpdatedAt,
 		arg.ID,
@@ -1609,18 +1619,19 @@ func (q *Queries) UpdateMedia(ctx context.Context, arg UpdateMediaParams) (CoreM
 
 const upsertAutosave = `-- name: UpsertAutosave :one
 INSERT INTO core.content_revisions (
-    id, content_id, kind, author_id, title, content, excerpt, created_at
+    id, content_id, kind, author_id, title, content, excerpt, fields, created_at
 )
 VALUES (
-    $1, $2, 'autosave', $3, $4, $5, $6, $7
+    $1, $2, 'autosave', $3, $4, $5, $6, $7, $8
 )
 ON CONFLICT (content_id, author_id) WHERE kind = 'autosave'
 DO UPDATE SET
     title = EXCLUDED.title,
     content = EXCLUDED.content,
     excerpt = EXCLUDED.excerpt,
+    fields = EXCLUDED.fields,
     created_at = EXCLUDED.created_at
-RETURNING id, content_id, kind, author_id, title, content, excerpt, created_at
+RETURNING id, content_id, kind, author_id, title, content, excerpt, fields, created_at
 `
 
 type UpsertAutosaveParams struct {
@@ -1630,6 +1641,7 @@ type UpsertAutosaveParams struct {
 	Title     string
 	Content   string
 	Excerpt   string
+	Fields    content.Values
 	CreatedAt time.Time
 }
 
@@ -1641,6 +1653,7 @@ type UpsertAutosaveRow struct {
 	Title     string
 	Content   string
 	Excerpt   string
+	Fields    content.Values
 	CreatedAt time.Time
 }
 
@@ -1652,6 +1665,7 @@ func (q *Queries) UpsertAutosave(ctx context.Context, arg UpsertAutosaveParams) 
 		arg.Title,
 		arg.Content,
 		arg.Excerpt,
+		arg.Fields,
 		arg.CreatedAt,
 	)
 	var i UpsertAutosaveRow
@@ -1663,6 +1677,7 @@ func (q *Queries) UpsertAutosave(ctx context.Context, arg UpsertAutosaveParams) 
 		&i.Title,
 		&i.Content,
 		&i.Excerpt,
+		&i.Fields,
 		&i.CreatedAt,
 	)
 	return i, err

--- a/internal/postgres/db/queries.sql.go
+++ b/internal/postgres/db/queries.sql.go
@@ -14,6 +14,31 @@ import (
 	"github.com/gopherium/gophenberg/internal/media"
 )
 
+const addRelation = `-- name: AddRelation :exec
+INSERT INTO core.content_relations (from_id, field_id, to_id, position, sort_at, visible)
+SELECT $1, $2, $3, $4, coalesce(c.published_at, c.created_at),
+    c.status = 'published'
+FROM core.content c
+WHERE c.id = $1
+`
+
+type AddRelationParams struct {
+	FromID   uuid.UUID
+	FieldID  int32
+	ToID     uuid.UUID
+	Position int32
+}
+
+func (q *Queries) AddRelation(ctx context.Context, arg AddRelationParams) error {
+	_, err := q.db.Exec(ctx, addRelation,
+		arg.FromID,
+		arg.FieldID,
+		arg.ToID,
+		arg.Position,
+	)
+	return err
+}
+
 const clearContentFieldValues = `-- name: ClearContentFieldValues :exec
 UPDATE core.content SET fields = fields - $1::text WHERE type = $2
 `
@@ -25,6 +50,20 @@ type ClearContentFieldValuesParams struct {
 
 func (q *Queries) ClearContentFieldValues(ctx context.Context, arg ClearContentFieldValuesParams) error {
 	_, err := q.db.Exec(ctx, clearContentFieldValues, arg.Key, arg.Type)
+	return err
+}
+
+const clearRelationsOfField = `-- name: ClearRelationsOfField :exec
+DELETE FROM core.content_relations WHERE from_id = $1 AND field_id = $2
+`
+
+type ClearRelationsOfFieldParams struct {
+	FromID  uuid.UUID
+	FieldID int32
+}
+
+func (q *Queries) ClearRelationsOfField(ctx context.Context, arg ClearRelationsOfFieldParams) error {
+	_, err := q.db.Exec(ctx, clearRelationsOfField, arg.FromID, arg.FieldID)
 	return err
 }
 
@@ -1027,6 +1066,77 @@ func (q *Queries) ListMedia(ctx context.Context, arg ListMediaParams) ([]CoreMed
 	return items, nil
 }
 
+const listRelationFieldsOfType = `-- name: ListRelationFieldsOfType :many
+SELECT id, key, relates_to, many FROM core.content_fields
+WHERE type_key = $1 AND kind = 'relation'
+ORDER BY id
+`
+
+type ListRelationFieldsOfTypeRow struct {
+	ID        int32
+	Key       string
+	RelatesTo *string
+	Many      bool
+}
+
+func (q *Queries) ListRelationFieldsOfType(ctx context.Context, typeKey string) ([]ListRelationFieldsOfTypeRow, error) {
+	rows, err := q.db.Query(ctx, listRelationFieldsOfType, typeKey)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListRelationFieldsOfTypeRow
+	for rows.Next() {
+		var i ListRelationFieldsOfTypeRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Key,
+			&i.RelatesTo,
+			&i.Many,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listRelationTargets = `-- name: ListRelationTargets :many
+SELECT f.key, r.to_id
+FROM core.content_relations r
+JOIN core.content_fields f ON f.id = r.field_id
+WHERE r.from_id = $1
+ORDER BY f.key, r.position
+`
+
+type ListRelationTargetsRow struct {
+	Key  string
+	ToID uuid.UUID
+}
+
+func (q *Queries) ListRelationTargets(ctx context.Context, fromID uuid.UUID) ([]ListRelationTargetsRow, error) {
+	rows, err := q.db.Query(ctx, listRelationTargets, fromID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListRelationTargetsRow
+	for rows.Next() {
+		var i ListRelationTargetsRow
+		if err := rows.Scan(&i.Key, &i.ToID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRevisions = `-- name: ListRevisions :many
 SELECT r.id, r.content_id, r.kind, r.author_id, r.title, r.excerpt, r.created_at
 FROM core.content_revisions r
@@ -1231,6 +1341,18 @@ func (q *Queries) PruneRevisions(ctx context.Context, arg PruneRevisionsParams) 
 	return err
 }
 
+const refreshRelationVisibility = `-- name: RefreshRelationVisibility :exec
+UPDATE core.content_relations r
+SET sort_at = coalesce(c.published_at, c.created_at), visible = (c.status = 'published')
+FROM core.content c
+WHERE r.from_id = c.id AND c.id = $1
+`
+
+func (q *Queries) RefreshRelationVisibility(ctx context.Context, id uuid.UUID) error {
+	_, err := q.db.Exec(ctx, refreshRelationVisibility, id)
+	return err
+}
+
 const restoreContent = `-- name: RestoreContent :one
 UPDATE core.content AS p
 SET status = 'draft',
@@ -1410,6 +1532,35 @@ func (q *Queries) TrashContent(ctx context.Context, arg TrashContentParams) (Cor
 		&i.Fields,
 	)
 	return i, err
+}
+
+const typesOfContent = `-- name: TypesOfContent :many
+SELECT id, type FROM core.content WHERE id = ANY($1::uuid[])
+`
+
+type TypesOfContentRow struct {
+	ID   uuid.UUID
+	Type string
+}
+
+func (q *Queries) TypesOfContent(ctx context.Context, ids []uuid.UUID) ([]TypesOfContentRow, error) {
+	rows, err := q.db.Query(ctx, typesOfContent, ids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []TypesOfContentRow
+	for rows.Next() {
+		var i TypesOfContentRow
+		if err := rows.Scan(&i.ID, &i.Type); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const updateContent = `-- name: UpdateContent :one

--- a/internal/postgres/db/queries.sql.go
+++ b/internal/postgres/db/queries.sql.go
@@ -1344,38 +1344,6 @@ func (q *Queries) LockContent(ctx context.Context, id uuid.UUID) (CoreContent, e
 	return i, err
 }
 
-const lockContentHoldingField = `-- name: LockContentHoldingField :many
-SELECT id FROM core.content
-WHERE type = $1 AND fields ? $2::text
-ORDER BY id
-FOR UPDATE
-`
-
-type LockContentHoldingFieldParams struct {
-	Type string
-	Key  string
-}
-
-func (q *Queries) LockContentHoldingField(ctx context.Context, arg LockContentHoldingFieldParams) ([]uuid.UUID, error) {
-	rows, err := q.db.Query(ctx, lockContentHoldingField, arg.Type, arg.Key)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []uuid.UUID
-	for rows.Next() {
-		var id uuid.UUID
-		if err := rows.Scan(&id); err != nil {
-			return nil, err
-		}
-		items = append(items, id)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const lockContentType = `-- name: LockContentType :one
 SELECT t.key, t.singular_label, t.plural_label, t.route_word, t.hierarchical, t.revisions,
     t.revision_cap, t.page_kind, t.is_default, t.active, t.created_at, t.updated_at
@@ -1430,6 +1398,31 @@ func (q *Queries) LockDefaultContentType(ctx context.Context) (CoreContentType, 
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const lockFieldKeysOfType = `-- name: LockFieldKeysOfType :many
+SELECT key FROM core.content_fields WHERE type_key = $1 ORDER BY key
+FOR KEY SHARE
+`
+
+func (q *Queries) LockFieldKeysOfType(ctx context.Context, typeKey string) ([]string, error) {
+	rows, err := q.db.Query(ctx, lockFieldKeysOfType, typeKey)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, err
+		}
+		items = append(items, key)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const moveDescendants = `-- name: MoveDescendants :exec

--- a/internal/postgres/db/queries.sql.go
+++ b/internal/postgres/db/queries.sql.go
@@ -13,6 +13,37 @@ import (
 	"github.com/gopherium/gophenberg/internal/media"
 )
 
+const clearContentFieldValues = `-- name: ClearContentFieldValues :exec
+UPDATE core.content SET fields = fields - $1::text WHERE type = $2
+`
+
+type ClearContentFieldValuesParams struct {
+	Key  string
+	Type string
+}
+
+func (q *Queries) ClearContentFieldValues(ctx context.Context, arg ClearContentFieldValuesParams) error {
+	_, err := q.db.Exec(ctx, clearContentFieldValues, arg.Key, arg.Type)
+	return err
+}
+
+const clearRevisionFieldValues = `-- name: ClearRevisionFieldValues :exec
+UPDATE core.content_revisions r
+SET fields = r.fields - $1::text
+FROM core.content c
+WHERE r.content_id = c.id AND c.type = $2
+`
+
+type ClearRevisionFieldValuesParams struct {
+	Key  string
+	Type string
+}
+
+func (q *Queries) ClearRevisionFieldValues(ctx context.Context, arg ClearRevisionFieldValuesParams) error {
+	_, err := q.db.Exec(ctx, clearRevisionFieldValues, arg.Key, arg.Type)
+	return err
+}
+
 const contentDepth = `-- name: ContentDepth :one
 WITH RECURSIVE below AS (
     SELECT c.id, 0 AS level
@@ -143,7 +174,7 @@ VALUES (
     $8, $9, $10, $11, $12, $13
 )
 RETURNING id, type, status, slug, title, content, excerpt,
-    author_id, published_at, created_at, updated_at, parent_id, path
+    author_id, published_at, created_at, updated_at, parent_id, path, fields
 `
 
 type CreateContentParams struct {
@@ -194,6 +225,57 @@ func (q *Queries) CreateContent(ctx context.Context, arg CreateContentParams) (C
 		&i.UpdatedAt,
 		&i.ParentID,
 		&i.Path,
+		&i.Fields,
+	)
+	return i, err
+}
+
+const createContentField = `-- name: CreateContentField :one
+INSERT INTO core.content_fields (
+    type_key, key, label, kind, relates_to, many, required, created_at, updated_at
+)
+VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9
+)
+RETURNING id, type_key, key, label, kind, relates_to, many, required, created_at, updated_at
+`
+
+type CreateContentFieldParams struct {
+	TypeKey   string
+	Key       string
+	Label     string
+	Kind      string
+	RelatesTo *string
+	Many      bool
+	Required  bool
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+func (q *Queries) CreateContentField(ctx context.Context, arg CreateContentFieldParams) (CoreContentField, error) {
+	row := q.db.QueryRow(ctx, createContentField,
+		arg.TypeKey,
+		arg.Key,
+		arg.Label,
+		arg.Kind,
+		arg.RelatesTo,
+		arg.Many,
+		arg.Required,
+		arg.CreatedAt,
+		arg.UpdatedAt,
+	)
+	var i CoreContentField
+	err := row.Scan(
+		&i.ID,
+		&i.TypeKey,
+		&i.Key,
+		&i.Label,
+		&i.Kind,
+		&i.RelatesTo,
+		&i.Many,
+		&i.Required,
+		&i.CreatedAt,
+		&i.UpdatedAt,
 	)
 	return i, err
 }
@@ -388,6 +470,23 @@ func (q *Queries) DeleteContent(ctx context.Context, id uuid.UUID) (int64, error
 	return result.RowsAffected(), nil
 }
 
+const deleteContentField = `-- name: DeleteContentField :execrows
+DELETE FROM core.content_fields WHERE type_key = $1 AND key = $2
+`
+
+type DeleteContentFieldParams struct {
+	TypeKey string
+	Key     string
+}
+
+func (q *Queries) DeleteContentField(ctx context.Context, arg DeleteContentFieldParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteContentField, arg.TypeKey, arg.Key)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const deleteContentType = `-- name: DeleteContentType :execrows
 DELETE FROM core.content_types AS t WHERE t.key = $1
 `
@@ -459,9 +558,20 @@ type GetAutosaveParams struct {
 	AuthorID  uuid.UUID
 }
 
-func (q *Queries) GetAutosave(ctx context.Context, arg GetAutosaveParams) (CoreContentRevision, error) {
+type GetAutosaveRow struct {
+	ID        uuid.UUID
+	ContentID uuid.UUID
+	Kind      string
+	AuthorID  uuid.UUID
+	Title     string
+	Content   string
+	Excerpt   string
+	CreatedAt time.Time
+}
+
+func (q *Queries) GetAutosave(ctx context.Context, arg GetAutosaveParams) (GetAutosaveRow, error) {
 	row := q.db.QueryRow(ctx, getAutosave, arg.ContentID, arg.AuthorID)
-	var i CoreContentRevision
+	var i GetAutosaveRow
 	err := row.Scan(
 		&i.ID,
 		&i.ContentID,
@@ -477,7 +587,7 @@ func (q *Queries) GetAutosave(ctx context.Context, arg GetAutosaveParams) (CoreC
 
 const getContent = `-- name: GetContent :one
 SELECT p.id, p.type, p.status, p.slug, p.title, p.content, p.excerpt,
-    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields
 FROM core.content p
 WHERE p.id = $1
 `
@@ -499,6 +609,7 @@ func (q *Queries) GetContent(ctx context.Context, id uuid.UUID) (CoreContent, er
 		&i.UpdatedAt,
 		&i.ParentID,
 		&i.Path,
+		&i.Fields,
 	)
 	return i, err
 }
@@ -562,7 +673,7 @@ func (q *Queries) GetMedia(ctx context.Context, id int64) (CoreMedia, error) {
 
 const getPublishedContentByPath = `-- name: GetPublishedContentByPath :one
 SELECT p.id, p.type, p.status, p.slug, p.title, p.content, p.excerpt,
-    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields
 FROM core.content p
 WHERE p.path = $1 AND p.status = 'published'
 `
@@ -584,6 +695,7 @@ func (q *Queries) GetPublishedContentByPath(ctx context.Context, path string) (C
 		&i.UpdatedAt,
 		&i.ParentID,
 		&i.Path,
+		&i.Fields,
 	)
 	return i, err
 }
@@ -599,9 +711,20 @@ type GetRevisionParams struct {
 	ID        uuid.UUID
 }
 
-func (q *Queries) GetRevision(ctx context.Context, arg GetRevisionParams) (CoreContentRevision, error) {
+type GetRevisionRow struct {
+	ID        uuid.UUID
+	ContentID uuid.UUID
+	Kind      string
+	AuthorID  uuid.UUID
+	Title     string
+	Content   string
+	Excerpt   string
+	CreatedAt time.Time
+}
+
+func (q *Queries) GetRevision(ctx context.Context, arg GetRevisionParams) (GetRevisionRow, error) {
 	row := q.db.QueryRow(ctx, getRevision, arg.ContentID, arg.ID)
-	var i CoreContentRevision
+	var i GetRevisionRow
 	err := row.Scan(
 		&i.ID,
 		&i.ContentID,
@@ -628,7 +751,7 @@ func (q *Queries) GetSetting(ctx context.Context, key string) (string, error) {
 
 const listContent = `-- name: ListContent :many
 SELECT p.id, p.type, p.status, p.slug, p.title, p.excerpt,
-    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields
 FROM core.content p
 WHERE p.type = $1
     AND ($2::text = '' OR p.status = $2)
@@ -671,6 +794,7 @@ type ListContentRow struct {
 	UpdatedAt   time.Time
 	ParentID    *uuid.UUID
 	Path        string
+	Fields      []byte
 }
 
 func (q *Queries) ListContent(ctx context.Context, arg ListContentParams) ([]ListContentRow, error) {
@@ -703,6 +827,77 @@ func (q *Queries) ListContent(ctx context.Context, arg ListContentParams) ([]Lis
 			&i.UpdatedAt,
 			&i.ParentID,
 			&i.Path,
+			&i.Fields,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listContentFields = `-- name: ListContentFields :many
+SELECT id, type_key, key, label, kind, relates_to, many, required, created_at, updated_at FROM core.content_fields ORDER BY id
+`
+
+func (q *Queries) ListContentFields(ctx context.Context) ([]CoreContentField, error) {
+	rows, err := q.db.Query(ctx, listContentFields)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []CoreContentField
+	for rows.Next() {
+		var i CoreContentField
+		if err := rows.Scan(
+			&i.ID,
+			&i.TypeKey,
+			&i.Key,
+			&i.Label,
+			&i.Kind,
+			&i.RelatesTo,
+			&i.Many,
+			&i.Required,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listContentFieldsOfType = `-- name: ListContentFieldsOfType :many
+SELECT id, type_key, key, label, kind, relates_to, many, required, created_at, updated_at FROM core.content_fields WHERE type_key = $1 ORDER BY id
+`
+
+func (q *Queries) ListContentFieldsOfType(ctx context.Context, typeKey string) ([]CoreContentField, error) {
+	rows, err := q.db.Query(ctx, listContentFieldsOfType, typeKey)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []CoreContentField
+	for rows.Next() {
+		var i CoreContentField
+		if err := rows.Scan(
+			&i.ID,
+			&i.TypeKey,
+			&i.Key,
+			&i.Label,
+			&i.Kind,
+			&i.RelatesTo,
+			&i.Many,
+			&i.Required,
+			&i.CreatedAt,
+			&i.UpdatedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -872,7 +1067,7 @@ func (q *Queries) ListRevisions(ctx context.Context, contentID uuid.UUID) ([]Lis
 
 const lockContent = `-- name: LockContent :one
 SELECT p.id, p.type, p.status, p.slug, p.title, p.content, p.excerpt,
-    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields
 FROM core.content p
 WHERE p.id = $1
 FOR UPDATE
@@ -895,8 +1090,34 @@ func (q *Queries) LockContent(ctx context.Context, id uuid.UUID) (CoreContent, e
 		&i.UpdatedAt,
 		&i.ParentID,
 		&i.Path,
+		&i.Fields,
 	)
 	return i, err
+}
+
+const lockContentOfType = `-- name: LockContentOfType :many
+SELECT id FROM core.content WHERE type = $1 ORDER BY id
+FOR UPDATE
+`
+
+func (q *Queries) LockContentOfType(ctx context.Context, type_ string) ([]uuid.UUID, error) {
+	rows, err := q.db.Query(ctx, lockContentOfType, type_)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const lockContentType = `-- name: LockContentType :one
@@ -1011,7 +1232,7 @@ SET status = 'draft',
     updated_at = $1
 WHERE p.id = $2
 RETURNING p.id, p.type, p.status, p.slug, p.title, p.content, p.excerpt,
-    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields
 `
 
 type RestoreContentParams struct {
@@ -1036,6 +1257,7 @@ func (q *Queries) RestoreContent(ctx context.Context, arg RestoreContentParams) 
 		&i.UpdatedAt,
 		&i.ParentID,
 		&i.Path,
+		&i.Fields,
 	)
 	return i, err
 }
@@ -1045,7 +1267,7 @@ UPDATE core.content AS p
 SET status = 'draft', updated_at = $1
 WHERE p.id = $2
 RETURNING p.id, p.type, p.status, p.slug, p.title, p.content, p.excerpt,
-    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields
 `
 
 type RestoreContentKeepingSlugParams struct {
@@ -1070,6 +1292,7 @@ func (q *Queries) RestoreContentKeepingSlug(ctx context.Context, arg RestoreCont
 		&i.UpdatedAt,
 		&i.ParentID,
 		&i.Path,
+		&i.Fields,
 	)
 	return i, err
 }
@@ -1151,7 +1374,7 @@ SET status = 'trash', slug = p.slug || $1::text, path = p.path || $1::text,
     updated_at = $2
 WHERE p.id = $3
 RETURNING p.id, p.type, p.status, p.slug, p.title, p.content, p.excerpt,
-    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields
 `
 
 type TrashContentParams struct {
@@ -1177,6 +1400,7 @@ func (q *Queries) TrashContent(ctx context.Context, arg TrashContentParams) (Cor
 		&i.UpdatedAt,
 		&i.ParentID,
 		&i.Path,
+		&i.Fields,
 	)
 	return i, err
 }
@@ -1187,7 +1411,7 @@ SET status = $1, slug = $2, path = $3, parent_id = $4, title = $5,
     content = $6, excerpt = $7, published_at = $8, updated_at = $9
 WHERE p.id = $10 AND p.updated_at = $11
 RETURNING p.id, p.type, p.status, p.slug, p.title, p.content, p.excerpt,
-    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields
 `
 
 type UpdateContentParams struct {
@@ -1233,6 +1457,46 @@ func (q *Queries) UpdateContent(ctx context.Context, arg UpdateContentParams) (C
 		&i.UpdatedAt,
 		&i.ParentID,
 		&i.Path,
+		&i.Fields,
+	)
+	return i, err
+}
+
+const updateContentField = `-- name: UpdateContentField :one
+UPDATE core.content_fields
+SET label = $1, required = $2, updated_at = $3
+WHERE type_key = $4 AND key = $5
+RETURNING id, type_key, key, label, kind, relates_to, many, required, created_at, updated_at
+`
+
+type UpdateContentFieldParams struct {
+	Label     string
+	Required  bool
+	UpdatedAt time.Time
+	TypeKey   string
+	Key       string
+}
+
+func (q *Queries) UpdateContentField(ctx context.Context, arg UpdateContentFieldParams) (CoreContentField, error) {
+	row := q.db.QueryRow(ctx, updateContentField,
+		arg.Label,
+		arg.Required,
+		arg.UpdatedAt,
+		arg.TypeKey,
+		arg.Key,
+	)
+	var i CoreContentField
+	err := row.Scan(
+		&i.ID,
+		&i.TypeKey,
+		&i.Key,
+		&i.Label,
+		&i.Kind,
+		&i.RelatesTo,
+		&i.Many,
+		&i.Required,
+		&i.CreatedAt,
+		&i.UpdatedAt,
 	)
 	return i, err
 }
@@ -1369,7 +1633,18 @@ type UpsertAutosaveParams struct {
 	CreatedAt time.Time
 }
 
-func (q *Queries) UpsertAutosave(ctx context.Context, arg UpsertAutosaveParams) (CoreContentRevision, error) {
+type UpsertAutosaveRow struct {
+	ID        uuid.UUID
+	ContentID uuid.UUID
+	Kind      string
+	AuthorID  uuid.UUID
+	Title     string
+	Content   string
+	Excerpt   string
+	CreatedAt time.Time
+}
+
+func (q *Queries) UpsertAutosave(ctx context.Context, arg UpsertAutosaveParams) (UpsertAutosaveRow, error) {
 	row := q.db.QueryRow(ctx, upsertAutosave,
 		arg.ID,
 		arg.ContentID,
@@ -1379,7 +1654,7 @@ func (q *Queries) UpsertAutosave(ctx context.Context, arg UpsertAutosaveParams) 
 		arg.Excerpt,
 		arg.CreatedAt,
 	)
-	var i CoreContentRevision
+	var i UpsertAutosaveRow
 	err := row.Scan(
 		&i.ID,
 		&i.ContentID,

--- a/internal/postgres/db/queries.sql.go
+++ b/internal/postgres/db/queries.sql.go
@@ -40,7 +40,8 @@ func (q *Queries) AddRelation(ctx context.Context, arg AddRelationParams) error 
 }
 
 const clearContentFieldValues = `-- name: ClearContentFieldValues :exec
-UPDATE core.content SET fields = fields - $1::text WHERE type = $2
+UPDATE core.content SET fields = fields - $1::text
+WHERE type = $2 AND fields ? $1::text
 `
 
 type ClearContentFieldValuesParams struct {
@@ -71,7 +72,7 @@ const clearRevisionFieldValues = `-- name: ClearRevisionFieldValues :exec
 UPDATE core.content_revisions r
 SET fields = r.fields - $1::text
 FROM core.content c
-WHERE r.content_id = c.id AND c.type = $2
+WHERE r.content_id = c.id AND c.type = $2 AND r.fields ? $1::text
 `
 
 type ClearRevisionFieldValuesParams struct {
@@ -901,7 +902,8 @@ func (q *Queries) ListContent(ctx context.Context, arg ListContentParams) ([]Lis
 }
 
 const listContentFields = `-- name: ListContentFields :many
-SELECT id, type_key, key, label, kind, relates_to, many, required, created_at, updated_at FROM core.content_fields ORDER BY id
+SELECT id, type_key, key, label, kind, relates_to, many, required, created_at, updated_at
+FROM core.content_fields ORDER BY id
 `
 
 func (q *Queries) ListContentFields(ctx context.Context) ([]CoreContentField, error) {
@@ -936,7 +938,8 @@ func (q *Queries) ListContentFields(ctx context.Context) ([]CoreContentField, er
 }
 
 const listContentFieldsOfType = `-- name: ListContentFieldsOfType :many
-SELECT id, type_key, key, label, kind, relates_to, many, required, created_at, updated_at FROM core.content_fields WHERE type_key = $1 ORDER BY id
+SELECT id, type_key, key, label, kind, relates_to, many, required, created_at, updated_at
+FROM core.content_fields WHERE type_key = $1 ORDER BY id
 `
 
 func (q *Queries) ListContentFieldsOfType(ctx context.Context, typeKey string) ([]CoreContentField, error) {
@@ -1341,13 +1344,20 @@ func (q *Queries) LockContent(ctx context.Context, id uuid.UUID) (CoreContent, e
 	return i, err
 }
 
-const lockContentOfType = `-- name: LockContentOfType :many
-SELECT id FROM core.content WHERE type = $1 ORDER BY id
+const lockContentHoldingField = `-- name: LockContentHoldingField :many
+SELECT id FROM core.content
+WHERE type = $1 AND fields ? $2::text
+ORDER BY id
 FOR UPDATE
 `
 
-func (q *Queries) LockContentOfType(ctx context.Context, type_ string) ([]uuid.UUID, error) {
-	rows, err := q.db.Query(ctx, lockContentOfType, type_)
+type LockContentHoldingFieldParams struct {
+	Type string
+	Key  string
+}
+
+func (q *Queries) LockContentHoldingField(ctx context.Context, arg LockContentHoldingFieldParams) ([]uuid.UUID, error) {
+	rows, err := q.db.Query(ctx, lockContentHoldingField, arg.Type, arg.Key)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/postgres/db/queries.sql.go
+++ b/internal/postgres/db/queries.sql.go
@@ -203,6 +203,21 @@ func (q *Queries) CountMedia(ctx context.Context, arg CountMediaParams) (int64, 
 	return count, err
 }
 
+const countRelatedContent = `-- name: CountRelatedContent :one
+SELECT count(DISTINCT r.from_id)
+FROM core.content_relations r
+JOIN core.content c ON c.id = r.from_id
+JOIN core.content_types t ON t.key = c.type
+WHERE r.to_id = $1 AND r.visible AND t.active
+`
+
+func (q *Queries) CountRelatedContent(ctx context.Context, target uuid.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countRelatedContent, target)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createContent = `-- name: CreateContent :one
 
 INSERT INTO core.content (
@@ -1066,6 +1081,78 @@ func (q *Queries) ListMedia(ctx context.Context, arg ListMediaParams) ([]CoreMed
 	return items, nil
 }
 
+const listRelatedContent = `-- name: ListRelatedContent :many
+SELECT c.id, c.type, c.status, c.slug, c.title, c.excerpt,
+    c.author_id, c.published_at, c.created_at, c.updated_at, c.parent_id, c.path, c.fields
+FROM (
+    SELECT DISTINCT r.sort_at, r.from_id
+    FROM core.content_relations r
+    JOIN core.content pointing ON pointing.id = r.from_id
+    JOIN core.content_types pointer ON pointer.key = pointing.type
+    WHERE r.to_id = $1 AND r.visible AND pointer.active
+    ORDER BY r.sort_at DESC, r.from_id
+    LIMIT $3 OFFSET $2
+) held
+JOIN core.content c ON c.id = held.from_id
+ORDER BY held.sort_at DESC, held.from_id
+`
+
+type ListRelatedContentParams struct {
+	Target    uuid.UUID
+	RowOffset int32
+	RowLimit  int32
+}
+
+type ListRelatedContentRow struct {
+	ID          uuid.UUID
+	Type        string
+	Status      string
+	Slug        string
+	Title       string
+	Excerpt     string
+	AuthorID    uuid.UUID
+	PublishedAt *time.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	ParentID    *uuid.UUID
+	Path        string
+	Fields      content.Values
+}
+
+func (q *Queries) ListRelatedContent(ctx context.Context, arg ListRelatedContentParams) ([]ListRelatedContentRow, error) {
+	rows, err := q.db.Query(ctx, listRelatedContent, arg.Target, arg.RowOffset, arg.RowLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListRelatedContentRow
+	for rows.Next() {
+		var i ListRelatedContentRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Type,
+			&i.Status,
+			&i.Slug,
+			&i.Title,
+			&i.Excerpt,
+			&i.AuthorID,
+			&i.PublishedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.ParentID,
+			&i.Path,
+			&i.Fields,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRelationFieldsOfType = `-- name: ListRelationFieldsOfType :many
 SELECT id, key, relates_to, many FROM core.content_fields
 WHERE type_key = $1 AND kind = 'relation'
@@ -1093,6 +1180,48 @@ func (q *Queries) ListRelationFieldsOfType(ctx context.Context, typeKey string) 
 			&i.Key,
 			&i.RelatesTo,
 			&i.Many,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listRelationSummaries = `-- name: ListRelationSummaries :many
+SELECT f.key, c.id, c.title, c.path
+FROM core.content_relations r
+JOIN core.content_fields f ON f.id = r.field_id
+JOIN core.content c ON c.id = r.to_id
+JOIN core.content_types t ON t.key = c.type
+WHERE r.from_id = $1 AND c.status = 'published' AND t.active
+ORDER BY f.key, r.position
+`
+
+type ListRelationSummariesRow struct {
+	Key   string
+	ID    uuid.UUID
+	Title string
+	Path  string
+}
+
+func (q *Queries) ListRelationSummaries(ctx context.Context, fromID uuid.UUID) ([]ListRelationSummariesRow, error) {
+	rows, err := q.db.Query(ctx, listRelationSummaries, fromID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListRelationSummariesRow
+	for rows.Next() {
+		var i ListRelationSummariesRow
+		if err := rows.Scan(
+			&i.Key,
+			&i.ID,
+			&i.Title,
+			&i.Path,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/postgres/migrations/00009_create_content_fields.sql
+++ b/internal/postgres/migrations/00009_create_content_fields.sql
@@ -7,7 +7,7 @@ CREATE TABLE core.content_fields (
     key text NOT NULL,
     label text NOT NULL,
     kind text NOT NULL CHECK (kind IN ('text', 'number', 'boolean', 'date', 'media', 'relation')),
-    relates_to text REFERENCES core.content_types (key),
+    relates_to text CONSTRAINT content_fields_relates_to_fkey REFERENCES core.content_types (key),
     many boolean NOT NULL DEFAULT false,
     required boolean NOT NULL DEFAULT false,
     created_at timestamptz NOT NULL,

--- a/internal/postgres/migrations/00009_create_content_fields.sql
+++ b/internal/postgres/migrations/00009_create_content_fields.sql
@@ -1,0 +1,29 @@
+-- SPDX-License-Identifier: Apache-2.0
+
+-- +goose Up
+CREATE TABLE core.content_fields (
+    id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    type_key text NOT NULL REFERENCES core.content_types (key) ON DELETE CASCADE,
+    key text NOT NULL,
+    label text NOT NULL,
+    kind text NOT NULL CHECK (kind IN ('text', 'number', 'boolean', 'date', 'media', 'relation')),
+    relates_to text REFERENCES core.content_types (key),
+    many boolean NOT NULL DEFAULT false,
+    required boolean NOT NULL DEFAULT false,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT content_fields_key_unique UNIQUE (type_key, key),
+    CONSTRAINT content_fields_relation_target CHECK ((kind = 'relation') = (relates_to IS NOT NULL)),
+    CONSTRAINT content_fields_many_relational CHECK (many = false OR kind = 'relation')
+);
+
+ALTER TABLE core.content ADD COLUMN fields jsonb NOT NULL DEFAULT '{}';
+
+ALTER TABLE core.content_revisions ADD COLUMN fields jsonb NOT NULL DEFAULT '{}';
+
+-- +goose Down
+ALTER TABLE core.content_revisions DROP COLUMN fields;
+
+ALTER TABLE core.content DROP COLUMN fields;
+
+DROP TABLE core.content_fields;

--- a/internal/postgres/migrations/00010_create_content_relations.sql
+++ b/internal/postgres/migrations/00010_create_content_relations.sql
@@ -14,7 +14,5 @@ CREATE TABLE core.content_relations (
 CREATE INDEX content_relations_target_idx ON core.content_relations (to_id, sort_at DESC, from_id)
     WHERE visible;
 
-CREATE INDEX content_relations_source_idx ON core.content_relations (from_id, field_id);
-
 -- +goose Down
 DROP TABLE core.content_relations;

--- a/internal/postgres/migrations/00010_create_content_relations.sql
+++ b/internal/postgres/migrations/00010_create_content_relations.sql
@@ -1,0 +1,20 @@
+-- SPDX-License-Identifier: Apache-2.0
+
+-- +goose Up
+CREATE TABLE core.content_relations (
+    from_id uuid NOT NULL REFERENCES core.content (id) ON DELETE CASCADE,
+    field_id integer NOT NULL REFERENCES core.content_fields (id) ON DELETE CASCADE,
+    to_id uuid NOT NULL REFERENCES core.content (id) ON DELETE CASCADE,
+    position integer NOT NULL DEFAULT 1,
+    sort_at timestamptz NOT NULL,
+    visible boolean NOT NULL DEFAULT false,
+    CONSTRAINT content_relations_pkey PRIMARY KEY (from_id, field_id, to_id)
+);
+
+CREATE INDEX content_relations_target_idx ON core.content_relations (to_id, sort_at DESC, from_id)
+    WHERE visible;
+
+CREATE INDEX content_relations_source_idx ON core.content_relations (from_id, field_id);
+
+-- +goose Down
+DROP TABLE core.content_relations;

--- a/internal/postgres/queries.sql
+++ b/internal/postgres/queries.sql
@@ -339,10 +339,12 @@ WHERE t.is_default
 FOR UPDATE;
 
 -- name: ListContentFields :many
-SELECT * FROM core.content_fields ORDER BY id;
+SELECT id, type_key, key, label, kind, relates_to, many, required, created_at, updated_at
+FROM core.content_fields ORDER BY id;
 
 -- name: ListContentFieldsOfType :many
-SELECT * FROM core.content_fields WHERE type_key = @type_key ORDER BY id;
+SELECT id, type_key, key, label, kind, relates_to, many, required, created_at, updated_at
+FROM core.content_fields WHERE type_key = @type_key ORDER BY id;
 
 -- name: CreateContentField :one
 INSERT INTO core.content_fields (
@@ -351,29 +353,32 @@ INSERT INTO core.content_fields (
 VALUES (
     @type_key, @key, @label, @kind, @relates_to, @many, @required, @created_at, @updated_at
 )
-RETURNING *;
+RETURNING id, type_key, key, label, kind, relates_to, many, required, created_at, updated_at;
 
 -- name: UpdateContentField :one
 UPDATE core.content_fields
 SET label = @label, required = @required, updated_at = @updated_at
 WHERE type_key = @type_key AND key = @key
-RETURNING *;
+RETURNING id, type_key, key, label, kind, relates_to, many, required, created_at, updated_at;
 
 -- name: DeleteContentField :execrows
 DELETE FROM core.content_fields WHERE type_key = @type_key AND key = @key;
 
--- name: LockContentOfType :many
-SELECT id FROM core.content WHERE type = @type ORDER BY id
+-- name: LockContentHoldingField :many
+SELECT id FROM core.content
+WHERE type = @type AND fields ? @key::text
+ORDER BY id
 FOR UPDATE;
 
 -- name: ClearContentFieldValues :exec
-UPDATE core.content SET fields = fields - @key::text WHERE type = @type;
+UPDATE core.content SET fields = fields - @key::text
+WHERE type = @type AND fields ? @key::text;
 
 -- name: ClearRevisionFieldValues :exec
 UPDATE core.content_revisions r
 SET fields = r.fields - @key::text
 FROM core.content c
-WHERE r.content_id = c.id AND c.type = @type;
+WHERE r.content_id = c.id AND c.type = @type AND r.fields ? @key::text;
 
 -- name: ListRelationFieldsOfType :many
 SELECT id, key, relates_to, many FROM core.content_fields

--- a/internal/postgres/queries.sql
+++ b/internal/postgres/queries.sql
@@ -59,7 +59,8 @@ WHERE p.type = @type
 -- name: UpdateContent :one
 UPDATE core.content AS p
 SET status = @status, slug = @slug, path = @path, parent_id = @parent_id, title = @title,
-    content = @content, excerpt = @excerpt, published_at = @published_at, updated_at = @updated_at
+    content = @content, excerpt = @excerpt, fields = @fields, published_at = @published_at,
+    updated_at = @updated_at
 WHERE p.id = @id AND p.updated_at = @expected_updated_at
 RETURNING p.id, p.type, p.status, p.slug, p.title, p.content, p.excerpt,
     p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields;
@@ -127,10 +128,10 @@ GROUP BY p.status;
 
 -- name: CreateRevision :exec
 INSERT INTO core.content_revisions (
-    id, content_id, kind, author_id, title, content, excerpt, created_at
+    id, content_id, kind, author_id, title, content, excerpt, fields, created_at
 )
 VALUES (
-    @id, @content_id, @kind, @author_id, @title, @content, @excerpt, @created_at
+    @id, @content_id, @kind, @author_id, @title, @content, @excerpt, @fields, @created_at
 );
 
 -- name: ListRevisions :many
@@ -140,7 +141,7 @@ WHERE r.content_id = @content_id
 ORDER BY r.created_at DESC, r.id DESC;
 
 -- name: GetRevision :one
-SELECT r.id, r.content_id, r.kind, r.author_id, r.title, r.content, r.excerpt, r.created_at
+SELECT r.id, r.content_id, r.kind, r.author_id, r.title, r.content, r.excerpt, r.fields, r.created_at
 FROM core.content_revisions r
 WHERE r.content_id = @content_id AND r.id = @id;
 
@@ -160,21 +161,22 @@ WHERE r.id IN (
 
 -- name: UpsertAutosave :one
 INSERT INTO core.content_revisions (
-    id, content_id, kind, author_id, title, content, excerpt, created_at
+    id, content_id, kind, author_id, title, content, excerpt, fields, created_at
 )
 VALUES (
-    @id, @content_id, 'autosave', @author_id, @title, @content, @excerpt, @created_at
+    @id, @content_id, 'autosave', @author_id, @title, @content, @excerpt, @fields, @created_at
 )
 ON CONFLICT (content_id, author_id) WHERE kind = 'autosave'
 DO UPDATE SET
     title = EXCLUDED.title,
     content = EXCLUDED.content,
     excerpt = EXCLUDED.excerpt,
+    fields = EXCLUDED.fields,
     created_at = EXCLUDED.created_at
-RETURNING id, content_id, kind, author_id, title, content, excerpt, created_at;
+RETURNING id, content_id, kind, author_id, title, content, excerpt, fields, created_at;
 
 -- name: GetAutosave :one
-SELECT r.id, r.content_id, r.kind, r.author_id, r.title, r.content, r.excerpt, r.created_at
+SELECT r.id, r.content_id, r.kind, r.author_id, r.title, r.content, r.excerpt, r.fields, r.created_at
 FROM core.content_revisions r
 WHERE r.content_id = @content_id AND r.author_id = @author_id AND r.kind = 'autosave';
 

--- a/internal/postgres/queries.sql
+++ b/internal/postgres/queries.sql
@@ -405,3 +405,34 @@ UPDATE core.content_relations r
 SET sort_at = coalesce(c.published_at, c.created_at), visible = (c.status = 'published')
 FROM core.content c
 WHERE r.from_id = c.id AND c.id = @id;
+
+-- name: ListRelatedContent :many
+SELECT c.id, c.type, c.status, c.slug, c.title, c.excerpt,
+    c.author_id, c.published_at, c.created_at, c.updated_at, c.parent_id, c.path, c.fields
+FROM (
+    SELECT DISTINCT r.sort_at, r.from_id
+    FROM core.content_relations r
+    JOIN core.content pointing ON pointing.id = r.from_id
+    JOIN core.content_types pointer ON pointer.key = pointing.type
+    WHERE r.to_id = @target AND r.visible AND pointer.active
+    ORDER BY r.sort_at DESC, r.from_id
+    LIMIT @row_limit OFFSET @row_offset
+) held
+JOIN core.content c ON c.id = held.from_id
+ORDER BY held.sort_at DESC, held.from_id;
+
+-- name: CountRelatedContent :one
+SELECT count(DISTINCT r.from_id)
+FROM core.content_relations r
+JOIN core.content c ON c.id = r.from_id
+JOIN core.content_types t ON t.key = c.type
+WHERE r.to_id = @target AND r.visible AND t.active;
+
+-- name: ListRelationSummaries :many
+SELECT f.key, c.id, c.title, c.path
+FROM core.content_relations r
+JOIN core.content_fields f ON f.id = r.field_id
+JOIN core.content c ON c.id = r.to_id
+JOIN core.content_types t ON t.key = c.type
+WHERE r.from_id = @from_id AND c.status = 'published' AND t.active
+ORDER BY f.key, r.position;

--- a/internal/postgres/queries.sql
+++ b/internal/postgres/queries.sql
@@ -10,23 +10,23 @@ VALUES (
     @author_id, @published_at, @created_at, @updated_at, @parent_id, @path
 )
 RETURNING id, type, status, slug, title, content, excerpt,
-    author_id, published_at, created_at, updated_at, parent_id, path;
+    author_id, published_at, created_at, updated_at, parent_id, path, fields;
 
 -- name: GetContent :one
 SELECT p.id, p.type, p.status, p.slug, p.title, p.content, p.excerpt,
-    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields
 FROM core.content p
 WHERE p.id = @id;
 
 -- name: GetPublishedContentByPath :one
 SELECT p.id, p.type, p.status, p.slug, p.title, p.content, p.excerpt,
-    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields
 FROM core.content p
 WHERE p.path = @path AND p.status = 'published';
 
 -- name: ListContent :many
 SELECT p.id, p.type, p.status, p.slug, p.title, p.excerpt,
-    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields
 FROM core.content p
 WHERE p.type = @type
     AND (@status::text = '' OR p.status = @status)
@@ -62,7 +62,7 @@ SET status = @status, slug = @slug, path = @path, parent_id = @parent_id, title 
     content = @content, excerpt = @excerpt, published_at = @published_at, updated_at = @updated_at
 WHERE p.id = @id AND p.updated_at = @expected_updated_at
 RETURNING p.id, p.type, p.status, p.slug, p.title, p.content, p.excerpt,
-    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path;
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields;
 
 -- name: MoveDescendants :exec
 WITH RECURSIVE moved AS (
@@ -97,7 +97,7 @@ SET status = 'trash', slug = p.slug || @suffix::text, path = p.path || @suffix::
     updated_at = @updated_at
 WHERE p.id = @id
 RETURNING p.id, p.type, p.status, p.slug, p.title, p.content, p.excerpt,
-    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path;
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields;
 
 -- name: RestoreContent :one
 UPDATE core.content AS p
@@ -107,14 +107,14 @@ SET status = 'draft',
     updated_at = @updated_at
 WHERE p.id = @id
 RETURNING p.id, p.type, p.status, p.slug, p.title, p.content, p.excerpt,
-    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path;
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields;
 
 -- name: RestoreContentKeepingSlug :one
 UPDATE core.content AS p
 SET status = 'draft', updated_at = @updated_at
 WHERE p.id = @id
 RETURNING p.id, p.type, p.status, p.slug, p.title, p.content, p.excerpt,
-    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path;
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields;
 
 -- name: DeleteContent :execrows
 DELETE FROM core.content AS p WHERE p.id = @id;
@@ -309,7 +309,7 @@ SELECT coalesce(max(level), 0)::int FROM below;
 
 -- name: LockContent :one
 SELECT p.id, p.type, p.status, p.slug, p.title, p.content, p.excerpt,
-    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields
 FROM core.content p
 WHERE p.id = @id
 FOR UPDATE;
@@ -335,3 +335,40 @@ SELECT t.key, t.singular_label, t.plural_label, t.route_word, t.hierarchical, t.
 FROM core.content_types t
 WHERE t.is_default
 FOR UPDATE;
+
+-- name: ListContentFields :many
+SELECT * FROM core.content_fields ORDER BY id;
+
+-- name: ListContentFieldsOfType :many
+SELECT * FROM core.content_fields WHERE type_key = @type_key ORDER BY id;
+
+-- name: CreateContentField :one
+INSERT INTO core.content_fields (
+    type_key, key, label, kind, relates_to, many, required, created_at, updated_at
+)
+VALUES (
+    @type_key, @key, @label, @kind, @relates_to, @many, @required, @created_at, @updated_at
+)
+RETURNING *;
+
+-- name: UpdateContentField :one
+UPDATE core.content_fields
+SET label = @label, required = @required, updated_at = @updated_at
+WHERE type_key = @type_key AND key = @key
+RETURNING *;
+
+-- name: DeleteContentField :execrows
+DELETE FROM core.content_fields WHERE type_key = @type_key AND key = @key;
+
+-- name: LockContentOfType :many
+SELECT id FROM core.content WHERE type = @type ORDER BY id
+FOR UPDATE;
+
+-- name: ClearContentFieldValues :exec
+UPDATE core.content SET fields = fields - @key::text WHERE type = @type;
+
+-- name: ClearRevisionFieldValues :exec
+UPDATE core.content_revisions r
+SET fields = r.fields - @key::text
+FROM core.content c
+WHERE r.content_id = c.id AND c.type = @type;

--- a/internal/postgres/queries.sql
+++ b/internal/postgres/queries.sql
@@ -364,11 +364,9 @@ RETURNING id, type_key, key, label, kind, relates_to, many, required, created_at
 -- name: DeleteContentField :execrows
 DELETE FROM core.content_fields WHERE type_key = @type_key AND key = @key;
 
--- name: LockContentHoldingField :many
-SELECT id FROM core.content
-WHERE type = @type AND fields ? @key::text
-ORDER BY id
-FOR UPDATE;
+-- name: LockFieldKeysOfType :many
+SELECT key FROM core.content_fields WHERE type_key = @type_key ORDER BY key
+FOR KEY SHARE;
 
 -- name: ClearContentFieldValues :exec
 UPDATE core.content SET fields = fields - @key::text

--- a/internal/postgres/queries.sql
+++ b/internal/postgres/queries.sql
@@ -374,3 +374,34 @@ UPDATE core.content_revisions r
 SET fields = r.fields - @key::text
 FROM core.content c
 WHERE r.content_id = c.id AND c.type = @type;
+
+-- name: ListRelationFieldsOfType :many
+SELECT id, key, relates_to, many FROM core.content_fields
+WHERE type_key = @type_key AND kind = 'relation'
+ORDER BY id;
+
+-- name: ListRelationTargets :many
+SELECT f.key, r.to_id
+FROM core.content_relations r
+JOIN core.content_fields f ON f.id = r.field_id
+WHERE r.from_id = @from_id
+ORDER BY f.key, r.position;
+
+-- name: TypesOfContent :many
+SELECT id, type FROM core.content WHERE id = ANY(@ids::uuid[]);
+
+-- name: ClearRelationsOfField :exec
+DELETE FROM core.content_relations WHERE from_id = @from_id AND field_id = @field_id;
+
+-- name: AddRelation :exec
+INSERT INTO core.content_relations (from_id, field_id, to_id, position, sort_at, visible)
+SELECT @from_id, @field_id, @to_id, @position, coalesce(c.published_at, c.created_at),
+    c.status = 'published'
+FROM core.content c
+WHERE c.id = @from_id;
+
+-- name: RefreshRelationVisibility :exec
+UPDATE core.content_relations r
+SET sort_at = coalesce(c.published_at, c.created_at), visible = (c.status = 'published')
+FROM core.content c
+WHERE r.from_id = c.id AND c.id = @id;

--- a/internal/postgres/relations.go
+++ b/internal/postgres/relations.go
@@ -86,6 +86,61 @@ func targetsAllowed(
 	return nil
 }
 
+// RelatedTo returns the published content of active types pointing at the target, newest first.
+func (s *ContentStore) RelatedTo(
+	ctx context.Context, target uuid.UUID, page, perPage int,
+) ([]content.Content, int, error) {
+	total, err := s.queries.CountRelatedContent(ctx, target)
+	if err != nil {
+		return nil, 0, fmt.Errorf("postgres: count related content: %w", err)
+	}
+	rows, err := s.queries.ListRelatedContent(ctx, db.ListRelatedContentParams{
+		Target:    target,
+		RowLimit:  int32(perPage),
+		RowOffset: pageOffset(page, perPage),
+	})
+	if err != nil {
+		return nil, 0, fmt.Errorf("postgres: list related content: %w", err)
+	}
+	items := make([]content.Content, len(rows))
+	for i, row := range rows {
+		items[i] = content.Content{
+			ID:          row.ID,
+			Type:        row.Type,
+			ParentID:    row.ParentID,
+			Path:        row.Path,
+			Status:      content.Status(row.Status),
+			Slug:        row.Slug,
+			Title:       row.Title,
+			Excerpt:     row.Excerpt,
+			AuthorID:    row.AuthorID,
+			Fields:      row.Fields,
+			PublishedAt: utcOrNil(row.PublishedAt),
+			CreatedAt:   row.CreatedAt.UTC(),
+			UpdatedAt:   row.UpdatedAt.UTC(),
+		}
+	}
+	return items, int(total), nil
+}
+
+// TargetsOf returns the published targets of active types the item points at, keyed by field key.
+func (s *ContentStore) TargetsOf(ctx context.Context, from uuid.UUID) (content.Targets, error) {
+	rows, err := s.queries.ListRelationSummaries(ctx, from)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: list relation summaries: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	targets := make(content.Targets)
+	for _, row := range rows {
+		targets[row.Key] = append(targets[row.Key], content.Target{
+			ID: row.ID, Title: row.Title, Path: row.Path,
+		})
+	}
+	return targets, nil
+}
+
 // isTargetGone reports whether err is a relation pointing at an item that was removed.
 func isTargetGone(err error) bool {
 	var pgErr *pgconn.PgError

--- a/internal/postgres/relations.go
+++ b/internal/postgres/relations.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/gopherium/gophenberg/internal/content"
+	"github.com/gopherium/gophenberg/internal/postgres/db"
+)
+
+// writeRelations stores the targets the item points at and refreshes what a term page reads.
+func writeRelations(ctx context.Context, queries *db.Queries, c content.Content) error {
+	declared, err := queries.ListRelationFieldsOfType(ctx, c.Type)
+	if err != nil {
+		return err
+	}
+	for _, f := range declared {
+		targets, named := c.Relations[f.Key]
+		if !named {
+			continue
+		}
+		if err := carryTargets(ctx, queries, c, f, targets); err != nil {
+			return err
+		}
+	}
+	return queries.RefreshRelationVisibility(ctx, c.ID)
+}
+
+// carryTargets replaces the targets one relation field holds.
+func carryTargets(
+	ctx context.Context, queries *db.Queries, c content.Content,
+	f db.ListRelationFieldsOfTypeRow, targets []uuid.UUID,
+) error {
+	if err := targetsAllowed(ctx, queries, f, targets); err != nil {
+		return err
+	}
+	err := queries.ClearRelationsOfField(ctx, db.ClearRelationsOfFieldParams{FromID: c.ID, FieldID: f.ID})
+	if err != nil {
+		return err
+	}
+	for i, target := range targets {
+		err := queries.AddRelation(ctx, db.AddRelationParams{
+			FromID:   c.ID,
+			FieldID:  f.ID,
+			ToID:     target,
+			Position: int32(i + 1),
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// targetsAllowed reports whether every target exists and is the type the field points at.
+func targetsAllowed(
+	ctx context.Context, queries *db.Queries, f db.ListRelationFieldsOfTypeRow, targets []uuid.UUID,
+) error {
+	if len(targets) == 0 {
+		return nil
+	}
+	rows, err := queries.TypesOfContent(ctx, targets)
+	if err != nil {
+		return err
+	}
+	held := make(map[uuid.UUID]string, len(rows))
+	for _, row := range rows {
+		held[row.ID] = row.Type
+	}
+	for _, target := range targets {
+		stored, found := held[target]
+		if !found {
+			return fmt.Errorf("%w: %s", content.ErrTargetNotFound, target)
+		}
+		if f.RelatesTo == nil || stored != *f.RelatesTo {
+			return fmt.Errorf("%w: %s holds %s", content.ErrTargetType, f.Key, stored)
+		}
+	}
+	return nil
+}
+
+// isTargetGone reports whether err is a relation pointing at an item that was removed.
+func isTargetGone(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != foreignKeyViolationCode {
+		return false
+	}
+	return strings.HasPrefix(pgErr.ConstraintName, "content_relations_")
+}
+
+// readRelations returns the targets the item points at, keyed by field key.
+func readRelations(ctx context.Context, queries *db.Queries, id uuid.UUID) (content.Relations, error) {
+	rows, err := queries.ListRelationTargets(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: list relation targets: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	relations := make(content.Relations)
+	for _, row := range rows {
+		relations[row.Key] = append(relations[row.Key], row.ToID)
+	}
+	return relations, nil
+}

--- a/internal/postgres/revisions.go
+++ b/internal/postgres/revisions.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -98,9 +97,17 @@ func (s *ContentStore) SaveAutosave(ctx context.Context, autosave content.Revisi
 	if err != nil {
 		return content.Revision{}, fmt.Errorf("postgres: save autosave: %w", err)
 	}
-	return toRevision(
-		row.ID, row.ContentID, row.Kind, row.AuthorID, row.Title, row.Content, row.Excerpt, row.Fields, row.CreatedAt,
-	), nil
+	return content.Revision{
+		ID:        row.ID,
+		ContentID: row.ContentID,
+		Kind:      content.RevisionKind(row.Kind),
+		AuthorID:  row.AuthorID,
+		Title:     row.Title,
+		Content:   row.Content,
+		Excerpt:   row.Excerpt,
+		Fields:    row.Fields,
+		CreatedAt: row.CreatedAt.UTC(),
+	}, nil
 }
 
 // Autosave returns the author's autosave of the item, or [content.ErrRevisionNotFound].
@@ -112,9 +119,17 @@ func (s *ContentStore) Autosave(ctx context.Context, contentID, authorID uuid.UU
 	if err != nil {
 		return content.Revision{}, fmt.Errorf("postgres: get autosave: %w", err)
 	}
-	return toRevision(
-		row.ID, row.ContentID, row.Kind, row.AuthorID, row.Title, row.Content, row.Excerpt, row.Fields, row.CreatedAt,
-	), nil
+	return content.Revision{
+		ID:        row.ID,
+		ContentID: row.ContentID,
+		Kind:      content.RevisionKind(row.Kind),
+		AuthorID:  row.AuthorID,
+		Title:     row.Title,
+		Content:   row.Content,
+		Excerpt:   row.Excerpt,
+		Fields:    row.Fields,
+		CreatedAt: row.CreatedAt.UTC(),
+	}, nil
 }
 
 // DeleteAutosave removes the author's autosave of the item.
@@ -124,24 +139,6 @@ func (s *ContentStore) DeleteAutosave(ctx context.Context, contentID, authorID u
 		return fmt.Errorf("postgres: delete autosave: %w", err)
 	}
 	return nil
-}
-
-// toRevision builds a revision from its stored columns.
-func toRevision(
-	id, contentID uuid.UUID, kind string, authorID uuid.UUID, title, body, excerpt string,
-	fields content.Values, createdAt time.Time,
-) content.Revision {
-	return content.Revision{
-		ID:        id,
-		ContentID: contentID,
-		Kind:      content.RevisionKind(kind),
-		AuthorID:  authorID,
-		Title:     title,
-		Content:   body,
-		Excerpt:   excerpt,
-		Fields:    fields,
-		CreatedAt: createdAt.UTC(),
-	}
 }
 
 // snapshotRevision stores the snapshot and prunes revisions beyond the cap, sparing autosaves.

--- a/internal/postgres/revisions.go
+++ b/internal/postgres/revisions.go
@@ -63,6 +63,7 @@ func (s *ContentStore) RevisionByID(ctx context.Context, contentID, revisionID u
 		Title:     row.Title,
 		Content:   row.Content,
 		Excerpt:   row.Excerpt,
+		Fields:    row.Fields,
 		CreatedAt: row.CreatedAt.UTC(),
 	}, nil
 }
@@ -88,6 +89,7 @@ func (s *ContentStore) SaveAutosave(ctx context.Context, autosave content.Revisi
 		Title:     autosave.Title,
 		Content:   autosave.Content,
 		Excerpt:   autosave.Excerpt,
+		Fields:    storedValues(autosave.Fields),
 		CreatedAt: autosave.CreatedAt,
 	})
 	if isContentGone(err) {
@@ -97,7 +99,7 @@ func (s *ContentStore) SaveAutosave(ctx context.Context, autosave content.Revisi
 		return content.Revision{}, fmt.Errorf("postgres: save autosave: %w", err)
 	}
 	return toRevision(
-		row.ID, row.ContentID, row.Kind, row.AuthorID, row.Title, row.Content, row.Excerpt, row.CreatedAt,
+		row.ID, row.ContentID, row.Kind, row.AuthorID, row.Title, row.Content, row.Excerpt, row.Fields, row.CreatedAt,
 	), nil
 }
 
@@ -111,7 +113,7 @@ func (s *ContentStore) Autosave(ctx context.Context, contentID, authorID uuid.UU
 		return content.Revision{}, fmt.Errorf("postgres: get autosave: %w", err)
 	}
 	return toRevision(
-		row.ID, row.ContentID, row.Kind, row.AuthorID, row.Title, row.Content, row.Excerpt, row.CreatedAt,
+		row.ID, row.ContentID, row.Kind, row.AuthorID, row.Title, row.Content, row.Excerpt, row.Fields, row.CreatedAt,
 	), nil
 }
 
@@ -126,7 +128,8 @@ func (s *ContentStore) DeleteAutosave(ctx context.Context, contentID, authorID u
 
 // toRevision builds a revision from its stored columns.
 func toRevision(
-	id, contentID uuid.UUID, kind string, authorID uuid.UUID, title, body, excerpt string, createdAt time.Time,
+	id, contentID uuid.UUID, kind string, authorID uuid.UUID, title, body, excerpt string,
+	fields content.Values, createdAt time.Time,
 ) content.Revision {
 	return content.Revision{
 		ID:        id,
@@ -136,6 +139,7 @@ func toRevision(
 		Title:     title,
 		Content:   body,
 		Excerpt:   excerpt,
+		Fields:    fields,
 		CreatedAt: createdAt.UTC(),
 	}
 }
@@ -150,6 +154,7 @@ func snapshotRevision(ctx context.Context, queries *db.Queries, snapshot content
 		Title:     snapshot.Title,
 		Content:   snapshot.Content,
 		Excerpt:   snapshot.Excerpt,
+		Fields:    storedValues(snapshot.Fields),
 		CreatedAt: snapshot.CreatedAt,
 	})
 	if err != nil {

--- a/internal/postgres/types.go
+++ b/internal/postgres/types.go
@@ -296,11 +296,6 @@ func (s *TypeStore) UpdateField(ctx context.Context, f content.Field) (content.F
 func (s *TypeStore) DeleteField(ctx context.Context, typeKey, key string) error {
 	err := pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
 		queries := s.queries.WithTx(tx)
-		if _, err := queries.LockContentHoldingField(ctx, db.LockContentHoldingFieldParams{
-			Type: typeKey, Key: key,
-		}); err != nil {
-			return err
-		}
 		removed, err := queries.DeleteContentField(ctx, db.DeleteContentFieldParams{TypeKey: typeKey, Key: key})
 		if err != nil {
 			return err

--- a/internal/postgres/types.go
+++ b/internal/postgres/types.go
@@ -296,7 +296,9 @@ func (s *TypeStore) UpdateField(ctx context.Context, f content.Field) (content.F
 func (s *TypeStore) DeleteField(ctx context.Context, typeKey, key string) error {
 	err := pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
 		queries := s.queries.WithTx(tx)
-		if _, err := queries.LockContentOfType(ctx, typeKey); err != nil {
+		if _, err := queries.LockContentHoldingField(ctx, db.LockContentHoldingFieldParams{
+			Type: typeKey, Key: key,
+		}); err != nil {
 			return err
 		}
 		removed, err := queries.DeleteContentField(ctx, db.DeleteContentFieldParams{TypeKey: typeKey, Key: key})

--- a/internal/postgres/types.go
+++ b/internal/postgres/types.go
@@ -27,6 +27,15 @@ const uniqueViolationCode = "23505"
 // restrictViolationCode is what Postgres reports when a restricted row is still referenced.
 const restrictViolationCode = "23001"
 
+// foreignKeyViolationCode is what Postgres reports when a reference points at no row.
+const foreignKeyViolationCode = "23503"
+
+// fieldKeyConstraint names the unique index over one type's field keys.
+const fieldKeyConstraint = "content_fields_key_unique"
+
+// fieldTargetConstraint names the reference a relation field keeps to its target type.
+const fieldTargetConstraint = "content_fields_relates_to_fkey"
+
 // TypeStore persists the content type registry in the core schema.
 type TypeStore struct {
 	queries *db.Queries
@@ -38,20 +47,29 @@ func NewTypeStore(pool *pgxpool.Pool) *TypeStore {
 	return &TypeStore{queries: db.New(pool), pool: pool}
 }
 
-// List returns every registered type in registration order.
+// List returns every registered type in registration order with its fields attached.
 func (s *TypeStore) List(ctx context.Context) ([]content.Type, error) {
 	rows, err := s.queries.ListContentTypes(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("postgres: list content types: %w", err)
 	}
+	declared, err := s.queries.ListContentFields(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: list content fields: %w", err)
+	}
+	held := make(map[string][]content.Field, len(rows))
+	for _, row := range declared {
+		held[row.TypeKey] = append(held[row.TypeKey], toField(row))
+	}
 	types := make([]content.Type, len(rows))
 	for i, row := range rows {
 		types[i] = toType(row)
+		types[i].Fields = held[row.Key]
 	}
 	return types, nil
 }
 
-// ByKey returns the type carrying the key, or [content.ErrTypeNotFound].
+// ByKey returns the type carrying the key with its fields, or [content.ErrTypeNotFound].
 func (s *TypeStore) ByKey(ctx context.Context, key string) (content.Type, error) {
 	row, err := s.queries.GetContentType(ctx, key)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -60,7 +78,15 @@ func (s *TypeStore) ByKey(ctx context.Context, key string) (content.Type, error)
 	if err != nil {
 		return content.Type{}, fmt.Errorf("postgres: get content type: %w", err)
 	}
-	return toType(row), nil
+	declared, err := s.queries.ListContentFieldsOfType(ctx, key)
+	if err != nil {
+		return content.Type{}, fmt.Errorf("postgres: list content fields: %w", err)
+	}
+	t := toType(row)
+	for _, f := range declared {
+		t.Fields = append(t.Fields, toField(f))
+	}
+	return t, nil
 }
 
 // Create stores a new content type, or reports the key or route word already in use.
@@ -227,6 +253,117 @@ func takenBy(err error) error {
 func isTypeInUse(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == restrictViolationCode
+}
+
+// CreateField declares the field on its type, or reports why the schema refused it.
+func (s *TypeStore) CreateField(ctx context.Context, f content.Field) (content.Field, error) {
+	row, err := s.queries.CreateContentField(ctx, db.CreateContentFieldParams{
+		TypeKey:   f.TypeKey,
+		Key:       f.Key,
+		Label:     f.Label,
+		Kind:      string(f.Kind),
+		RelatesTo: targetOf(f),
+		Many:      f.Many,
+		Required:  f.Required,
+		CreatedAt: f.CreatedAt,
+		UpdatedAt: f.UpdatedAt,
+	})
+	if err != nil {
+		return content.Field{}, fieldWriteFailure(err)
+	}
+	return toField(row), nil
+}
+
+// UpdateField stores the field's label and required flag, or reports it missing.
+func (s *TypeStore) UpdateField(ctx context.Context, f content.Field) (content.Field, error) {
+	row, err := s.queries.UpdateContentField(ctx, db.UpdateContentFieldParams{
+		Label:     f.Label,
+		Required:  f.Required,
+		UpdatedAt: f.UpdatedAt,
+		TypeKey:   f.TypeKey,
+		Key:       f.Key,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return content.Field{}, content.ErrFieldNotFound
+	}
+	if err != nil {
+		return content.Field{}, fmt.Errorf("postgres: update content field: %w", err)
+	}
+	return toField(row), nil
+}
+
+// DeleteField removes the definition and sweeps its values in one transaction.
+func (s *TypeStore) DeleteField(ctx context.Context, typeKey, key string) error {
+	err := pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
+		queries := s.queries.WithTx(tx)
+		if _, err := queries.LockContentOfType(ctx, typeKey); err != nil {
+			return err
+		}
+		removed, err := queries.DeleteContentField(ctx, db.DeleteContentFieldParams{TypeKey: typeKey, Key: key})
+		if err != nil {
+			return err
+		}
+		if removed == 0 {
+			return content.ErrFieldNotFound
+		}
+		if err := queries.ClearContentFieldValues(ctx, db.ClearContentFieldValuesParams{
+			Key: key, Type: typeKey,
+		}); err != nil {
+			return err
+		}
+		return queries.ClearRevisionFieldValues(ctx, db.ClearRevisionFieldValuesParams{Key: key, Type: typeKey})
+	})
+	if errors.Is(err, content.ErrFieldNotFound) {
+		return err
+	}
+	if err != nil {
+		return fmt.Errorf("postgres: delete content field: %w", err)
+	}
+	return nil
+}
+
+// fieldWriteFailure returns the refusal a field write carries, and wraps anything else.
+func fieldWriteFailure(err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		if pgErr.Code == uniqueViolationCode && pgErr.ConstraintName == fieldKeyConstraint {
+			return content.ErrFieldTaken
+		}
+		if pgErr.Code == foreignKeyViolationCode && pgErr.ConstraintName == fieldTargetConstraint {
+			return content.ErrTargetUnknown
+		}
+		if pgErr.Code == foreignKeyViolationCode {
+			return content.ErrTypeNotFound
+		}
+	}
+	return fmt.Errorf("postgres: create content field: %w", err)
+}
+
+// targetOf returns the relation target as the nullable column holds it.
+func targetOf(f content.Field) *string {
+	if f.RelatesTo == "" {
+		return nil
+	}
+	return &f.RelatesTo
+}
+
+// toField maps a stored row to a domain field definition with UTC timestamps.
+func toField(row db.CoreContentField) content.Field {
+	f := content.Field{
+		ID:        int(row.ID),
+		TypeKey:   row.TypeKey,
+		Key:       row.Key,
+		Label:     row.Label,
+		Kind:      content.FieldKind(row.Kind),
+		Many:      row.Many,
+		Required:  row.Required,
+		CreatedAt: row.CreatedAt.UTC(),
+		UpdatedAt: row.UpdatedAt.UTC(),
+	}
+	if row.RelatesTo != nil {
+		f.RelatesTo = *row.RelatesTo
+	}
+	return f
 }
 
 // toType maps a stored row to a domain content type with UTC timestamps.

--- a/internal/postgres/types_fields_test.go
+++ b/internal/postgres/types_fields_test.go
@@ -3,7 +3,6 @@
 package postgres_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -42,7 +41,7 @@ func storedFields(t *testing.T, pool *pgxpool.Pool, slug string) string {
 // plantValues stores a content row and one revision carrying raw field values.
 func plantValues(t *testing.T, pool *pgxpool.Pool, author uuid.UUID, slug, values string) {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 	id := uuid.Must(uuid.NewV7())
 	now := time.Now().UTC()
 	if _, err := pool.Exec(ctx,
@@ -112,6 +111,19 @@ func TestTypeStoreKeepsARelationTargetWhole(t *testing.T) {
 	}
 	if created.RelatesTo != "page" || created.Kind != content.FieldKindRelation {
 		t.Errorf("CreateField() = %+v, want the relation shape stored", created)
+	}
+}
+
+func TestTypeStoreRefusesARelationTargetingAnUnknownType(t *testing.T) {
+	t.Parallel()
+
+	_, _, pool := newContentStoreWithPool(t)
+	types := postgres.NewTypeStore(pool)
+
+	_, err := types.CreateField(t.Context(), fieldOn(t, "post", "pages", content.FieldKindRelation, "ghost"))
+
+	if !errors.Is(err, content.ErrTargetUnknown) {
+		t.Fatalf("CreateField() error = %v, want %v", err, content.ErrTargetUnknown)
 	}
 }
 
@@ -205,7 +217,10 @@ func TestTypeStoreDeleteFieldSweepsValues(t *testing.T) {
 	}
 	var revision string
 	if err := pool.QueryRow(
-		t.Context(), `SELECT fields::text FROM core.content_revisions LIMIT 1`,
+		t.Context(),
+		`SELECT r.fields::text FROM core.content_revisions r
+		JOIN core.content c ON c.id = r.content_id WHERE c.slug = $1`,
+		"planted",
 	).Scan(&revision); err != nil {
 		t.Fatalf("reading the revision fields: %v, want nil", err)
 	}

--- a/internal/postgres/types_fields_test.go
+++ b/internal/postgres/types_fields_test.go
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gopherium/gophenberg/internal/content"
+	"github.com/gopherium/gophenberg/internal/postgres"
+)
+
+// fieldOn returns a field definition ready to declare on the type.
+func fieldOn(t *testing.T, typeKey, key string, kind content.FieldKind, relatesTo string) content.Field {
+	t.Helper()
+	built, err := content.NewField(content.Field{
+		TypeKey: typeKey, Key: key, Label: "A Field", Kind: kind, RelatesTo: relatesTo,
+	})
+	if err != nil {
+		t.Fatalf("NewField() error = %v, want nil", err)
+	}
+	return built
+}
+
+// storedFields reads the raw fields column of the content row carrying the slug.
+func storedFields(t *testing.T, pool *pgxpool.Pool, slug string) string {
+	t.Helper()
+	var held string
+	if err := pool.QueryRow(
+		t.Context(), `SELECT fields::text FROM core.content WHERE slug = $1`, slug,
+	).Scan(&held); err != nil {
+		t.Fatalf("reading the fields of %q: %v, want nil", slug, err)
+	}
+	return held
+}
+
+// plantValues stores a content row and one revision carrying raw field values.
+func plantValues(t *testing.T, pool *pgxpool.Pool, author uuid.UUID, slug, values string) {
+	t.Helper()
+	ctx := context.Background()
+	id := uuid.Must(uuid.NewV7())
+	now := time.Now().UTC()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO core.content
+		(id, type, status, slug, path, title, content, excerpt, author_id, created_at, updated_at, fields)
+		VALUES ($1, 'post', 'draft', $2, $2, 'Planted', '', '', $3, $4, $4, $5)`,
+		id, slug, author, now, values,
+	); err != nil {
+		t.Fatalf("planting the content row: %v, want nil", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO core.content_revisions
+		(id, content_id, kind, author_id, title, content, excerpt, created_at, fields)
+		VALUES ($1, $2, 'revision', $3, $4, '', '', $5, $6)`,
+		uuid.Must(uuid.NewV7()), id, author, "Planted", now, values,
+	); err != nil {
+		t.Fatalf("planting the revision row: %v, want nil", err)
+	}
+}
+
+func TestTypeStoreDeclaresAField(t *testing.T) {
+	t.Parallel()
+
+	_, _, pool := newContentStoreWithPool(t)
+	types := postgres.NewTypeStore(pool)
+
+	created, err := types.CreateField(t.Context(), fieldOn(t, "post", "color", content.FieldKindText, ""))
+
+	if err != nil {
+		t.Fatalf("CreateField() error = %v, want nil", err)
+	}
+	if created.ID == 0 {
+		t.Errorf("CreateField() id = 0, want a stored identity")
+	}
+	held, err := types.ByKey(t.Context(), "post")
+	if err != nil {
+		t.Fatalf("ByKey() error = %v, want nil", err)
+	}
+	if len(held.Fields) != 1 || held.Fields[0].Key != "color" {
+		t.Fatalf("ByKey() fields = %+v, want the declared field attached", held.Fields)
+	}
+	listed, err := types.List(t.Context())
+	if err != nil {
+		t.Fatalf("List() error = %v, want nil", err)
+	}
+	for _, stored := range listed {
+		if stored.Key == "post" && len(stored.Fields) == 1 {
+			return
+		}
+	}
+	t.Errorf("List() = %+v, want the post type carrying its field", listed)
+}
+
+func TestTypeStoreKeepsARelationTargetWhole(t *testing.T) {
+	t.Parallel()
+
+	_, _, pool := newContentStoreWithPool(t)
+	types := postgres.NewTypeStore(pool)
+	if _, err := types.Create(t.Context(), pageType()); err != nil {
+		t.Fatalf("registering the page type: %v, want nil", err)
+	}
+
+	created, err := types.CreateField(t.Context(), fieldOn(t, "post", "pages", content.FieldKindRelation, "page"))
+
+	if err != nil {
+		t.Fatalf("CreateField() error = %v, want nil", err)
+	}
+	if created.RelatesTo != "page" || created.Kind != content.FieldKindRelation {
+		t.Errorf("CreateField() = %+v, want the relation shape stored", created)
+	}
+}
+
+func TestTypeStoreRefusesATakenFieldKey(t *testing.T) {
+	t.Parallel()
+
+	_, _, pool := newContentStoreWithPool(t)
+	types := postgres.NewTypeStore(pool)
+	if _, err := types.CreateField(t.Context(), fieldOn(t, "post", "color", content.FieldKindText, "")); err != nil {
+		t.Fatalf("declaring the first field: %v, want nil", err)
+	}
+
+	_, err := types.CreateField(t.Context(), fieldOn(t, "post", "color", content.FieldKindNumber, ""))
+
+	if !errors.Is(err, content.ErrFieldTaken) {
+		t.Fatalf("CreateField() error = %v, want %v", err, content.ErrFieldTaken)
+	}
+}
+
+func TestTypeStoreRefusesAFieldOnAnUnknownType(t *testing.T) {
+	t.Parallel()
+
+	_, _, pool := newContentStoreWithPool(t)
+	types := postgres.NewTypeStore(pool)
+
+	_, err := types.CreateField(t.Context(), fieldOn(t, "ghost", "color", content.FieldKindText, ""))
+
+	if !errors.Is(err, content.ErrTypeNotFound) {
+		t.Fatalf("CreateField() error = %v, want %v", err, content.ErrTypeNotFound)
+	}
+}
+
+func TestTypeStoreRelabelsAField(t *testing.T) {
+	t.Parallel()
+
+	_, _, pool := newContentStoreWithPool(t)
+	types := postgres.NewTypeStore(pool)
+	declared, err := types.CreateField(t.Context(), fieldOn(t, "post", "color", content.FieldKindText, ""))
+	if err != nil {
+		t.Fatalf("declaring the field: %v, want nil", err)
+	}
+	declared.Label, declared.Required = "Paint", true
+	declared.UpdatedAt = time.Now().UTC()
+
+	updated, err := types.UpdateField(t.Context(), declared)
+
+	if err != nil {
+		t.Fatalf("UpdateField() error = %v, want nil", err)
+	}
+	if updated.Label != "Paint" || !updated.Required || updated.Kind != content.FieldKindText {
+		t.Errorf("UpdateField() = %+v, want the label carried and the kind kept", updated)
+	}
+}
+
+func TestTypeStoreMissesAnUnknownFieldOnUpdate(t *testing.T) {
+	t.Parallel()
+
+	_, _, pool := newContentStoreWithPool(t)
+	types := postgres.NewTypeStore(pool)
+
+	_, err := types.UpdateField(t.Context(), fieldOn(t, "post", "color", content.FieldKindText, ""))
+
+	if !errors.Is(err, content.ErrFieldNotFound) {
+		t.Fatalf("UpdateField() error = %v, want %v", err, content.ErrFieldNotFound)
+	}
+}
+
+func TestTypeStoreDeleteFieldSweepsValues(t *testing.T) {
+	t.Parallel()
+
+	_, author, pool := newContentStoreWithPool(t)
+	types := postgres.NewTypeStore(pool)
+	if _, err := types.CreateField(t.Context(), fieldOn(t, "post", "color", content.FieldKindText, "")); err != nil {
+		t.Fatalf("declaring the field: %v, want nil", err)
+	}
+	plantValues(t, pool, author, "planted", `{"color": "red", "other": 1}`)
+
+	if err := types.DeleteField(t.Context(), "post", "color"); err != nil {
+		t.Fatalf("DeleteField() error = %v, want nil", err)
+	}
+
+	held, err := types.ByKey(t.Context(), "post")
+	if err != nil {
+		t.Fatalf("ByKey() error = %v, want nil", err)
+	}
+	if len(held.Fields) != 0 {
+		t.Errorf("ByKey() fields = %+v, want the definition gone", held.Fields)
+	}
+	if got := storedFields(t, pool, "planted"); got != `{"other": 1}` {
+		t.Errorf("the content row holds %s, want only the surviving key", got)
+	}
+	var revision string
+	if err := pool.QueryRow(
+		t.Context(), `SELECT fields::text FROM core.content_revisions LIMIT 1`,
+	).Scan(&revision); err != nil {
+		t.Fatalf("reading the revision fields: %v, want nil", err)
+	}
+	if revision != `{"other": 1}` {
+		t.Errorf("the revision holds %s, want the key swept from snapshots too", revision)
+	}
+}
+
+func TestTypeStoreMissesAnUnknownFieldOnDelete(t *testing.T) {
+	t.Parallel()
+
+	_, _, pool := newContentStoreWithPool(t)
+	types := postgres.NewTypeStore(pool)
+
+	err := types.DeleteField(t.Context(), "post", "color")
+
+	if !errors.Is(err, content.ErrFieldNotFound) {
+		t.Fatalf("DeleteField() error = %v, want %v", err, content.ErrFieldNotFound)
+	}
+}

--- a/internal/publicsite/publicsite.go
+++ b/internal/publicsite/publicsite.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/gopherium/gophenberg/internal/content"
 	"github.com/gopherium/gophenberg/internal/publichtml"
 	"github.com/gopherium/gophenberg/internal/version"
@@ -37,12 +39,14 @@ var (
 	indexTemplate    = template.Must(template.ParseFS(files, "templates/shell.html", "templates/index.html"))
 	postTemplate     = template.Must(template.ParseFS(files, "templates/shell.html", "templates/content.html"))
 	notFoundTemplate = template.Must(template.ParseFS(files, "templates/shell.html", "templates/notfound.html"))
+	termTemplate     = template.Must(template.ParseFS(files, "templates/shell.html", "templates/term.html"))
 )
 
 // Reader reads the published content the site serves.
 type Reader interface {
 	List(ctx context.Context, f content.Filter) ([]content.Content, int, error)
 	PublishedByPath(ctx context.Context, path string) (content.Content, error)
+	RelatedTo(ctx context.Context, target uuid.UUID, page, perPage int) ([]content.Content, int, error)
 }
 
 // Config carries what the site renders with.
@@ -95,6 +99,15 @@ type detailData struct {
 	Post detail
 }
 
+// termData is what a term page renders with, the item and what points at it.
+type termData struct {
+	Shell
+	Post  detail
+	Posts []summary
+	Older string
+	Newer string
+}
+
 // site serves published content as HTML pages.
 type site struct {
 	posts     Reader
@@ -128,11 +141,35 @@ func (s *site) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		serveError(w)
 		return
 	}
-	if held.Kind == content.KindItem {
-		s.serveItem(w, held.Item)
+	if held.Kind == content.KindArchive {
+		s.serveList(w, r, held.Type, held.Page)
 		return
 	}
-	s.serveList(w, r, held.Type, held.Page)
+	if held.Kind == content.KindTerm {
+		s.serveTerm(w, r, held)
+		return
+	}
+	s.serveItem(w, held.Item)
+}
+
+// serveTerm renders a term page, the item itself above what points at it.
+func (s *site) serveTerm(w http.ResponseWriter, r *http.Request, held content.Address) {
+	rows, total, err := s.posts.RelatedTo(r.Context(), held.Item.ID, held.Page, postsPerPage)
+	if err != nil {
+		serveError(w)
+		return
+	}
+	summaries := make([]summary, len(rows))
+	for i, p := range rows {
+		summaries[i] = newSummary(p)
+	}
+	s.render(w, termTemplate, http.StatusOK, termData{
+		Shell: s.shell(held.Item.Title + " | " + s.title),
+		Post:  newDetail(held.Item),
+		Posts: summaries,
+		Older: olderLink(held.Item.Path, held.Page, total),
+		Newer: newerLink(held.Item.Path, held.Page),
+	})
 }
 
 // serveList renders one page of the published content of a type.

--- a/internal/publicsite/publicsite_test.go
+++ b/internal/publicsite/publicsite_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -47,6 +48,31 @@ func (r *fakeReader) List(_ context.Context, f content.Filter) ([]content.Conten
 	return matched[start:min(start+f.PerPage, total)], total, nil
 }
 
+// RelatedTo returns the published items pointing at the target, newest first, and the total.
+func (r *fakeReader) RelatedTo(
+	_ context.Context, target uuid.UUID, page, perPage int,
+) ([]content.Content, int, error) {
+	if r.listErr != nil {
+		return nil, 0, r.listErr
+	}
+	matched := make([]content.Content, 0, len(r.posts))
+	for _, p := range r.posts {
+		if p.Status != content.StatusPublished {
+			continue
+		}
+		for _, targets := range p.Relations {
+			if slices.Contains(targets, target) {
+				p.Content = ""
+				matched = append(matched, p)
+				break
+			}
+		}
+	}
+	total := len(matched)
+	start := min((page-1)*perPage, total)
+	return matched[start:min(start+perPage, total)], total, nil
+}
+
 // PublishedByPath returns the stored published item answering at the address.
 func (r *fakeReader) PublishedByPath(_ context.Context, path string) (content.Content, error) {
 	if r.readErr != nil {
@@ -60,8 +86,29 @@ func (r *fakeReader) PublishedByPath(_ context.Context, path string) (content.Co
 	return content.Content{}, content.ErrNotFound
 }
 
-// fakeTypes answers which type answers under a route word.
+// fakeTypes answers which type answers under a route word and which carries a key.
 type fakeTypes struct{ err error }
+
+// ByKey returns the type carrying the key, or reports it missing.
+func (t fakeTypes) ByKey(_ context.Context, key string) (content.Type, error) {
+	if t.err != nil {
+		return content.Type{}, t.err
+	}
+	switch key {
+	case "category":
+		return content.Type{
+			Key: "category", PluralLabel: "Categories", RouteWord: "categories",
+			PageKind: content.PageKindArchive, Active: true,
+		}, nil
+	case content.TypePost:
+		return content.Type{Key: content.TypePost, PluralLabel: "Posts", Default: true, Active: true}, nil
+	case "page":
+		return content.Type{
+			Key: "page", PluralLabel: "Pages", RouteWord: "pages", Hierarchical: true, Active: true,
+		}, nil
+	}
+	return content.Type{}, content.ErrTypeNotFound
+}
 
 // ByRouteWord returns the post type at the root and the page type under its word.
 func (t fakeTypes) ByRouteWord(_ context.Context, word string) (content.Type, error) {
@@ -374,4 +421,57 @@ func TestSiteShowsTheDateAPostWasPublished(t *testing.T) {
 	if !strings.Contains(body, `datetime="2026-08-03"`) {
 		t.Errorf("body = %q, want a machine readable date", body)
 	}
+}
+
+func TestSiteRendersATermPageWithItsRelatedContent(t *testing.T) {
+	t.Parallel()
+
+	news := content.Content{
+		ID: uuid.Must(uuid.NewV7()), Type: "category", Status: content.StatusPublished,
+		Path: "categories/news", Slug: "news", Title: "News", Content: blockMarkup,
+	}
+	filed := content.Content{
+		ID: uuid.Must(uuid.NewV7()), Type: content.TypePost, Status: content.StatusPublished,
+		Path: "hello-world", Slug: "hello-world", Title: "Hello world",
+		Relations: content.Relations{"categories": {news.ID}},
+	}
+	reader := &fakeReader{posts: []content.Content{news, filed}}
+	handler := publicsite.New(publicsite.Config{
+		Content: reader, Types: fakeTypes{}, Title: "A Test Site", Version: "1.2.3",
+	})
+
+	recorder := get(t, handler, "/categories/news")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	body := recorder.Body.String()
+	if !strings.Contains(body, "News") || !strings.Contains(body, "Body text.") {
+		t.Errorf("the term page does not carry the category itself: %s", body)
+	}
+	if !strings.Contains(body, "Hello world") {
+		t.Errorf("the term page does not list what points at it: %s", body)
+	}
+}
+
+// TargetsOf returns the published targets the item points at, keyed by field key.
+func (r *fakeReader) TargetsOf(_ context.Context, from uuid.UUID) (content.Targets, error) {
+	targets := make(content.Targets)
+	for _, held := range r.posts {
+		if held.ID != from {
+			continue
+		}
+		for key, listed := range held.Relations {
+			for _, id := range listed {
+				for _, pointed := range r.posts {
+					if pointed.ID == id && pointed.Status == content.StatusPublished {
+						targets[key] = append(targets[key], content.Target{
+							ID: pointed.ID, Title: pointed.Title, Path: pointed.Path,
+						})
+					}
+				}
+			}
+		}
+	}
+	return targets, nil
 }

--- a/internal/publicsite/templates/term.html
+++ b/internal/publicsite/templates/term.html
@@ -1,0 +1,21 @@
+{{define "main"}}
+<article class="gophenberg-site__post">
+<h1 class="gophenberg-site__post-title">{{.Post.Title}}</h1>
+<div class="gophenberg-site__content">
+{{.Post.Content}}
+</div>
+</article>
+{{range .Posts}}
+<article class="gophenberg-site__summary">
+<h2 class="gophenberg-site__summary-title"><a href="{{.URL}}">{{.Title}}</a></h2>
+<p class="gophenberg-site__date"><time datetime="{{.DateAttr}}">{{.DateText}}</time></p>
+<p class="gophenberg-site__excerpt">{{.Excerpt}}</p>
+</article>
+{{else}}
+<p class="gophenberg-site__empty">Nothing published here yet.</p>
+{{end}}
+<nav class="gophenberg-site__pagination">
+{{with .Newer}}<a class="gophenberg-site__newer" href="{{.}}">Newer posts</a>{{end}}
+{{with .Older}}<a class="gophenberg-site__older" href="{{.}}">Older posts</a>{{end}}
+</nav>
+{{end}}

--- a/internal/seed/categories.go
+++ b/internal/seed/categories.go
@@ -165,7 +165,7 @@ func fileUnderCategory(ctx context.Context, store content.Store, postID, categor
 		return fmt.Errorf("seed filed post lookup: %w", err)
 	}
 	version := held.UpdatedAt
-	held.Relations = content.Relations{CategoriesFieldKey: {categoryID}}
+	held.Relations = held.Relations.Merge(content.Relations{CategoriesFieldKey: {categoryID}})
 	held.UpdatedAt = time.Now().UTC()
 	if _, err := store.Update(ctx, held, version, nil, 0); err != nil {
 		return fmt.Errorf("seed filed post: %w", err)

--- a/internal/seed/categories.go
+++ b/internal/seed/categories.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package seed
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/gopherium/gouncer"
+
+	"github.com/gopherium/gophenberg/internal/content"
+)
+
+// CategoryTypeKey is the key the demo categories are registered under.
+const CategoryTypeKey = "category"
+
+// CategoriesFieldKey is the key posts point at their categories through.
+const CategoriesFieldKey = "categories"
+
+// demoCategory is one scripted category and the post the demo files under it.
+type demoCategory struct {
+	id      string
+	title   string
+	excerpt string
+	content string
+	filed   string
+}
+
+// demoCategories returns the categories the demo data set holds.
+func demoCategories() []demoCategory {
+	return []demoCategory{{
+		id:      "019fb000-0000-7000-8000-0000000000c1",
+		title:   "News",
+		excerpt: "What is happening around the project.",
+		content: "<!-- wp:paragraph -->\n<p>Everything filed under News shows up below.</p>\n" +
+			"<!-- /wp:paragraph -->",
+		filed: "019fb000-0000-7000-8000-000000000001",
+	}}
+}
+
+// CategoryType returns the content type the demo categories are registered under.
+func CategoryType() content.Type {
+	now := time.Now().UTC()
+	return content.Type{
+		Key:           CategoryTypeKey,
+		SingularLabel: "Category",
+		PluralLabel:   "Categories",
+		RouteWord:     "categories",
+		Hierarchical:  true,
+		Revisions:     true,
+		RevisionCap:   100,
+		PageKind:      content.PageKindArchive,
+		Active:        true,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+}
+
+// CategoriesField returns the relation field the demo points posts at their categories through.
+func CategoriesField() content.Field {
+	now := time.Now().UTC()
+	return content.Field{
+		TypeKey:   content.TypePost,
+		Key:       CategoriesFieldKey,
+		Label:     "Categories",
+		Kind:      content.FieldKindRelation,
+		RelatesTo: CategoryTypeKey,
+		Many:      true,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+// Categories registers the category type, its relation field, and the demo categories.
+func Categories(
+	ctx context.Context, store content.Store, types *content.Registry, users gouncer.Store,
+) error {
+	if err := registerCategoryType(ctx, types); err != nil {
+		return err
+	}
+	if err := declareCategoriesField(ctx, types); err != nil {
+		return err
+	}
+	admin, err := users.UserByEmail(ctx, AdminEmail)
+	if err != nil {
+		return fmt.Errorf("seed admin lookup: %w", err)
+	}
+	categoryType, err := types.ByKey(ctx, CategoryTypeKey)
+	if err != nil {
+		return fmt.Errorf("seed category type lookup: %w", err)
+	}
+	for _, scripted := range demoCategories() {
+		if err := storeDemoCategory(ctx, store, categoryType, scripted, admin.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// registerCategoryType registers the category type unless the registry already holds it.
+func registerCategoryType(ctx context.Context, types *content.Registry) error {
+	if _, err := types.ByKey(ctx, CategoryTypeKey); err == nil {
+		return nil
+	} else if !errors.Is(err, content.ErrTypeNotFound) {
+		return fmt.Errorf("seed category type lookup: %w", err)
+	}
+	if _, err := types.Create(ctx, CategoryType()); err != nil {
+		return fmt.Errorf("seed category type: %w", err)
+	}
+	return nil
+}
+
+// declareCategoriesField declares the relation field unless the post type already carries it.
+func declareCategoriesField(ctx context.Context, types *content.Registry) error {
+	postType, err := types.ByKey(ctx, content.TypePost)
+	if err != nil {
+		return fmt.Errorf("seed post type lookup: %w", err)
+	}
+	for _, held := range postType.Fields {
+		if held.Key == CategoriesFieldKey {
+			return nil
+		}
+	}
+	if _, err := types.CreateField(ctx, CategoriesField()); err != nil {
+		return fmt.Errorf("seed categories field: %w", err)
+	}
+	return nil
+}
+
+// storeDemoCategory stores one scripted category and files its post under it.
+func storeDemoCategory(
+	ctx context.Context, store content.Store, categoryType content.Type,
+	scripted demoCategory, authorID uuid.UUID,
+) error {
+	id := uuid.MustParse(scripted.id)
+	if _, err := store.ByID(ctx, id); err == nil {
+		return nil
+	} else if !errors.Is(err, content.ErrNotFound) {
+		return fmt.Errorf("seed category lookup: %w", err)
+	}
+	built, err := content.New(categoryType, nil, scripted.title, authorID)
+	if err != nil {
+		return fmt.Errorf("build category: %w", err)
+	}
+	built.ID = id
+	built.Excerpt = scripted.excerpt
+	built.Content = scripted.content
+	if err := built.Transition(content.StatusPublished); err != nil {
+		return fmt.Errorf("build category: %w", err)
+	}
+	if _, err := store.Create(ctx, built); err != nil {
+		return fmt.Errorf("seed category: %w", err)
+	}
+	return fileUnderCategory(ctx, store, uuid.MustParse(scripted.filed), id)
+}
+
+// fileUnderCategory points a seeded post at the category it belongs to.
+func fileUnderCategory(ctx context.Context, store content.Store, postID, categoryID uuid.UUID) error {
+	held, err := store.ByID(ctx, postID)
+	if err != nil {
+		return fmt.Errorf("seed filed post lookup: %w", err)
+	}
+	version := held.UpdatedAt
+	held.Relations = content.Relations{CategoriesFieldKey: {categoryID}}
+	held.UpdatedAt = time.Now().UTC()
+	if _, err := store.Update(ctx, held, version, nil, 0); err != nil {
+		return fmt.Errorf("seed filed post: %w", err)
+	}
+	return nil
+}

--- a/internal/seed/categories_test.go
+++ b/internal/seed/categories_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package seed
+
+import (
+	"testing"
+
+	"github.com/gopherium/gophenberg/internal/content"
+)
+
+func TestTheCategoryTypeServesTermPages(t *testing.T) {
+	t.Parallel()
+
+	held := CategoryType()
+
+	if held.PageKind != content.PageKindArchive {
+		t.Errorf("the category type serves %q pages, want %q", held.PageKind, content.PageKindArchive)
+	}
+	if held.RouteWord != "categories" || !held.Hierarchical || !held.Active {
+		t.Errorf("the category type = %+v, want it nesting under categories and serving", held)
+	}
+	if err := held.Validate(); err != nil {
+		t.Errorf("Validate() error = %v, want the seeded type storable", err)
+	}
+}
+
+func TestTheCategoriesFieldPointsPostsAtCategories(t *testing.T) {
+	t.Parallel()
+
+	held := CategoriesField()
+
+	if held.TypeKey != content.TypePost || held.RelatesTo != CategoryTypeKey {
+		t.Errorf("the field = %+v, want posts pointing at categories", held)
+	}
+	if held.Kind != content.FieldKindRelation || !held.Many {
+		t.Errorf("the field = %+v, want a relation holding many", held)
+	}
+	if err := held.Validate(); err != nil {
+		t.Errorf("Validate() error = %v, want the seeded field storable", err)
+	}
+}
+
+func TestTheSeededCategoryCarriesAFixedIdentity(t *testing.T) {
+	t.Parallel()
+
+	held := demoCategories()
+
+	if len(held) != 1 {
+		t.Fatalf("the seed scripts %d categories, want the one the demo files under", len(held))
+	}
+	if held[0].title != "News" {
+		t.Errorf("the seeded category is %q, want News", held[0].title)
+	}
+	if held[0].id == "" || held[0].filed == "" {
+		t.Errorf("the seeded category = %+v, want a fixed identity and a post to file", held[0])
+	}
+}
+
+func TestTheSeededCategoryFilesAPublishedPost(t *testing.T) {
+	t.Parallel()
+
+	published := make(map[string]bool, len(demoPosts()))
+	for _, scripted := range publishedDemoPosts() {
+		published[scripted.id] = true
+	}
+
+	for _, scripted := range demoCategories() {
+		if !published[scripted.filed] {
+			t.Errorf("the category %q files %q, want a post the demo publishes", scripted.title, scripted.filed)
+		}
+	}
+}

--- a/internal/seed/seed_test.go
+++ b/internal/seed/seed_test.go
@@ -54,6 +54,21 @@ func (stubTypeStore) Update(context.Context, content.Type) (content.Type, error)
 // Delete refuses to remove a type in a seeding run.
 func (stubTypeStore) Delete(context.Context, string) error { return content.ErrTypeNotFound }
 
+// CreateField refuses to declare a field in a seeding run.
+func (stubTypeStore) CreateField(context.Context, content.Field) (content.Field, error) {
+	return content.Field{}, content.ErrTypeNotFound
+}
+
+// UpdateField refuses to edit a field in a seeding run.
+func (stubTypeStore) UpdateField(context.Context, content.Field) (content.Field, error) {
+	return content.Field{}, content.ErrFieldNotFound
+}
+
+// DeleteField refuses to remove a field in a seeding run.
+func (stubTypeStore) DeleteField(context.Context, string, string) error {
+	return content.ErrFieldNotFound
+}
+
 func TestPostsReportsStoreFailures(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/autosave.go
+++ b/internal/server/autosave.go
@@ -89,10 +89,12 @@ func (s *server) handleAutosaveSave() http.HandlerFunc {
 			respondDomainError(w, err)
 			return
 		}
-		if err := s.bufferedValues(r, stored, req); err != nil {
+		scalars, err := s.bufferedValues(r, stored, req)
+		if err != nil {
 			respondDomainError(w, err)
 			return
 		}
+		req.Fields = scalars
 		s.storeBuffer(w, r, stored, req, authkit.IdentityFromContext(r.Context()).ID)
 	}
 }
@@ -203,14 +205,18 @@ func newAutosaveResponse(
 	}
 }
 
-// bufferedValues reports whether the buffer's field values are ones the type declares.
-func (s *server) bufferedValues(r *http.Request, c content.Content, req autosaveRequest) error {
+// bufferedValues returns the scalar values the buffer holds, leaving its targets to a save.
+func (s *server) bufferedValues(r *http.Request, c content.Content, req autosaveRequest) (content.Values, error) {
 	if req.Fields == nil {
-		return nil
+		return nil, nil
 	}
 	t, err := s.types.Active(r.Context(), c.Type)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return req.Fields.Validate(t.Fields)
+	scalars, _, err := content.SplitValues(req.Fields, t.Fields)
+	if err != nil {
+		return nil, err
+	}
+	return scalars, scalars.Validate(t.Fields)
 }

--- a/internal/server/autosave.go
+++ b/internal/server/autosave.go
@@ -21,20 +21,22 @@ const (
 )
 
 type autosaveResponse struct {
-	Target    string    `json:"target"`
-	ContentID uuid.UUID `json:"content_id"`
-	Title     string    `json:"title"`
-	Content   string    `json:"content"`
-	Excerpt   string    `json:"excerpt"`
-	SavedAt   time.Time `json:"saved_at"`
+	Target    string         `json:"target"`
+	ContentID uuid.UUID      `json:"content_id"`
+	Title     string         `json:"title"`
+	Content   string         `json:"content"`
+	Excerpt   string         `json:"excerpt"`
+	Fields    content.Values `json:"fields"`
+	SavedAt   time.Time      `json:"saved_at"`
 }
 
 // autosaveRequest carries the version the buffer was prepared against and the words it holds.
 type autosaveRequest struct {
-	UpdatedAt *time.Time `json:"updated_at"`
-	Title     string     `json:"title"`
-	Content   string     `json:"content"`
-	Excerpt   string     `json:"excerpt"`
+	UpdatedAt *time.Time     `json:"updated_at"`
+	Title     string         `json:"title"`
+	Content   string         `json:"content"`
+	Excerpt   string         `json:"excerpt"`
+	Fields    content.Values `json:"fields"`
 }
 
 // decodeAutosaveRequest reads an autosave request, reporting whether it may be used.
@@ -53,7 +55,16 @@ func decodeAutosaveRequest(w http.ResponseWriter, r *http.Request) (autosaveRequ
 
 // holdsBuffer reports whether the item already holds the words the buffer carries.
 func holdsBuffer(c content.Content, req autosaveRequest) bool {
-	return c.Title == req.Title && c.Content == req.Content && c.Excerpt == req.Excerpt
+	return c.Title == req.Title && c.Content == req.Content && c.Excerpt == req.Excerpt &&
+		sameValues(c.Fields, bufferValues(c, req))
+}
+
+// bufferValues returns the values the buffer holds, keeping the stored ones when it names none.
+func bufferValues(c content.Content, req autosaveRequest) content.Values {
+	if req.Fields == nil {
+		return c.Fields
+	}
+	return req.Fields
 }
 
 // writesInPlace reports whether the buffer may be written straight to the item.
@@ -78,6 +89,10 @@ func (s *server) handleAutosaveSave() http.HandlerFunc {
 			respondDomainError(w, err)
 			return
 		}
+		if err := s.bufferedValues(r, stored, req); err != nil {
+			respondDomainError(w, err)
+			return
+		}
 		s.storeBuffer(w, r, stored, req, authkit.IdentityFromContext(r.Context()).ID)
 	}
 }
@@ -92,11 +107,12 @@ func (s *server) storeBuffer(
 			return
 		}
 		authkit.Respond(w, http.StatusOK, newAutosaveResponse(autosaveTargetAutosave, stored.ID,
-			req.Title, req.Content, req.Excerpt, stored.UpdatedAt))
+			req.Title, req.Content, req.Excerpt, bufferValues(stored, req), stored.UpdatedAt))
 		return
 	}
 	buffer := stored
 	buffer.Title, buffer.Content, buffer.Excerpt = req.Title, req.Content, req.Excerpt
+	buffer.Fields = bufferValues(stored, req)
 	if writesInPlace(stored, authorID, *req.UpdatedAt) {
 		s.saveBufferToContent(w, r, buffer, stored.UpdatedAt)
 		return
@@ -113,7 +129,7 @@ func (s *server) clearParkedBuffer(
 		return
 	}
 	authkit.Respond(w, http.StatusOK, newAutosaveResponse(autosaveTargetPost, c.ID,
-		c.Title, c.Content, c.Excerpt, c.UpdatedAt))
+		c.Title, c.Content, c.Excerpt, c.Fields, c.UpdatedAt))
 }
 
 // saveBufferToContent writes the buffer to the item itself.
@@ -127,7 +143,7 @@ func (s *server) saveBufferToContent(
 		return
 	}
 	authkit.Respond(w, http.StatusOK, newAutosaveResponse(autosaveTargetPost, updated.ID,
-		updated.Title, updated.Content, updated.Excerpt, updated.UpdatedAt))
+		updated.Title, updated.Content, updated.Excerpt, updated.Fields, updated.UpdatedAt))
 }
 
 // parkBufferAsAutosave stores the buffer as the author's autosave.
@@ -145,7 +161,7 @@ func (s *server) parkBufferAsAutosave(
 		return
 	}
 	authkit.Respond(w, http.StatusOK, newAutosaveResponse(autosaveTargetAutosave, saved.ContentID,
-		saved.Title, saved.Content, saved.Excerpt, saved.CreatedAt))
+		saved.Title, saved.Content, saved.Excerpt, saved.Fields, saved.CreatedAt))
 }
 
 // handleAutosaveGet returns an http.HandlerFunc responding with the requester's autosave.
@@ -167,13 +183,14 @@ func (s *server) handleAutosaveGet() http.HandlerFunc {
 			return
 		}
 		authkit.Respond(w, http.StatusOK, newAutosaveResponse(autosaveTargetAutosave, autosave.ContentID,
-			autosave.Title, autosave.Content, autosave.Excerpt, autosave.CreatedAt))
+			autosave.Title, autosave.Content, autosave.Excerpt, autosave.Fields, autosave.CreatedAt))
 	}
 }
 
 // newAutosaveResponse builds an autosaveResponse, normalizing the timestamp to UTC.
 func newAutosaveResponse(
-	target string, contentID uuid.UUID, title, body, excerpt string, savedAt time.Time,
+	target string, contentID uuid.UUID, title, body, excerpt string,
+	fields content.Values, savedAt time.Time,
 ) autosaveResponse {
 	return autosaveResponse{
 		Target:    target,
@@ -181,6 +198,19 @@ func newAutosaveResponse(
 		Title:     title,
 		Content:   body,
 		Excerpt:   excerpt,
+		Fields:    heldValues(fields),
 		SavedAt:   savedAt.UTC(),
 	}
+}
+
+// bufferedValues reports whether the buffer's field values are ones the type declares.
+func (s *server) bufferedValues(r *http.Request, c content.Content, req autosaveRequest) error {
+	if req.Fields == nil {
+		return nil
+	}
+	t, err := s.types.Active(r.Context(), c.Type)
+	if err != nil {
+		return err
+	}
+	return req.Fields.Validate(t.Fields)
 }

--- a/internal/server/content.go
+++ b/internal/server/content.go
@@ -247,6 +247,22 @@ func (s *server) respondResolvedItem(w http.ResponseWriter, r *http.Request, hel
 	})
 }
 
+// relatedTarget is one item a relation field points at, as a public reader sees it.
+type relatedTarget struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	Path  string `json:"path"`
+}
+
+// namedTargets returns the targets a public payload carries under one relation field.
+func namedTargets(held []content.Target) []relatedTarget {
+	named := make([]relatedTarget, len(held))
+	for i, target := range held {
+		named[i] = relatedTarget{ID: target.ID.String(), Title: target.Title, Path: target.Path}
+	}
+	return named
+}
+
 // publishedDetailOf returns the public view of an item with its targets named and addressed.
 func (s *server) publishedDetailOf(r *http.Request, c content.Content) (publishedDetail, error) {
 	targets, err := s.content.TargetsOf(r.Context(), c.ID)
@@ -259,7 +275,7 @@ func (s *server) publishedDetailOf(r *http.Request, c content.Content) (publishe
 		values[key] = value
 	}
 	for key, listed := range targets {
-		values[key] = listed
+		values[key] = namedTargets(listed)
 	}
 	return publishedDetail{
 		publishedSummary: newPublishedSummary(c),

--- a/internal/server/content.go
+++ b/internal/server/content.go
@@ -183,17 +183,25 @@ func (s *server) handleContentResolve() http.HandlerFunc {
 			respondDomainError(w, err)
 			return
 		}
-		if held.Kind == content.KindArchive {
+		switch held.Kind {
+		case content.KindArchive:
 			s.respondArchive(w, r, held)
-			return
+		case content.KindTerm:
+			s.respondTerm(w, r, held)
+		default:
+			s.respondResolvedItem(w, r, held)
 		}
-		s.respondResolvedItem(w, r, held)
 	}
 }
 
 // respondResolvedItem answers with the addressed item, or reports it unchanged.
 func (s *server) respondResolvedItem(w http.ResponseWriter, r *http.Request, held content.Address) {
 	listed, err := s.types.ByKey(r.Context(), held.Item.Type)
+	if err != nil {
+		respondDomainError(w, err)
+		return
+	}
+	detail, err := s.publishedDetailOf(r, held.Item)
 	if err != nil {
 		respondDomainError(w, err)
 		return
@@ -207,11 +215,56 @@ func (s *server) respondResolvedItem(w http.ResponseWriter, r *http.Request, hel
 	authkit.Respond(w, http.StatusOK, resolvedAddress{
 		Kind: string(content.KindItem),
 		Type: newServedType(listed),
+		Item: &detail,
+	})
+}
+
+// publishedDetailOf returns the public view of an item with its targets named and addressed.
+func (s *server) publishedDetailOf(r *http.Request, c content.Content) (publishedDetail, error) {
+	targets, err := s.content.TargetsOf(r.Context(), c.ID)
+	if err != nil {
+		return publishedDetail{}, err
+	}
+	held := heldValues(c.Fields)
+	values := make(content.Values, len(held)+len(targets))
+	for key, value := range held {
+		values[key] = value
+	}
+	for key, listed := range targets {
+		values[key] = listed
+	}
+	return publishedDetail{
+		publishedSummary: newPublishedSummary(c),
+		Content:          publichtml.Sanitize(c.Content),
+		Fields:           values,
+	}, nil
+}
+
+// respondTerm answers with the addressed item and the published content pointing at it.
+func (s *server) respondTerm(w http.ResponseWriter, r *http.Request, held content.Address) {
+	filter, err := parsePublishedFilter(r.URL.Query())
+	if err != nil {
+		authkit.RespondError(w, http.StatusBadRequest, "invalid list parameters")
+		return
+	}
+	rows, total, err := s.content.RelatedTo(r.Context(), held.Item.ID, held.Page, filter.PerPage)
+	if err != nil {
+		respondDomainError(w, err)
+		return
+	}
+	items := make([]publishedSummary, len(rows))
+	for i, c := range rows {
+		items[i] = newPublishedSummary(c)
+	}
+	authkit.Respond(w, http.StatusOK, resolvedAddress{
+		Kind: string(content.KindTerm),
+		Type: newServedType(held.Type),
 		Item: &publishedDetail{
 			publishedSummary: newPublishedSummary(held.Item),
 			Content:          publichtml.Sanitize(held.Item.Content),
 			Fields:           payloadValues(held.Item),
 		},
+		Page: &publishedPage{Items: items, Total: total, Page: held.Page, PerPage: filter.PerPage},
 	})
 }
 

--- a/internal/server/content.go
+++ b/internal/server/content.go
@@ -74,10 +74,11 @@ type publishedSummary struct {
 	UpdatedAt   time.Time `json:"updated_at"`
 }
 
-// publishedDetail adds the sanitized block markup to a summary.
+// publishedDetail adds the sanitized block markup and the field values to a summary.
 type publishedDetail struct {
 	publishedSummary
-	Content string `json:"content"`
+	Content string         `json:"content"`
+	Fields  content.Values `json:"fields"`
 }
 
 // publishedPage is one page of published summaries with the total behind it.
@@ -209,6 +210,7 @@ func (s *server) respondResolvedItem(w http.ResponseWriter, r *http.Request, hel
 		Item: &publishedDetail{
 			publishedSummary: newPublishedSummary(held.Item),
 			Content:          publichtml.Sanitize(held.Item.Content),
+			Fields:           heldValues(held.Item.Fields),
 		},
 	})
 }

--- a/internal/server/content.go
+++ b/internal/server/content.go
@@ -3,6 +3,9 @@
 package server
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -234,7 +237,11 @@ func (s *server) respondResolvedItem(w http.ResponseWriter, r *http.Request, hel
 		respondDomainError(w, err)
 		return
 	}
-	etag := contentETag(held.Item)
+	etag, err := contentETag(detail)
+	if err != nil {
+		respondDomainError(w, err)
+		return
+	}
 	w.Header().Set("ETag", etag)
 	if r.Header.Get("If-None-Match") == etag {
 		w.WriteHeader(http.StatusNotModified)
@@ -300,14 +307,15 @@ func (s *server) respondTerm(w http.ResponseWriter, r *http.Request, held conten
 	for i, c := range rows {
 		items[i] = newPublishedSummary(c)
 	}
+	detail, err := s.publishedDetailOf(r, held.Item)
+	if err != nil {
+		respondDomainError(w, err)
+		return
+	}
 	authkit.Respond(w, http.StatusOK, resolvedAddress{
 		Kind: string(content.KindTerm),
 		Type: newServedType(held.Type),
-		Item: &publishedDetail{
-			publishedSummary: newPublishedSummary(held.Item),
-			Content:          publichtml.Sanitize(held.Item.Content),
-			Fields:           payloadValues(held.Item),
-		},
+		Item: &detail,
 		Page: &publishedPage{Items: items, Total: total, Page: held.Page, PerPage: filter.PerPage},
 	})
 }
@@ -370,7 +378,12 @@ func (s *server) handlePublishedList() http.HandlerFunc {
 	}
 }
 
-// contentETag returns the validator standing for the item's current revision.
-func contentETag(c content.Content) string {
-	return `"` + strconv.FormatInt(c.UpdatedAt.UTC().UnixNano(), 36) + `"`
+// contentETag returns the validator standing for the payload a reader is served.
+func contentETag(detail publishedDetail) (string, error) {
+	encoded, err := json.Marshal(detail)
+	if err != nil {
+		return "", fmt.Errorf("server: encode content etag: %w", err)
+	}
+	sum := sha256.Sum256(encoded)
+	return `"` + hex.EncodeToString(sum[:16]) + `"`, nil
 }

--- a/internal/server/content.go
+++ b/internal/server/content.go
@@ -32,13 +32,24 @@ type contentHandshake struct {
 
 // servedType is a content type as a public reader sees it.
 type servedType struct {
-	Key          string `json:"key"`
-	SingularName string `json:"singular_label"`
-	PluralName   string `json:"plural_label"`
-	RouteWord    string `json:"route_word"`
-	Hierarchical bool   `json:"hierarchical"`
-	PageKind     string `json:"page_kind"`
-	Default      bool   `json:"default"`
+	Key          string        `json:"key"`
+	SingularName string        `json:"singular_label"`
+	PluralName   string        `json:"plural_label"`
+	RouteWord    string        `json:"route_word"`
+	Hierarchical bool          `json:"hierarchical"`
+	PageKind     string        `json:"page_kind"`
+	Default      bool          `json:"default"`
+	Fields       []servedField `json:"fields"`
+}
+
+// servedField is a field definition as a public reader sees it.
+type servedField struct {
+	Key       string `json:"key"`
+	Label     string `json:"label"`
+	Kind      string `json:"kind"`
+	RelatesTo string `json:"relates_to,omitempty"`
+	Many      bool   `json:"many"`
+	Required  bool   `json:"required"`
 }
 
 // newServedType returns the public view of a content type.
@@ -51,7 +62,24 @@ func newServedType(t content.Type) servedType {
 		Hierarchical: t.Hierarchical,
 		PageKind:     string(t.PageKind),
 		Default:      t.Default,
+		Fields:       servedFields(t),
 	}
+}
+
+// servedFields returns the type's field definitions as a public reader sees them.
+func servedFields(t content.Type) []servedField {
+	fields := make([]servedField, len(t.Fields))
+	for i, f := range t.Fields {
+		fields[i] = servedField{
+			Key:       f.Key,
+			Label:     f.Label,
+			Kind:      string(f.Kind),
+			RelatesTo: f.RelatesTo,
+			Many:      f.Many,
+			Required:  f.Required,
+		}
+	}
+	return fields
 }
 
 // resolvedAddress is what a public address holds, as a reader sees it.

--- a/internal/server/content.go
+++ b/internal/server/content.go
@@ -210,7 +210,7 @@ func (s *server) respondResolvedItem(w http.ResponseWriter, r *http.Request, hel
 		Item: &publishedDetail{
 			publishedSummary: newPublishedSummary(held.Item),
 			Content:          publichtml.Sanitize(held.Item.Content),
-			Fields:           heldValues(held.Item.Fields),
+			Fields:           payloadValues(held.Item),
 		},
 	})
 }

--- a/internal/server/content.go
+++ b/internal/server/content.go
@@ -227,17 +227,17 @@ func (s *server) handleContentResolve() http.HandlerFunc {
 
 // respondResolvedItem answers with the addressed item, or reports it unchanged.
 func (s *server) respondResolvedItem(w http.ResponseWriter, r *http.Request, held content.Address) {
-	listed, err := s.types.ByKey(r.Context(), held.Item.Type)
-	if err != nil {
-		respondDomainError(w, err)
-		return
-	}
 	detail, err := s.publishedDetailOf(r, held.Item)
 	if err != nil {
 		respondDomainError(w, err)
 		return
 	}
-	etag, err := contentETag(detail)
+	answer := resolvedAddress{
+		Kind: string(content.KindItem),
+		Type: newServedType(held.Type),
+		Item: &detail,
+	}
+	etag, err := contentETag(answer)
 	if err != nil {
 		respondDomainError(w, err)
 		return
@@ -247,11 +247,7 @@ func (s *server) respondResolvedItem(w http.ResponseWriter, r *http.Request, hel
 		w.WriteHeader(http.StatusNotModified)
 		return
 	}
-	authkit.Respond(w, http.StatusOK, resolvedAddress{
-		Kind: string(content.KindItem),
-		Type: newServedType(listed),
-		Item: &detail,
-	})
+	authkit.Respond(w, http.StatusOK, answer)
 }
 
 // relatedTarget is one item a relation field points at, as a public reader sees it.
@@ -378,9 +374,9 @@ func (s *server) handlePublishedList() http.HandlerFunc {
 	}
 }
 
-// contentETag returns the validator standing for the payload a reader is served.
-func contentETag(detail publishedDetail) (string, error) {
-	encoded, err := json.Marshal(detail)
+// contentETag returns the validator standing for the answer a reader is served.
+func contentETag(answer resolvedAddress) (string, error) {
+	encoded, err := json.Marshal(answer)
 	if err != nil {
 		return "", fmt.Errorf("server: encode content etag: %w", err)
 	}

--- a/internal/server/content_admin.go
+++ b/internal/server/content_admin.go
@@ -51,7 +51,8 @@ type contentResponse struct {
 
 type contentDetailResponse struct {
 	contentResponse
-	Content string `json:"content"`
+	Content string         `json:"content"`
+	Fields  content.Values `json:"fields"`
 }
 
 type contentListResponse struct {
@@ -239,5 +240,6 @@ func (s *server) respondContent(w http.ResponseWriter, r *http.Request, status i
 	authkit.Respond(w, status, contentDetailResponse{
 		contentResponse: newContentResponse(c, names[c.AuthorID]),
 		Content:         c.Content,
+		Fields:          heldValues(c.Fields),
 	})
 }

--- a/internal/server/content_admin.go
+++ b/internal/server/content_admin.go
@@ -240,6 +240,6 @@ func (s *server) respondContent(w http.ResponseWriter, r *http.Request, status i
 	authkit.Respond(w, status, contentDetailResponse{
 		contentResponse: newContentResponse(c, names[c.AuthorID]),
 		Content:         c.Content,
-		Fields:          heldValues(c.Fields),
+		Fields:          payloadValues(c),
 	})
 }

--- a/internal/server/content_helpers_test.go
+++ b/internal/server/content_helpers_test.go
@@ -167,6 +167,23 @@ func (s *fakePostStore) List(_ context.Context, f content.Filter) ([]content.Con
 	return matched[start:min(start+f.PerPage, total)], total, nil
 }
 
+// RelatedTo returns the published items pointing at the target, newest first, and the total.
+func (s *fakePostStore) RelatedTo(
+	_ context.Context, target uuid.UUID, page, perPage int,
+) ([]content.Content, int, error) {
+	matched := make([]content.Content, 0, len(s.posts))
+	for _, p := range s.ordered() {
+		if p.Status != content.StatusPublished || !pointsAt(p.Relations, target) {
+			continue
+		}
+		p.Content = ""
+		matched = append(matched, p)
+	}
+	total := len(matched)
+	start := min((page-1)*perPage, total)
+	return matched[start:min(start+perPage, total)], total, nil
+}
+
 // Update stores the post's fields and any snapshot unless an update error is injected.
 func (s *fakePostStore) Update(
 	_ context.Context, p content.Content, expectedUpdatedAt time.Time, snapshot *content.Revision, revisionCap int,
@@ -478,4 +495,37 @@ type failingUserStore struct {
 // ListUsers reports a failure.
 func (failingUserStore) ListUsers(_ context.Context) ([]gouncer.User, error) {
 	return nil, context.DeadlineExceeded
+}
+
+// pointsAt reports whether any of the item's fields names the target.
+func pointsAt(held content.Relations, target uuid.UUID) bool {
+	for _, targets := range held {
+		for _, listed := range targets {
+			if listed == target {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TargetsOf returns the published targets of active types the item points at.
+func (s *fakePostStore) TargetsOf(_ context.Context, from uuid.UUID) (content.Targets, error) {
+	held, found := s.posts[from]
+	if !found {
+		return nil, nil
+	}
+	targets := make(content.Targets)
+	for key, listed := range held.Relations {
+		for _, id := range listed {
+			pointed, stored := s.posts[id]
+			if !stored || pointed.Status != content.StatusPublished {
+				continue
+			}
+			targets[key] = append(targets[key], content.Target{
+				ID: pointed.ID, Title: pointed.Title, Path: pointed.Path,
+			})
+		}
+	}
+	return targets, nil
 }

--- a/internal/server/content_values_test.go
+++ b/internal/server/content_values_test.go
@@ -498,3 +498,174 @@ func TestContentPatchRefusesTargetsTheRegistryTurnsAway(t *testing.T) {
 		})
 	}
 }
+
+// termAnswerBody is a resolved term page as a public reader sees it.
+type termAnswerBody struct {
+	Kind string `json:"kind"`
+	Type struct {
+		Key      string `json:"key"`
+		PageKind string `json:"page_kind"`
+	} `json:"type"`
+	Item *struct {
+		Title string `json:"title"`
+	} `json:"item"`
+	Page *struct {
+		Items []struct {
+			Title string `json:"title"`
+		} `json:"items"`
+		Total   int `json:"total"`
+		Page    int `json:"page"`
+		PerPage int `json:"per_page"`
+	} `json:"page"`
+}
+
+// termTypeServer returns a handler over a registry holding a category type serving term pages.
+func termTypeServer(t *testing.T) http.Handler {
+	t.Helper()
+	handler := authedTypeServer(t)
+	declaredRelation(t, handler)
+	recorder := doRequest(t, handler, http.MethodPatch, "/api/types/category", `{"page_kind":"archive"}`)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("serving term pages: %d: %s", recorder.Code, recorder.Body.String())
+	}
+	return handler
+}
+
+// publishItemAt takes stored content public through the admin API.
+func publishItemAt(t *testing.T, handler http.Handler, held contentValuesBody) contentValuesBody {
+	t.Helper()
+	body := fmt.Sprintf(`{"updated_at":%q,"status":"published"}`, held.UpdatedAt)
+	recorder := doRequest(t, handler, http.MethodPatch, "/api/content/"+held.ID, body)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("publishing: %d: %s", recorder.Code, recorder.Body.String())
+	}
+	return decodeBody[contentValuesBody](t, recorder)
+}
+
+func TestResolveAnswersATermPage(t *testing.T) {
+	t.Parallel()
+
+	handler := termTypeServer(t)
+	news := publishItemAt(t, handler, storedCategoryItem(t, handler))
+	post := draftedPost(t, handler)
+	filed := patchValues(t, handler, post, fmt.Sprintf(`{"categories":[%q]}`, news.ID))
+	publishItemAt(t, handler, filed)
+
+	recorder := doRequest(t, handler, http.MethodGet, "/api/content/v1/resolve?path=categories/news", "")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	answer := decodeBody[termAnswerBody](t, recorder)
+	if answer.Kind != "term" || answer.Type.Key != "category" {
+		t.Fatalf("answer = %+v, want a term page of the category type", answer)
+	}
+	if answer.Item == nil || answer.Item.Title != "News" {
+		t.Fatalf("answer item = %v, want the category itself", answer.Item)
+	}
+	if answer.Page == nil || len(answer.Page.Items) != 1 || answer.Page.Items[0].Title != "Hello world" {
+		t.Errorf("answer page = %+v, want the post pointing at it", answer.Page)
+	}
+}
+
+func TestResolveGivesATermPageNoValidator(t *testing.T) {
+	t.Parallel()
+
+	handler := termTypeServer(t)
+	publishItemAt(t, handler, storedCategoryItem(t, handler))
+
+	recorder := doRequest(t, handler, http.MethodGet, "/api/content/v1/resolve?path=categories/news", "")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if held := recorder.Header().Get("ETag"); held != "" {
+		t.Errorf("the term page carries the validator %q, want none", held)
+	}
+}
+
+func TestResolvePagesATermPage(t *testing.T) {
+	t.Parallel()
+
+	handler := termTypeServer(t)
+	news := publishItemAt(t, handler, storedCategoryItem(t, handler))
+	post := draftedPost(t, handler)
+	filed := patchValues(t, handler, post, fmt.Sprintf(`{"categories":[%q]}`, news.ID))
+	publishItemAt(t, handler, filed)
+
+	recorder := doRequest(t, handler, http.MethodGet,
+		"/api/content/v1/resolve?path=categories/news/page/2&per_page=1", "")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	answer := decodeBody[termAnswerBody](t, recorder)
+	if answer.Kind != "term" || answer.Page == nil || answer.Page.Page != 2 {
+		t.Errorf("answer = %+v, want the second page of the term", answer)
+	}
+}
+
+func TestResolveKeepsASingleItemOffThePageWord(t *testing.T) {
+	t.Parallel()
+
+	handler := termTypeServer(t)
+	publishItemAt(t, handler, draftedPost(t, handler))
+
+	recorder := doRequest(t, handler, http.MethodGet,
+		"/api/content/v1/resolve?path=hello-world/page/2", "")
+
+	if recorder.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d for a page suffix on a single item", recorder.Code, http.StatusNotFound)
+	}
+}
+
+func TestResolveCarriesRelationSummaries(t *testing.T) {
+	t.Parallel()
+
+	handler := termTypeServer(t)
+	news := publishItemAt(t, handler, storedCategoryItem(t, handler))
+	post := draftedPost(t, handler)
+	filed := patchValues(t, handler, post, fmt.Sprintf(`{"categories":[%q]}`, news.ID))
+	publishItemAt(t, handler, filed)
+
+	recorder := doRequest(t, handler, http.MethodGet, "/api/content/v1/resolve?path=hello-world", "")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	answer := decodeBody[struct {
+		Item struct {
+			Fields map[string][]struct {
+				ID    string `json:"id"`
+				Title string `json:"title"`
+				Path  string `json:"path"`
+			} `json:"fields"`
+		} `json:"item"`
+	}](t, recorder)
+	held := answer.Item.Fields["categories"]
+	if len(held) != 1 {
+		t.Fatalf("the public item holds %v in categories, want the target it points at", answer.Item.Fields)
+	}
+	if held[0].Title != "News" || held[0].Path != "categories/news" {
+		t.Errorf("the target reads %+v, want the category named and addressed", held[0])
+	}
+}
+
+func TestResolveLeavesAnUnpublishedTargetOut(t *testing.T) {
+	t.Parallel()
+
+	handler := termTypeServer(t)
+	news := storedCategoryItem(t, handler)
+	post := draftedPost(t, handler)
+	filed := patchValues(t, handler, post, fmt.Sprintf(`{"categories":[%q]}`, news.ID))
+	publishItemAt(t, handler, filed)
+
+	recorder := doRequest(t, handler, http.MethodGet, "/api/content/v1/resolve?path=hello-world", "")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if body := recorder.Body.String(); containsWord(body, "News") {
+		t.Errorf("the public item names an unpublished target: %s", body)
+	}
+}

--- a/internal/server/content_values_test.go
+++ b/internal/server/content_values_test.go
@@ -566,11 +566,11 @@ func TestResolveAnswersATermPage(t *testing.T) {
 }
 
 // resolvedValidator returns the entity tag a public read of the address carries.
-func resolvedValidator(t *testing.T, handler http.Handler, path string) string {
+func resolvedValidator(t *testing.T, handler http.Handler) string {
 	t.Helper()
-	recorder := doRequest(t, handler, http.MethodGet, "/api/content/v1/resolve?path="+path, "")
+	recorder := doRequest(t, handler, http.MethodGet, "/api/content/v1/resolve?path=hello-world", "")
 	if recorder.Code != http.StatusOK {
-		t.Fatalf("resolving %q: %d: %s", path, recorder.Code, recorder.Body.String())
+		t.Fatalf("resolving the post: %d: %s", recorder.Code, recorder.Body.String())
 	}
 	return recorder.Header().Get("ETag")
 }
@@ -615,15 +615,29 @@ func TestResolveChangesTheValidatorWhenATargetIsRenamed(t *testing.T) {
 	news := publishItemAt(t, handler, storedCategoryItem(t, handler))
 	filed := patchValues(t, handler, draftedPost(t, handler), fmt.Sprintf(`{"categories":[%q]}`, news.ID))
 	publishItemAt(t, handler, filed)
-	before := resolvedValidator(t, handler, "hello-world")
+	before := resolvedValidator(t, handler)
 
 	renamed := fmt.Sprintf(`{"updated_at":%q,"title":"Headlines"}`, news.UpdatedAt)
 	if held := doRequest(t, handler, http.MethodPatch, "/api/content/"+news.ID, renamed); held.Code != http.StatusOK {
 		t.Fatalf("renaming the target: %d: %s", held.Code, held.Body.String())
 	}
 
-	if after := resolvedValidator(t, handler, "hello-world"); after == before {
+	if after := resolvedValidator(t, handler); after == before {
 		t.Errorf("the validator stayed %q, want the renamed target to have changed it", after)
+	}
+}
+
+func TestResolveChangesTheValidatorWhenAFieldIsDeclared(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	publishItemAt(t, handler, draftedPost(t, handler))
+	before := resolvedValidator(t, handler)
+
+	declaredOn(t, handler, `{"key":"subtitle","label":"Subtitle","kind":"text"}`)
+
+	if after := resolvedValidator(t, handler); after == before {
+		t.Errorf("the validator stayed %q, want the declared field to have changed it", after)
 	}
 }
 

--- a/internal/server/content_values_test.go
+++ b/internal/server/content_values_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/gopherium/gophenberg/internal/content"
@@ -28,9 +29,15 @@ type autosaveValuesBody struct {
 // declaredOn adds a field definition to the post type through the admin API.
 func declaredOn(t *testing.T, handler http.Handler, body string) {
 	t.Helper()
-	recorder := doRequest(t, handler, http.MethodPost, "/api/types/post/fields", body)
+	declaredOnType(t, handler, content.TypePost, body)
+}
+
+// declaredOnType adds a field definition to the named type through the admin API.
+func declaredOnType(t *testing.T, handler http.Handler, typeKey, body string) {
+	t.Helper()
+	recorder := doRequest(t, handler, http.MethodPost, "/api/types/"+typeKey+"/fields", body)
 	if recorder.Code != http.StatusCreated {
-		t.Fatalf("declaring a field: %d: %s", recorder.Code, recorder.Body.String())
+		t.Fatalf("declaring a field on %q: %d: %s", typeKey, recorder.Code, recorder.Body.String())
 	}
 }
 
@@ -161,7 +168,7 @@ func TestContentPatchRefusesPublishingWithoutARequiredField(t *testing.T) {
 	if recorder.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusUnprocessableEntity, recorder.Body.String())
 	}
-	if body := recorder.Body.String(); !containsWord(body, "color") {
+	if body := recorder.Body.String(); !strings.Contains(body, "color") {
 		t.Errorf("body = %s, want the field named", body)
 	}
 }
@@ -236,16 +243,6 @@ func TestAutosaveRefusesAnUnknownField(t *testing.T) {
 	if recorder.Code != http.StatusUnprocessableEntity {
 		t.Errorf("status = %d, want %d: %s", recorder.Code, http.StatusUnprocessableEntity, recorder.Body.String())
 	}
-}
-
-// containsWord reports whether the body names the word.
-func containsWord(body, word string) bool {
-	for i := 0; i+len(word) <= len(body); i++ {
-		if body[i:i+len(word)] == word {
-			return true
-		}
-	}
-	return false
 }
 
 func TestRevisionDetailCarriesFieldValues(t *testing.T) {
@@ -568,6 +565,68 @@ func TestResolveAnswersATermPage(t *testing.T) {
 	}
 }
 
+// resolvedValidator returns the entity tag a public read of the address carries.
+func resolvedValidator(t *testing.T, handler http.Handler, path string) string {
+	t.Helper()
+	recorder := doRequest(t, handler, http.MethodGet, "/api/content/v1/resolve?path="+path, "")
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("resolving %q: %d: %s", path, recorder.Code, recorder.Body.String())
+	}
+	return recorder.Header().Get("ETag")
+}
+
+func TestResolveNamesATermsRelationsTheWayAnItemDoes(t *testing.T) {
+	t.Parallel()
+
+	handler := termTypeServer(t)
+	declaredOnType(t, handler, "category",
+		`{"key":"picks","label":"Picks","kind":"relation","relates_to":"post","many":true}`)
+	post := publishItemAt(t, handler, draftedPost(t, handler))
+	picked := patchValues(t, handler, storedCategoryItem(t, handler), fmt.Sprintf(`{"picks":[%q]}`, post.ID))
+	publishItemAt(t, handler, picked)
+
+	recorder := doRequest(t, handler, http.MethodGet, "/api/content/v1/resolve?path=categories/news", "")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	answer := decodeBody[struct {
+		Item struct {
+			Fields map[string][]struct {
+				ID    string `json:"id"`
+				Title string `json:"title"`
+				Path  string `json:"path"`
+			} `json:"fields"`
+		} `json:"item"`
+	}](t, recorder)
+	held := answer.Item.Fields["picks"]
+	if len(held) != 1 {
+		t.Fatalf("the term holds %v in picks, want the target it points at", answer.Item.Fields)
+	}
+	if held[0].Title != "Hello world" || held[0].Path != "hello-world" {
+		t.Errorf("the target reads %+v, want the post named and addressed as an item response names it", held[0])
+	}
+}
+
+func TestResolveChangesTheValidatorWhenATargetIsRenamed(t *testing.T) {
+	t.Parallel()
+
+	handler := termTypeServer(t)
+	news := publishItemAt(t, handler, storedCategoryItem(t, handler))
+	filed := patchValues(t, handler, draftedPost(t, handler), fmt.Sprintf(`{"categories":[%q]}`, news.ID))
+	publishItemAt(t, handler, filed)
+	before := resolvedValidator(t, handler, "hello-world")
+
+	renamed := fmt.Sprintf(`{"updated_at":%q,"title":"Headlines"}`, news.UpdatedAt)
+	if held := doRequest(t, handler, http.MethodPatch, "/api/content/"+news.ID, renamed); held.Code != http.StatusOK {
+		t.Fatalf("renaming the target: %d: %s", held.Code, held.Body.String())
+	}
+
+	if after := resolvedValidator(t, handler, "hello-world"); after == before {
+		t.Errorf("the validator stayed %q, want the renamed target to have changed it", after)
+	}
+}
+
 func TestResolveGivesATermPageNoValidator(t *testing.T) {
 	t.Parallel()
 
@@ -665,7 +724,7 @@ func TestResolveLeavesAnUnpublishedTargetOut(t *testing.T) {
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
 	}
-	if body := recorder.Body.String(); containsWord(body, "News") {
+	if body := recorder.Body.String(); strings.Contains(body, "News") {
 		t.Errorf("the public item names an unpublished target: %s", body)
 	}
 }
@@ -724,11 +783,11 @@ func TestResolveNamesRelationSummariesTheWayAReaderReadsThem(t *testing.T) {
 	}
 	body := recorder.Body.String()
 	for _, member := range []string{`"id":`, `"title":`, `"path":`} {
-		if !containsWord(body, member) {
+		if !strings.Contains(body, member) {
 			t.Errorf("the target names no %s member: %s", member, body)
 		}
 	}
-	if containsWord(body, `"ID":`) {
+	if strings.Contains(body, `"ID":`) {
 		t.Errorf("the target names a Go field rather than a wire member: %s", body)
 	}
 }

--- a/internal/server/content_values_test.go
+++ b/internal/server/content_values_test.go
@@ -3,6 +3,7 @@
 package server_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -356,5 +357,144 @@ func TestContentPatchRefusesClearingAnUnknownField(t *testing.T) {
 
 	if recorder.Code != http.StatusUnprocessableEntity {
 		t.Errorf("status = %d, want a null against an undeclared key refused like any other", recorder.Code)
+	}
+}
+
+// declaredRelation adds a category type and a relation field pointing at it.
+func declaredRelation(t *testing.T, handler http.Handler) {
+	t.Helper()
+	created := doRequest(t, handler, http.MethodPost, "/api/types",
+		`{"key":"category","singular_label":"Category","plural_label":"Categories","route_word":"categories"}`)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("registering the category type: %d: %s", created.Code, created.Body.String())
+	}
+	declaredOn(t, handler,
+		`{"key":"categories","label":"Categories","kind":"relation","relates_to":"category","many":true}`)
+}
+
+// storedCategoryItem stores one category item and returns it.
+func storedCategoryItem(t *testing.T, handler http.Handler) contentValuesBody {
+	t.Helper()
+	recorder := doRequest(t, handler, http.MethodPost, "/api/content", `{"type":"category","title":"News"}`)
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("storing the category: %d: %s", recorder.Code, recorder.Body.String())
+	}
+	return decodeBody[contentValuesBody](t, recorder)
+}
+
+func TestAutosaveAcceptsTheFieldsTheItemAnswersWith(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	declaredRelation(t, handler)
+	news := storedCategoryItem(t, handler)
+	held := draftedPost(t, handler)
+	filed := patchValues(t, handler, held, fmt.Sprintf(`{"categories":[%q]}`, news.ID))
+
+	sent, err := json.Marshal(map[string]any{
+		"updated_at": filed.UpdatedAt,
+		"title":      "Hello again",
+		"fields":     filed.Fields,
+	})
+	if err != nil {
+		t.Fatalf("building the buffer: %v, want nil", err)
+	}
+	recorder := doRequest(t, handler, http.MethodPost, "/api/content/"+held.ID+"/autosave", string(sent))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want the buffer the item answered with accepted: %s",
+			recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestContentPatchLeavesTheVersionWhenTheTargetsDidNotMove(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	declaredRelation(t, handler)
+	news := storedCategoryItem(t, handler)
+	held := draftedPost(t, handler)
+	filed := patchValues(t, handler, held, fmt.Sprintf(`{"categories":[%q]}`, news.ID))
+
+	again := patchValues(t, handler, filed, fmt.Sprintf(`{"categories":[%q]}`, news.ID))
+
+	if again.UpdatedAt != filed.UpdatedAt {
+		t.Errorf("updated_at moved to %q, want a save holding the same targets to change nothing", again.UpdatedAt)
+	}
+}
+
+func TestContentPatchKeepsNoRevisionForATargetMove(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	declaredRelation(t, handler)
+	news := storedCategoryItem(t, handler)
+	held := draftedPost(t, handler)
+
+	patchValues(t, handler, held, fmt.Sprintf(`{"categories":[%q]}`, news.ID))
+
+	listed := doRequest(t, handler, http.MethodGet, "/api/content/"+held.ID+"/revisions", "")
+	revisions := decodeBody[struct {
+		Items []struct {
+			ID string `json:"id"`
+		} `json:"items"`
+	}](t, listed)
+	if len(revisions.Items) != 0 {
+		t.Errorf("the item holds %d revisions, want none for a change a snapshot cannot carry",
+			len(revisions.Items))
+	}
+}
+
+func TestContentPatchRefusesTargetsTheRegistryTurnsAway(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		field   string
+		targets func(t *testing.T, handler http.Handler) string
+	}{
+		"a target that is not an identity": {
+			field:   "categories",
+			targets: func(*testing.T, http.Handler) string { return `["news"]` },
+		},
+		"a target that is not a list": {
+			field:   "categories",
+			targets: func(*testing.T, http.Handler) string { return `"news"` },
+		},
+		"a target named twice": {
+			field: "categories",
+			targets: func(t *testing.T, handler http.Handler) string {
+				t.Helper()
+				news := storedCategoryItem(t, handler)
+				return fmt.Sprintf(`[%q,%q]`, news.ID, news.ID)
+			},
+		},
+		"a list where the field holds one": {
+			field: "series",
+			targets: func(t *testing.T, handler http.Handler) string {
+				t.Helper()
+				first, second := storedCategoryItem(t, handler), storedCategoryItem(t, handler)
+				return fmt.Sprintf(`[%q,%q]`, first.ID, second.ID)
+			},
+		},
+	}
+	for name, held := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := authedTypeServer(t)
+			declaredRelation(t, handler)
+			declaredOn(t, handler,
+				`{"key":"series","label":"Series","kind":"relation","relates_to":"category"}`)
+			post := draftedPost(t, handler)
+			asked := held.targets(t, handler)
+
+			body := fmt.Sprintf(`{"updated_at":%q,"fields":{%q:%s}}`, post.UpdatedAt, held.field, asked)
+			recorder := doRequest(t, handler, http.MethodPatch, "/api/content/"+post.ID, body)
+
+			if recorder.Code != http.StatusUnprocessableEntity {
+				t.Errorf("status = %d, want %d: %s",
+					recorder.Code, http.StatusUnprocessableEntity, recorder.Body.String())
+			}
+		})
 	}
 }

--- a/internal/server/content_values_test.go
+++ b/internal/server/content_values_test.go
@@ -707,3 +707,28 @@ func TestHandshakeCarriesFieldDefinitions(t *testing.T) {
 	}
 	t.Fatal("the handshake advertises no post type")
 }
+
+func TestResolveNamesRelationSummariesTheWayAReaderReadsThem(t *testing.T) {
+	t.Parallel()
+
+	handler := termTypeServer(t)
+	news := publishItemAt(t, handler, storedCategoryItem(t, handler))
+	post := draftedPost(t, handler)
+	filed := patchValues(t, handler, post, fmt.Sprintf(`{"categories":[%q]}`, news.ID))
+	publishItemAt(t, handler, filed)
+
+	recorder := doRequest(t, handler, http.MethodGet, "/api/content/v1/resolve?path=hello-world", "")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	body := recorder.Body.String()
+	for _, member := range []string{`"id":`, `"title":`, `"path":`} {
+		if !containsWord(body, member) {
+			t.Errorf("the target names no %s member: %s", member, body)
+		}
+	}
+	if containsWord(body, `"ID":`) {
+		t.Errorf("the target names a Go field rather than a wire member: %s", body)
+	}
+}

--- a/internal/server/content_values_test.go
+++ b/internal/server/content_values_test.go
@@ -669,3 +669,41 @@ func TestResolveLeavesAnUnpublishedTargetOut(t *testing.T) {
 		t.Errorf("the public item names an unpublished target: %s", body)
 	}
 }
+
+func TestHandshakeCarriesFieldDefinitions(t *testing.T) {
+	t.Parallel()
+
+	handler := termTypeServer(t)
+	declaredOn(t, handler, `{"key":"color","label":"Color","kind":"text","required":true}`)
+
+	recorder := doRequest(t, handler, http.MethodGet, "/api/content/v1", "")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	advertised := decodeBody[struct {
+		Types []struct {
+			Key    string `json:"key"`
+			Fields []struct {
+				Key       string `json:"key"`
+				Label     string `json:"label"`
+				Kind      string `json:"kind"`
+				RelatesTo string `json:"relates_to"`
+				Many      bool   `json:"many"`
+				Required  bool   `json:"required"`
+			} `json:"fields"`
+		} `json:"types"`
+	}](t, recorder)
+	for _, listed := range advertised.Types {
+		if listed.Key != content.TypePost {
+			continue
+		}
+		for _, held := range listed.Fields {
+			if held.Key == "color" && held.Kind == "text" && held.Required {
+				return
+			}
+		}
+		t.Fatalf("the post type advertises %+v, want its declared field", listed.Fields)
+	}
+	t.Fatal("the handshake advertises no post type")
+}

--- a/internal/server/content_values_test.go
+++ b/internal/server/content_values_test.go
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gopherium/gophenberg/internal/content"
+)
+
+// contentValuesBody is the item shape a fields test reads.
+type contentValuesBody struct {
+	ID        string         `json:"id"`
+	Status    string         `json:"status"`
+	UpdatedAt string         `json:"updated_at"`
+	Fields    map[string]any `json:"fields"`
+}
+
+// autosaveValuesBody is the autosave shape a fields test reads.
+type autosaveValuesBody struct {
+	Target string         `json:"target"`
+	Fields map[string]any `json:"fields"`
+}
+
+// declaredOn adds a field definition to the post type through the admin API.
+func declaredOn(t *testing.T, handler http.Handler, body string) {
+	t.Helper()
+	recorder := doRequest(t, handler, http.MethodPost, "/api/types/post/fields", body)
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("declaring a field: %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+// draftedPost stores a draft post and returns it as the admin API reported it.
+func draftedPost(t *testing.T, handler http.Handler) contentValuesBody {
+	t.Helper()
+	recorder := doRequest(t, handler, http.MethodPost, "/api/content", `{"type":"post","title":"Hello world"}`)
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("storing the draft: %d: %s", recorder.Code, recorder.Body.String())
+	}
+	return decodeBody[contentValuesBody](t, recorder)
+}
+
+// patchValues sends a fields edit against the item's version.
+func patchValues(t *testing.T, handler http.Handler, held contentValuesBody, fields string) contentValuesBody {
+	t.Helper()
+	body := fmt.Sprintf(`{"updated_at":%q,"fields":%s}`, held.UpdatedAt, fields)
+	recorder := doRequest(t, handler, http.MethodPatch, "/api/content/"+held.ID, body)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("saving the values: %d: %s", recorder.Code, recorder.Body.String())
+	}
+	return decodeBody[contentValuesBody](t, recorder)
+}
+
+func TestContentPatchHoldsFieldValues(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	declaredOn(t, handler, `{"key":"color","label":"Color","kind":"text"}`)
+	held := draftedPost(t, handler)
+
+	saved := patchValues(t, handler, held, `{"color":"red"}`)
+
+	if saved.Fields["color"] != "red" {
+		t.Fatalf("fields = %v, want the value carried back", saved.Fields)
+	}
+	read := doRequest(t, handler, http.MethodGet, "/api/content/"+held.ID, "")
+	if got := decodeBody[contentValuesBody](t, read).Fields["color"]; got != "red" {
+		t.Errorf("the stored item holds %v, want the value", got)
+	}
+}
+
+func TestContentPatchLeavesAbsentFieldsAlone(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	declaredOn(t, handler, `{"key":"color","label":"Color","kind":"text"}`)
+	declaredOn(t, handler, `{"key":"doors","label":"Doors","kind":"number"}`)
+	held := patchValues(t, handler, draftedPost(t, handler), `{"color":"red","doors":4}`)
+
+	saved := patchValues(t, handler, held, `{"color":"blue"}`)
+
+	if saved.Fields["color"] != "blue" {
+		t.Errorf("fields = %v, want the named value replaced", saved.Fields)
+	}
+	if saved.Fields["doors"] != float64(4) {
+		t.Errorf("fields = %v, want the absent key left alone", saved.Fields)
+	}
+}
+
+func TestContentPatchClearsAFieldWithNull(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	declaredOn(t, handler, `{"key":"color","label":"Color","kind":"text"}`)
+	held := patchValues(t, handler, draftedPost(t, handler), `{"color":"red"}`)
+
+	saved := patchValues(t, handler, held, `{"color":null}`)
+
+	if _, holds := saved.Fields["color"]; holds {
+		t.Errorf("fields = %v, want the null to have cleared the key", saved.Fields)
+	}
+}
+
+func TestContentPatchRefusesAnUnknownField(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	held := draftedPost(t, handler)
+
+	body := fmt.Sprintf(`{"updated_at":%q,"fields":{"finish":"matte"}}`, held.UpdatedAt)
+	recorder := doRequest(t, handler, http.MethodPatch, "/api/content/"+held.ID, body)
+
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want %d: %s", recorder.Code, http.StatusUnprocessableEntity, recorder.Body.String())
+	}
+}
+
+func TestContentPatchRefusesTheWrongShape(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	declaredOn(t, handler, `{"key":"doors","label":"Doors","kind":"number"}`)
+	held := draftedPost(t, handler)
+
+	body := fmt.Sprintf(`{"updated_at":%q,"fields":{"doors":"many"}}`, held.UpdatedAt)
+	recorder := doRequest(t, handler, http.MethodPatch, "/api/content/"+held.ID, body)
+
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want %d: %s", recorder.Code, http.StatusUnprocessableEntity, recorder.Body.String())
+	}
+}
+
+func TestContentPatchKeepsADraftWithoutARequiredField(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	declaredOn(t, handler, `{"key":"color","label":"Color","kind":"text","required":true}`)
+	held := draftedPost(t, handler)
+
+	saved := patchValues(t, handler, held, `{}`)
+
+	if saved.Status != string(content.StatusDraft) {
+		t.Errorf("status = %q, want the draft saved", saved.Status)
+	}
+}
+
+func TestContentPatchRefusesPublishingWithoutARequiredField(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	declaredOn(t, handler, `{"key":"color","label":"Color","kind":"text","required":true}`)
+	held := draftedPost(t, handler)
+
+	body := fmt.Sprintf(`{"updated_at":%q,"status":"published"}`, held.UpdatedAt)
+	recorder := doRequest(t, handler, http.MethodPatch, "/api/content/"+held.ID, body)
+
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusUnprocessableEntity, recorder.Body.String())
+	}
+	if body := recorder.Body.String(); !containsWord(body, "color") {
+		t.Errorf("body = %s, want the field named", body)
+	}
+}
+
+func TestContentPatchPublishesWithARequiredFieldFilled(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	declaredOn(t, handler, `{"key":"color","label":"Color","kind":"text","required":true}`)
+	held := draftedPost(t, handler)
+
+	body := fmt.Sprintf(`{"updated_at":%q,"status":"published","fields":{"color":"red"}}`, held.UpdatedAt)
+	recorder := doRequest(t, handler, http.MethodPatch, "/api/content/"+held.ID, body)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if saved := decodeBody[contentValuesBody](t, recorder); saved.Status != string(content.StatusPublished) {
+		t.Errorf("status = %q, want the item published", saved.Status)
+	}
+}
+
+func TestContentPatchRefusesEmptyingARequiredFieldOnAPublishedItem(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	declaredOn(t, handler, `{"key":"color","label":"Color","kind":"text","required":true}`)
+	held := draftedPost(t, handler)
+	published := patchValues(t, handler, held, `{"color":"red"}`)
+	body := fmt.Sprintf(`{"updated_at":%q,"status":"published"}`, published.UpdatedAt)
+	promoted := doRequest(t, handler, http.MethodPatch, "/api/content/"+held.ID, body)
+	if promoted.Code != http.StatusOK {
+		t.Fatalf("publishing: %d: %s", promoted.Code, promoted.Body.String())
+	}
+	live := decodeBody[contentValuesBody](t, promoted)
+
+	cleared := fmt.Sprintf(`{"updated_at":%q,"fields":{"color":null}}`, live.UpdatedAt)
+	recorder := doRequest(t, handler, http.MethodPatch, "/api/content/"+held.ID, cleared)
+
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want the published item kept whole", recorder.Code)
+	}
+}
+
+func TestAutosaveCarriesFieldValues(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	declaredOn(t, handler, `{"key":"color","label":"Color","kind":"text"}`)
+	held := draftedPost(t, handler)
+
+	body := fmt.Sprintf(`{"updated_at":%q,"title":"Hello world","fields":{"color":"red"}}`, held.UpdatedAt)
+	recorder := doRequest(t, handler, http.MethodPost, "/api/content/"+held.ID+"/autosave", body)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if saved := decodeBody[autosaveValuesBody](t, recorder); saved.Fields["color"] != "red" {
+		t.Errorf("fields = %v, want the buffer's values", saved.Fields)
+	}
+}
+
+func TestAutosaveRefusesAnUnknownField(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	held := draftedPost(t, handler)
+
+	body := fmt.Sprintf(`{"updated_at":%q,"title":"Hello world","fields":{"finish":"matte"}}`, held.UpdatedAt)
+	recorder := doRequest(t, handler, http.MethodPost, "/api/content/"+held.ID+"/autosave", body)
+
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want %d: %s", recorder.Code, http.StatusUnprocessableEntity, recorder.Body.String())
+	}
+}
+
+// containsWord reports whether the body names the word.
+func containsWord(body, word string) bool {
+	for i := 0; i+len(word) <= len(body); i++ {
+		if body[i:i+len(word)] == word {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRevisionDetailCarriesFieldValues(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	declaredOn(t, handler, `{"key":"color","label":"Color","kind":"text"}`)
+	held := patchValues(t, handler, draftedPost(t, handler), `{"color":"red"}`)
+	patchValues(t, handler, held, `{"color":"blue"}`)
+
+	listed := doRequest(t, handler, http.MethodGet, "/api/content/"+held.ID+"/revisions", "")
+	if listed.Code != http.StatusOK {
+		t.Fatalf("listing the revisions: %d: %s", listed.Code, listed.Body.String())
+	}
+	type revisionRow struct {
+		ID string `json:"id"`
+	}
+	revisions := decodeBody[struct {
+		Items []revisionRow `json:"items"`
+	}](t, listed)
+	if len(revisions.Items) == 0 {
+		t.Fatal("the item holds no revisions, want the snapshot the value change took")
+	}
+
+	detail := doRequest(t, handler, http.MethodGet,
+		"/api/content/"+held.ID+"/revisions/"+revisions.Items[0].ID, "")
+
+	if detail.Code != http.StatusOK {
+		t.Fatalf("reading the revision: %d: %s", detail.Code, detail.Body.String())
+	}
+	if got := decodeBody[contentValuesBody](t, detail).Fields["color"]; got != "red" {
+		t.Errorf("the revision holds %v in color, want the value as it stood", got)
+	}
+}
+
+func TestAutosaveWithoutFieldsKeepsTheStoredValues(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	declaredOn(t, handler, `{"key":"color","label":"Color","kind":"text"}`)
+	held := patchValues(t, handler, draftedPost(t, handler), `{"color":"red"}`)
+
+	body := fmt.Sprintf(`{"updated_at":%q,"title":"Hello again"}`, held.UpdatedAt)
+	recorder := doRequest(t, handler, http.MethodPost, "/api/content/"+held.ID+"/autosave", body)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	read := doRequest(t, handler, http.MethodGet, "/api/content/"+held.ID, "")
+	if got := decodeBody[contentValuesBody](t, read).Fields["color"]; got != "red" {
+		t.Errorf("the stored item holds %v in color, want a buffer naming no fields to have left them alone", got)
+	}
+}
+
+func TestContentPatchMovesTheVersionWhenOnlyValuesChange(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	declaredOn(t, handler, `{"key":"color","label":"Color","kind":"text"}`)
+	held := draftedPost(t, handler)
+
+	saved := patchValues(t, handler, held, `{"color":"red"}`)
+
+	if saved.UpdatedAt == held.UpdatedAt {
+		t.Fatalf("updated_at stayed %q, want a values write to move the version", saved.UpdatedAt)
+	}
+	stale := fmt.Sprintf(`{"updated_at":%q,"fields":{"color":"blue"}}`, held.UpdatedAt)
+	recorder := doRequest(t, handler, http.MethodPatch, "/api/content/"+held.ID, stale)
+	if recorder.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d for a save against the old version", recorder.Code, http.StatusConflict)
+	}
+}
+
+func TestPublicItemCarriesFieldValues(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	declaredOn(t, handler, `{"key":"color","label":"Color","kind":"text"}`)
+	held := patchValues(t, handler, draftedPost(t, handler), `{"color":"red"}`)
+	body := fmt.Sprintf(`{"updated_at":%q,"status":"published"}`, held.UpdatedAt)
+	published := doRequest(t, handler, http.MethodPatch, "/api/content/"+held.ID, body)
+	if published.Code != http.StatusOK {
+		t.Fatalf("publishing: %d: %s", published.Code, published.Body.String())
+	}
+
+	recorder := doRequest(t, handler, http.MethodGet, "/api/content/v1/resolve?path=hello-world", "")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	answer := decodeBody[struct {
+		Item struct {
+			Fields map[string]any `json:"fields"`
+		} `json:"item"`
+	}](t, recorder)
+	if answer.Item.Fields["color"] != "red" {
+		t.Errorf("the public item holds %v in color, want the value a theme reads", answer.Item.Fields)
+	}
+}
+
+func TestContentPatchRefusesClearingAnUnknownField(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	held := draftedPost(t, handler)
+
+	body := fmt.Sprintf(`{"updated_at":%q,"fields":{"finish":null}}`, held.UpdatedAt)
+	recorder := doRequest(t, handler, http.MethodPatch, "/api/content/"+held.ID, body)
+
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want a null against an undeclared key refused like any other", recorder.Code)
+	}
+}

--- a/internal/server/content_write.go
+++ b/internal/server/content_write.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -228,23 +229,9 @@ func (s *server) patchContent(
 		return content.Content{}, err
 	}
 	previous := stored
-	changed, contentChanged, err := req.applyTo(&stored)
+	changed, snapshotted, err := s.applyEdit(r, &stored, req)
 	if err != nil {
 		return content.Content{}, err
-	}
-	filled, err := s.applyValues(r, &stored, req.Fields)
-	if err != nil {
-		return content.Content{}, err
-	}
-	if filled {
-		changed, contentChanged = true, true
-	}
-	nested, err := s.nestAsked(r, &stored, req)
-	if err != nil {
-		return content.Content{}, err
-	}
-	if nested {
-		changed = true
 	}
 	if !changed {
 		return stored, nil
@@ -252,36 +239,73 @@ func (s *server) patchContent(
 	if err := s.addressFree(r, stored.Path, stored.Type); err != nil {
 		return content.Content{}, err
 	}
-	snapshot, revisionCap, err := s.revisionFor(r, previous, contentChanged)
+	snapshot, revisionCap, err := s.revisionFor(r, previous, snapshotted)
 	if err != nil {
 		return content.Content{}, err
 	}
 	return s.content.Update(r.Context(), stored, previous.UpdatedAt, snapshot, revisionCap)
 }
 
-// applyValues merges the values the request carries and gates publishing, reporting whether any moved.
-func (s *server) applyValues(r *http.Request, c *content.Content, patch content.Values) (bool, error) {
+// applyEdit applies the whole edit, reporting whether the item moved and whether a snapshot is due.
+func (s *server) applyEdit(
+	r *http.Request, c *content.Content, req contentPatchRequest,
+) (changed, snapshotted bool, err error) {
+	changed, snapshotted, err = req.applyTo(c)
+	if err != nil {
+		return false, false, err
+	}
+	valued, related, err := s.applyValues(r, c, req.Fields)
+	if err != nil {
+		return false, false, err
+	}
+	nested, err := s.nestAsked(r, c, req)
+	if err != nil {
+		return false, false, err
+	}
+	return changed || valued || related || nested, snapshotted || valued, nil
+}
+
+// applyValues merges what the request carries and gates publishing, reporting which halves moved.
+func (s *server) applyValues(
+	r *http.Request, c *content.Content, patch content.Values,
+) (valued, related bool, err error) {
 	t, err := s.types.Active(r.Context(), c.Type)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
-	if err := patch.Validate(t.Fields); err != nil {
-		return false, err
+	scalars, targets, err := content.SplitValues(patch, t.Fields)
+	if err != nil {
+		return false, false, err
 	}
-	merged := c.Fields.Merge(patch)
+	merged := c.Fields.Merge(scalars)
 	if err := merged.Validate(t.Fields); err != nil {
-		return false, err
+		return false, false, err
 	}
+	held := c.Relations.Merge(targets)
 	if c.Status == content.StatusPublished {
-		if err := merged.Filled(t.Fields); err != nil {
-			return false, err
+		if err := content.Filled(merged, held, t.Fields); err != nil {
+			return false, false, err
 		}
 	}
-	if sameValues(c.Fields, merged) {
-		return false, nil
+	valued, related = !sameValues(c.Fields, merged), !sameRelations(c.Relations, held)
+	if !valued && !related {
+		return false, false, nil
 	}
-	c.Fields, c.UpdatedAt = merged, time.Now().UTC()
-	return true, nil
+	c.Fields, c.Relations, c.UpdatedAt = merged, held, time.Now().UTC()
+	return valued, related, nil
+}
+
+// sameRelations reports whether two sets of targets hold the same items in the same order.
+func sameRelations(held, asked content.Relations) bool {
+	if len(held) != len(asked) {
+		return false
+	}
+	for key, targets := range held {
+		if !slices.Equal(targets, asked[key]) {
+			return false
+		}
+	}
+	return true
 }
 
 // sameValues reports whether two sets of field values hold the same things.
@@ -295,6 +319,22 @@ func heldValues(v content.Values) content.Values {
 		return content.Values{}
 	}
 	return v
+}
+
+// payloadValues returns the item's scalar values with its targets named beside them.
+func payloadValues(c content.Content) content.Values {
+	held := make(content.Values, len(c.Fields)+len(c.Relations))
+	for key, value := range c.Fields {
+		held[key] = value
+	}
+	for key, targets := range c.Relations {
+		named := make([]string, len(targets))
+		for i, target := range targets {
+			named[i] = target.String()
+		}
+		held[key] = named
+	}
+	return held
 }
 
 // nestAsked moves the item under the parent the request names, reporting whether it moved.

--- a/internal/server/content_write.go
+++ b/internal/server/content_write.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -28,6 +29,7 @@ type contentPatchRequest struct {
 	Slug      *string         `json:"slug"`
 	Status    *string         `json:"status"`
 	ParentID  json.RawMessage `json:"parent_id"`
+	Fields    content.Values  `json:"fields"`
 }
 
 // nesting returns the parent the request names and whether it names one at all.
@@ -230,6 +232,13 @@ func (s *server) patchContent(
 	if err != nil {
 		return content.Content{}, err
 	}
+	filled, err := s.applyValues(r, &stored, req.Fields)
+	if err != nil {
+		return content.Content{}, err
+	}
+	if filled {
+		changed, contentChanged = true, true
+	}
 	nested, err := s.nestAsked(r, &stored, req)
 	if err != nil {
 		return content.Content{}, err
@@ -248,6 +257,44 @@ func (s *server) patchContent(
 		return content.Content{}, err
 	}
 	return s.content.Update(r.Context(), stored, previous.UpdatedAt, snapshot, revisionCap)
+}
+
+// applyValues merges the values the request carries and gates publishing, reporting whether any moved.
+func (s *server) applyValues(r *http.Request, c *content.Content, patch content.Values) (bool, error) {
+	t, err := s.types.Active(r.Context(), c.Type)
+	if err != nil {
+		return false, err
+	}
+	if err := patch.Validate(t.Fields); err != nil {
+		return false, err
+	}
+	merged := c.Fields.Merge(patch)
+	if err := merged.Validate(t.Fields); err != nil {
+		return false, err
+	}
+	if c.Status == content.StatusPublished {
+		if err := merged.Filled(t.Fields); err != nil {
+			return false, err
+		}
+	}
+	if sameValues(c.Fields, merged) {
+		return false, nil
+	}
+	c.Fields, c.UpdatedAt = merged, time.Now().UTC()
+	return true, nil
+}
+
+// sameValues reports whether two sets of field values hold the same things.
+func sameValues(held, asked content.Values) bool {
+	return reflect.DeepEqual(heldValues(held), heldValues(asked))
+}
+
+// heldValues returns the values an answer carries, never nil so the payload holds an object.
+func heldValues(v content.Values) content.Values {
+	if v == nil {
+		return content.Values{}
+	}
+	return v
 }
 
 // nestAsked moves the item under the parent the request names, reporting whether it moved.

--- a/internal/server/content_write.go
+++ b/internal/server/content_write.go
@@ -282,6 +282,11 @@ func (s *server) applyValues(
 		return false, false, err
 	}
 	held := c.Relations.Merge(targets)
+	pointing := *c
+	pointing.Relations = held
+	if err := pointing.SelfTargeted(); err != nil {
+		return false, false, err
+	}
 	if c.Status == content.StatusPublished {
 		if err := content.Filled(merged, held, t.Fields); err != nil {
 			return false, false, err

--- a/internal/server/fields.go
+++ b/internal/server/fields.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/gopherium/gouncer/authkit"
+
+	"github.com/gopherium/gophenberg/internal/content"
+)
+
+// fieldResponse is a field definition as the admin API answers it.
+type fieldResponse struct {
+	Key       string    `json:"key"`
+	Label     string    `json:"label"`
+	Kind      string    `json:"kind"`
+	RelatesTo string    `json:"relates_to,omitempty"`
+	Many      bool      `json:"many"`
+	Required  bool      `json:"required"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// fieldListResponse is one type's definition list as the admin API answers it.
+type fieldListResponse struct {
+	Items []fieldResponse `json:"items"`
+}
+
+// newFieldResponse builds a fieldResponse, normalizing timestamps to UTC.
+func newFieldResponse(f content.Field) fieldResponse {
+	return fieldResponse{
+		Key:       f.Key,
+		Label:     f.Label,
+		Kind:      string(f.Kind),
+		RelatesTo: f.RelatesTo,
+		Many:      f.Many,
+		Required:  f.Required,
+		CreatedAt: f.CreatedAt.UTC(),
+		UpdatedAt: f.UpdatedAt.UTC(),
+	}
+}
+
+// handleFieldList returns an http.HandlerFunc listing a type's field definitions.
+func (s *server) handleFieldList() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		t, err := s.types.ByKey(r.Context(), chi.URLParam(r, "key"))
+		if err != nil {
+			respondDomainError(w, err)
+			return
+		}
+		items := make([]fieldResponse, len(t.Fields))
+		for i, f := range t.Fields {
+			items[i] = newFieldResponse(f)
+		}
+		authkit.Respond(w, http.StatusOK, fieldListResponse{Items: items})
+	}
+}
+
+// handleFieldCreate returns an http.HandlerFunc declaring a field on a type.
+func (s *server) handleFieldCreate() http.HandlerFunc {
+	type request struct {
+		Key       string `json:"key"`
+		Label     string `json:"label"`
+		Kind      string `json:"kind"`
+		RelatesTo string `json:"relates_to"`
+		Many      bool   `json:"many"`
+		Required  bool   `json:"required"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		req, err := authkit.Decode[request](w, r)
+		if err != nil {
+			authkit.RespondError(w, http.StatusBadRequest, "malformed json")
+			return
+		}
+		asked, err := content.NewField(content.Field{
+			TypeKey:   chi.URLParam(r, "key"),
+			Key:       req.Key,
+			Label:     req.Label,
+			Kind:      content.FieldKind(req.Kind),
+			RelatesTo: req.RelatesTo,
+			Many:      req.Many,
+			Required:  req.Required,
+		})
+		if err != nil {
+			respondDomainError(w, err)
+			return
+		}
+		created, err := s.types.CreateField(r.Context(), asked)
+		if err != nil {
+			respondDomainError(w, err)
+			return
+		}
+		authkit.Respond(w, http.StatusCreated, newFieldResponse(created))
+	}
+}
+
+// handleFieldPatch returns an http.HandlerFunc carrying a field's label and required flag.
+func (s *server) handleFieldPatch() http.HandlerFunc {
+	type request struct {
+		Label    *string `json:"label"`
+		Required *bool   `json:"required"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		t, err := s.types.ByKey(r.Context(), chi.URLParam(r, "key"))
+		if err != nil {
+			respondDomainError(w, err)
+			return
+		}
+		stored, err := s.declaredField(t, chi.URLParam(r, "fieldKey"))
+		if err != nil {
+			respondDomainError(w, err)
+			return
+		}
+		req, err := authkit.Decode[request](w, r)
+		if err != nil {
+			authkit.RespondError(w, http.StatusBadRequest, "malformed json")
+			return
+		}
+		if req.Label != nil {
+			stored.Label = *req.Label
+		}
+		if req.Required != nil {
+			stored.Required = *req.Required
+		}
+		updated, err := s.types.UpdateField(r.Context(), stored)
+		if err != nil {
+			respondDomainError(w, err)
+			return
+		}
+		authkit.Respond(w, http.StatusOK, newFieldResponse(updated))
+	}
+}
+
+// handleFieldDelete returns an http.HandlerFunc removing a field and its values.
+func (s *server) handleFieldDelete() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		err := s.types.DeleteField(r.Context(), chi.URLParam(r, "key"), chi.URLParam(r, "fieldKey"))
+		if err != nil {
+			respondDomainError(w, err)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// declaredField returns the type's field carrying the key, or [content.ErrFieldNotFound].
+func (s *server) declaredField(t content.Type, key string) (content.Field, error) {
+	for _, f := range t.Fields {
+		if f.Key == key {
+			return f, nil
+		}
+	}
+	return content.Field{}, content.ErrFieldNotFound
+}

--- a/internal/server/fields_test.go
+++ b/internal/server/fields_test.go
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gopherium/gophenberg/internal/content"
+)
+
+// CreateField stores a field on its type.
+func (s *fakeTypeStore) CreateField(_ context.Context, f content.Field) (content.Field, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, stored := range s.types {
+		if stored.Key != f.TypeKey {
+			continue
+		}
+		f.ID = len(stored.Fields) + 1
+		s.types[i].Fields = append(s.types[i].Fields, f)
+		return f, nil
+	}
+	return content.Field{}, content.ErrTypeNotFound
+}
+
+// UpdateField stores the edited field on its type.
+func (s *fakeTypeStore) UpdateField(_ context.Context, f content.Field) (content.Field, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, stored := range s.types {
+		if stored.Key != f.TypeKey {
+			continue
+		}
+		for j, held := range stored.Fields {
+			if held.Key == f.Key {
+				f.ID = held.ID
+				s.types[i].Fields[j] = f
+				return f, nil
+			}
+		}
+	}
+	return content.Field{}, content.ErrFieldNotFound
+}
+
+// DeleteField removes the field from its type.
+func (s *fakeTypeStore) DeleteField(_ context.Context, typeKey, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, stored := range s.types {
+		if stored.Key != typeKey {
+			continue
+		}
+		for j, held := range stored.Fields {
+			if held.Key == key {
+				s.types[i].Fields = append(stored.Fields[:j], stored.Fields[j+1:]...)
+				return nil
+			}
+		}
+	}
+	return content.ErrFieldNotFound
+}
+
+// fieldBody is the field definition shape the admin API answers.
+type fieldBody struct {
+	Key       string `json:"key"`
+	Label     string `json:"label"`
+	Kind      string `json:"kind"`
+	RelatesTo string `json:"relates_to"`
+	Many      bool   `json:"many"`
+	Required  bool   `json:"required"`
+}
+
+// fieldListBody is the definition list shape the admin API answers.
+type fieldListBody struct {
+	Items []fieldBody `json:"items"`
+}
+
+func TestFieldListStartsEmpty(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+
+	recorder := doRequest(t, handler, http.MethodGet, "/api/types/post/fields", "")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	body := decodeBody[fieldListBody](t, recorder)
+	if len(body.Items) != 0 {
+		t.Errorf("items = %d, want no declared fields", len(body.Items))
+	}
+}
+
+func TestFieldListMissesAnUnknownType(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+
+	recorder := doRequest(t, handler, http.MethodGet, "/api/types/ghost/fields", "")
+
+	if recorder.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusNotFound)
+	}
+}
+
+func TestFieldCreateDeclaresAField(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+
+	recorder := doRequest(t, handler, http.MethodPost, "/api/types/post/fields",
+		`{"key":"color","label":"Color","kind":"text","required":true}`)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	body := decodeBody[fieldBody](t, recorder)
+	if body.Key != "color" || body.Label != "Color" || body.Kind != "text" || !body.Required {
+		t.Errorf("body = %+v, want the declared field", body)
+	}
+	listed := doRequest(t, handler, http.MethodGet, "/api/types/post/fields", "")
+	if items := decodeBody[fieldListBody](t, listed).Items; len(items) != 1 {
+		t.Errorf("items = %d, want the field listed", len(items))
+	}
+}
+
+func TestFieldCreateDeclaresARelation(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	created := doRequest(t, handler, http.MethodPost, "/api/types",
+		`{"key":"category","singular_label":"Category","plural_label":"Categories","route_word":"categories"}`)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("registering the type: %d: %s", created.Code, created.Body.String())
+	}
+
+	recorder := doRequest(t, handler, http.MethodPost, "/api/types/post/fields",
+		`{"key":"categories","label":"Categories","kind":"relation","relates_to":"category","many":true}`)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	body := decodeBody[fieldBody](t, recorder)
+	if body.RelatesTo != "category" || !body.Many {
+		t.Errorf("body = %+v, want the relation shape", body)
+	}
+}
+
+func TestFieldCreateRefusesATakenKey(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	first := doRequest(t, handler, http.MethodPost, "/api/types/post/fields",
+		`{"key":"color","label":"Color","kind":"text"}`)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("declaring the first field: %d", first.Code)
+	}
+
+	recorder := doRequest(t, handler, http.MethodPost, "/api/types/post/fields",
+		`{"key":"color","label":"Colour","kind":"number"}`)
+
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnprocessableEntity)
+	}
+}
+
+func TestFieldCreateRefusesAnUnknownKind(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+
+	recorder := doRequest(t, handler, http.MethodPost, "/api/types/post/fields",
+		`{"key":"taste","label":"Taste","kind":"flavor"}`)
+
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnprocessableEntity)
+	}
+}
+
+func TestFieldCreateRefusesARelationWithoutATarget(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+
+	recorder := doRequest(t, handler, http.MethodPost, "/api/types/post/fields",
+		`{"key":"engine","label":"Engine","kind":"relation"}`)
+
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnprocessableEntity)
+	}
+}
+
+func TestFieldCreateRefusesAnUnknownTarget(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+
+	recorder := doRequest(t, handler, http.MethodPost, "/api/types/post/fields",
+		`{"key":"engine","label":"Engine","kind":"relation","relates_to":"engine-type"}`)
+
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusUnprocessableEntity)
+	}
+}
+
+func TestFieldPatchRelabels(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	created := doRequest(t, handler, http.MethodPost, "/api/types/post/fields",
+		`{"key":"color","label":"Color","kind":"text"}`)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("declaring the field: %d", created.Code)
+	}
+
+	recorder := doRequest(t, handler, http.MethodPatch, "/api/types/post/fields/color",
+		`{"label":"Paint","required":true}`)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	body := decodeBody[fieldBody](t, recorder)
+	if body.Label != "Paint" || !body.Required || body.Kind != "text" {
+		t.Errorf("body = %+v, want the label carried and the kind kept", body)
+	}
+}
+
+func TestFieldPatchMissesAnUnknownField(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+
+	recorder := doRequest(t, handler, http.MethodPatch, "/api/types/post/fields/color", `{"label":"Paint"}`)
+
+	if recorder.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusNotFound)
+	}
+}
+
+func TestFieldDeleteRemovesTheDefinition(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	created := doRequest(t, handler, http.MethodPost, "/api/types/post/fields",
+		`{"key":"color","label":"Color","kind":"text"}`)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("declaring the field: %d", created.Code)
+	}
+
+	recorder := doRequest(t, handler, http.MethodDelete, "/api/types/post/fields/color", "")
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusNoContent, recorder.Body.String())
+	}
+	listed := doRequest(t, handler, http.MethodGet, "/api/types/post/fields", "")
+	if items := decodeBody[fieldListBody](t, listed).Items; len(items) != 0 {
+		t.Errorf("items = %d, want the definition gone", len(items))
+	}
+}
+
+func TestFieldDeleteMissesAnUnknownField(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+
+	recorder := doRequest(t, handler, http.MethodDelete, "/api/types/post/fields/color", "")
+
+	if recorder.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", recorder.Code, http.StatusNotFound)
+	}
+}
+
+func TestTypeDeleteRefusedWhileAFieldTargetsIt(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	created := doRequest(t, handler, http.MethodPost, "/api/types",
+		`{"key":"category","singular_label":"Category","plural_label":"Categories","route_word":"categories"}`)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("registering the type: %d", created.Code)
+	}
+	declared := doRequest(t, handler, http.MethodPost, "/api/types/post/fields",
+		`{"key":"categories","label":"Categories","kind":"relation","relates_to":"category"}`)
+	if declared.Code != http.StatusCreated {
+		t.Fatalf("declaring the relation: %d", declared.Code)
+	}
+
+	recorder := doRequest(t, handler, http.MethodDelete, "/api/types/category", "")
+
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want the targeted type kept", recorder.Code)
+	}
+}

--- a/internal/server/fields_test.go
+++ b/internal/server/fields_test.go
@@ -293,3 +293,32 @@ func TestTypeDeleteRefusedWhileAFieldTargetsIt(t *testing.T) {
 		t.Errorf("status = %d, want the targeted type kept", recorder.Code)
 	}
 }
+
+func TestTypeListCarriesFieldDefinitions(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	created := doRequest(t, handler, http.MethodPost, "/api/types/post/fields",
+		`{"key":"color","label":"Color","kind":"text","required":true}`)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("declaring the field: %d", created.Code)
+	}
+
+	recorder := doRequest(t, handler, http.MethodGet, "/api/types", "")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	body := decodeBody[struct {
+		Items []struct {
+			Key    string      `json:"key"`
+			Fields []fieldBody `json:"fields"`
+		} `json:"items"`
+	}](t, recorder)
+	if len(body.Items) == 0 || len(body.Items[0].Fields) != 1 {
+		t.Fatalf("items = %+v, want the post type carrying its definition", body.Items)
+	}
+	if held := body.Items[0].Fields[0]; held.Key != "color" || !held.Required {
+		t.Errorf("fields[0] = %+v, want the declared field", held)
+	}
+}

--- a/internal/server/json.go
+++ b/internal/server/json.go
@@ -24,7 +24,8 @@ func respondDomainError(w http.ResponseWriter, err error) {
 func statusFor(err error) (int, string) {
 	switch {
 	case errors.Is(err, content.ErrNotFound), errors.Is(err, content.ErrRevisionNotFound),
-		errors.Is(err, content.ErrTypeNotFound), errors.Is(err, media.ErrNotFound):
+		errors.Is(err, content.ErrTypeNotFound), errors.Is(err, content.ErrFieldNotFound),
+		errors.Is(err, media.ErrNotFound):
 		return http.StatusNotFound, err.Error()
 	case errors.Is(err, content.ErrConflict), errors.Is(err, media.ErrConflict):
 		return http.StatusConflict, err.Error()
@@ -66,6 +67,14 @@ var refusals = []error{
 	content.ErrInvalidPageKind,
 	content.ErrPageKindUnavailable,
 	content.ErrInvalidRevisionCap,
+	content.ErrFieldTaken,
+	content.ErrInvalidFieldKey,
+	content.ErrInvalidFieldLabel,
+	content.ErrInvalidFieldKind,
+	content.ErrRelationNeedsTarget,
+	content.ErrFieldNotRelational,
+	content.ErrTargetUnknown,
+	content.ErrTypeTargeted,
 }
 
 // isRefusal reports whether err is the CMS turning an edit away.

--- a/internal/server/json.go
+++ b/internal/server/json.go
@@ -78,7 +78,10 @@ var refusals = []error{
 	content.ErrUnknownField,
 	content.ErrFieldShape,
 	content.ErrFieldRequired,
-	content.ErrRelationValuesWait,
+	content.ErrTooManyTargets,
+	content.ErrRepeatedTarget,
+	content.ErrTargetNotFound,
+	content.ErrTargetType,
 }
 
 // isRefusal reports whether err is the CMS turning an edit away.

--- a/internal/server/json.go
+++ b/internal/server/json.go
@@ -81,6 +81,7 @@ var refusals = []error{
 	content.ErrRepeatedTarget,
 	content.ErrTargetNotFound,
 	content.ErrTargetType,
+	content.ErrSelfTarget,
 }
 
 // isRefusal reports whether err is the CMS turning an edit away.

--- a/internal/server/json.go
+++ b/internal/server/json.go
@@ -75,6 +75,10 @@ var refusals = []error{
 	content.ErrFieldNotRelational,
 	content.ErrTargetUnknown,
 	content.ErrTypeTargeted,
+	content.ErrUnknownField,
+	content.ErrFieldShape,
+	content.ErrFieldRequired,
+	content.ErrRelationValuesWait,
 }
 
 // isRefusal reports whether err is the CMS turning an edit away.

--- a/internal/server/json.go
+++ b/internal/server/json.go
@@ -65,7 +65,6 @@ var refusals = []error{
 	content.ErrInvalidRouteWord,
 	content.ErrInvalidLabel,
 	content.ErrInvalidPageKind,
-	content.ErrPageKindUnavailable,
 	content.ErrInvalidRevisionCap,
 	content.ErrFieldTaken,
 	content.ErrInvalidFieldKey,

--- a/internal/server/revisions.go
+++ b/internal/server/revisions.go
@@ -27,7 +27,8 @@ type revisionResponse struct {
 
 type revisionDetailResponse struct {
 	revisionResponse
-	Content string `json:"content"`
+	Content string         `json:"content"`
+	Fields  content.Values `json:"fields"`
 }
 
 type revisionListResponse struct {
@@ -98,6 +99,7 @@ func (s *server) handleRevisionGet() http.HandlerFunc {
 		authkit.Respond(w, http.StatusOK, revisionDetailResponse{
 			revisionResponse: newRevisionResponse(revision, names[revision.AuthorID]),
 			Content:          revision.Content,
+			Fields:           heldValues(revision.Fields),
 		})
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -88,6 +88,10 @@ func NewServer(cfg Config) http.Handler {
 			protected.Post("/api/types", s.handleTypeCreate())
 			protected.Patch("/api/types/{key}", s.handleTypePatch())
 			protected.Delete("/api/types/{key}", s.handleTypeDelete())
+			protected.Get("/api/types/{key}/fields", s.handleFieldList())
+			protected.Post("/api/types/{key}/fields", s.handleFieldCreate())
+			protected.Patch("/api/types/{key}/fields/{fieldKey}", s.handleFieldPatch())
+			protected.Delete("/api/types/{key}/fields/{fieldKey}", s.handleFieldDelete())
 		}
 		protected.Get("/api/content", s.handleContentList())
 		protected.Post("/api/content", s.handleContentCreate())

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -15,18 +15,19 @@ import (
 
 // typeResponse is a content type as the admin API answers it.
 type typeResponse struct {
-	Key           string    `json:"key"`
-	SingularLabel string    `json:"singular_label"`
-	PluralLabel   string    `json:"plural_label"`
-	RouteWord     string    `json:"route_word"`
-	Hierarchical  bool      `json:"hierarchical"`
-	Revisions     bool      `json:"revisions"`
-	RevisionCap   int       `json:"revision_cap"`
-	PageKind      string    `json:"page_kind"`
-	Default       bool      `json:"default"`
-	Active        bool      `json:"active"`
-	CreatedAt     time.Time `json:"created_at"`
-	UpdatedAt     time.Time `json:"updated_at"`
+	Key           string          `json:"key"`
+	SingularLabel string          `json:"singular_label"`
+	PluralLabel   string          `json:"plural_label"`
+	RouteWord     string          `json:"route_word"`
+	Hierarchical  bool            `json:"hierarchical"`
+	Revisions     bool            `json:"revisions"`
+	RevisionCap   int             `json:"revision_cap"`
+	PageKind      string          `json:"page_kind"`
+	Default       bool            `json:"default"`
+	Active        bool            `json:"active"`
+	Fields        []fieldResponse `json:"fields"`
+	CreatedAt     time.Time       `json:"created_at"`
+	UpdatedAt     time.Time       `json:"updated_at"`
 }
 
 // typeListResponse is the registry as the admin API answers it.
@@ -60,9 +61,19 @@ func newTypeResponse(t content.Type) typeResponse {
 		PageKind:      string(t.PageKind),
 		Default:       t.Default,
 		Active:        t.Active,
+		Fields:        declaredFields(t),
 		CreatedAt:     t.CreatedAt.UTC(),
 		UpdatedAt:     t.UpdatedAt.UTC(),
 	}
+}
+
+// declaredFields returns the type's field definitions as the admin API answers them.
+func declaredFields(t content.Type) []fieldResponse {
+	fields := make([]fieldResponse, len(t.Fields))
+	for i, f := range t.Fields {
+		fields[i] = newFieldResponse(f)
+	}
+	return fields
 }
 
 // applyTo edits the type, reporting whether anything changed.

--- a/internal/server/types_test.go
+++ b/internal/server/types_test.go
@@ -274,7 +274,7 @@ func TestTypePatchRefusesASecondTypeAtTheRoot(t *testing.T) {
 	}
 }
 
-func TestTypePatchRefusesAnArchivePageKind(t *testing.T) {
+func TestTypePatchTakesAnArchivePageKind(t *testing.T) {
 	t.Parallel()
 
 	handler := authedTypeServer(t)
@@ -283,9 +283,11 @@ func TestTypePatchRefusesAnArchivePageKind(t *testing.T) {
 
 	recorder := doRequest(t, handler, http.MethodPatch, "/api/types/car", `{"page_kind":"archive"}`)
 
-	if recorder.Code != http.StatusUnprocessableEntity {
-		t.Errorf("status = %d, want %d: %s",
-			recorder.Code, http.StatusUnprocessableEntity, recorder.Body.String())
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if body := decodeBody[typeBody](t, recorder); body.PageKind != string(content.PageKindArchive) {
+		t.Errorf("page kind = %q, want %q", body.PageKind, content.PageKindArchive)
 	}
 }
 

--- a/sdk/astro/content.ts
+++ b/sdk/astro/content.ts
@@ -12,9 +12,27 @@ export interface PostSummary {
 	updated_at: string
 }
 
-/** A published post carrying the block markup the editor saved. */
+/** A published post carrying the block markup the editor saved and the values it holds. */
 export interface Post extends PostSummary {
 	content: string
+	fields: Record<string, unknown>
+}
+
+/** One item a relation field points at, as a reader sees it. */
+export interface RelatedItem {
+	id: string
+	title: string
+	path: string
+}
+
+/** One typed field a content type declares. */
+export interface ContentTypeField {
+	key: string
+	label: string
+	kind: string
+	relates_to?: string
+	many: boolean
+	required: boolean
 }
 
 /** A content type as the handshake advertises it. */
@@ -26,6 +44,7 @@ export interface ContentType {
 	hierarchical: boolean
 	page_kind: string
 	default: boolean
+	fields: ContentTypeField[]
 }
 
 /** The shape an instance speaks and the types it serves. */
@@ -37,7 +56,7 @@ export interface Handshake {
 
 /** What a public address holds. */
 export interface Resolved {
-	kind: 'item' | 'archive'
+	kind: 'item' | 'archive' | 'term'
 	type: ContentType
 	item?: Post
 	page?: Page<PostSummary>

--- a/sdk/astro/index.ts
+++ b/sdk/astro/index.ts
@@ -13,10 +13,21 @@ export {
 } from './kit.ts'
 export { defineTheme } from './theme.ts'
 export { gophenbergLoader } from './loader.ts'
+export { relatedFields, relatedItems } from './related.ts'
 
 export type { BlockComponentMap, BlockNode, BlockProps, BlockSegment, ParsedBlock } from './blocks.ts'
 export type { ClientOptions, ListQuery, ResolveOptions } from './client.ts'
-export type { ContentType, Handshake, Page, Post, PostSummary, Resolved } from './content.ts'
+export type {
+	ContentType,
+	ContentTypeField,
+	Handshake,
+	Page,
+	Post,
+	PostSummary,
+	RelatedItem,
+	Resolved,
+} from './content.ts'
 export type { SiteAssetUrls } from './assets.ts'
 export type { LivePost, LoaderOptions, PostCollectionFilter, PostEntryFilter } from './loader.ts'
+export type { RelatedField } from './related.ts'
 export type { GophenbergTheme, ThemeLayouts, ThemeSeo } from './theme.ts'

--- a/sdk/astro/related.ts
+++ b/sdk/astro/related.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Post, RelatedItem } from './content.ts'
+
+/** One relation field of an item and the content it points at. */
+export interface RelatedField {
+	key: string
+	items: RelatedItem[]
+}
+
+/**
+ * Returns the items a value names, or nothing when it names no content.
+ * @param value - The value an item holds under a field key.
+ * @returns The items named, or nothing.
+ */
+export function relatedItems(value: unknown): RelatedItem[] | undefined {
+	if (!Array.isArray(value)) {
+		return undefined
+	}
+	if (value.every(isRelatedItem)) {
+		return value
+	}
+	return undefined
+}
+
+/**
+ * Reports whether a listed value names one item.
+ * @param held - One entry of a field value.
+ * @returns True when the entry names an item.
+ */
+function isRelatedItem(held: unknown): held is RelatedItem {
+	if (typeof held !== 'object' || held === null) {
+		return false
+	}
+	const named = held as Record<string, unknown>
+	return (
+		typeof named.id === 'string' &&
+		typeof named.title === 'string' &&
+		typeof named.path === 'string'
+	)
+}
+
+/**
+ * Returns the relation fields an item carries, keyed in the order their keys read.
+ * @param post - The item to read.
+ * @returns Each relation field and what it points at.
+ */
+export function relatedFields(post: Post): RelatedField[] {
+	const held: RelatedField[] = []
+	for (const key of Object.keys(post.fields).sort()) {
+		const items = relatedItems(post.fields[key])
+		if (items !== undefined && items.length > 0) {
+			held.push({ key, items })
+		}
+	}
+	return held
+}

--- a/sdk/astro/routes/content.astro
+++ b/sdk/astro/routes/content.astro
@@ -17,11 +17,23 @@ if (!held) {
 
 const Post = theme.layouts.Post
 const Archive = theme.layouts.Archive
+const Term = theme.layouts.Term
 ---
 
 {
 	held.kind === 'item' && held.item ? (
 		<Post post={held.item} blocks={theme.blocks} seo={theme.seo} />
+	) : held.kind === 'term' && held.item ? (
+		<Term
+			term={held.item}
+			type={held.type}
+			posts={held.page?.items ?? []}
+			total={held.page?.total ?? 0}
+			page={held.page?.page ?? 1}
+			perPage={held.page?.per_page ?? 0}
+			blocks={theme.blocks}
+			seo={theme.seo}
+		/>
 	) : (
 		<Archive
 			type={held.type}

--- a/sdk/astro/test/client.test.ts
+++ b/sdk/astro/test/client.test.ts
@@ -18,7 +18,11 @@ const summary: PostSummary = {
 }
 
 /** The same post carrying its block markup. */
-const post: Post = { ...summary, content: '<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->' }
+const post: Post = {
+	...summary,
+	content: '<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->',
+	fields: {},
+}
 
 /** The default content type as the handshake advertises it. */
 const postType: ContentType = {
@@ -29,6 +33,7 @@ const postType: ContentType = {
 	hierarchical: false,
 	page_kind: 'single',
 	default: true,
+	fields: [],
 }
 
 /** A page holding one summary. */

--- a/sdk/astro/test/loader.test.ts
+++ b/sdk/astro/test/loader.test.ts
@@ -19,7 +19,11 @@ const summary: PostSummary = {
 }
 
 /** The same post carrying its block markup. */
-const post: Post = { ...summary, content: '<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->' }
+const post: Post = {
+	...summary,
+	content: '<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->',
+	fields: {},
+}
 
 /** The default content type as the handshake advertises it. */
 const postType: ContentType = {
@@ -30,6 +34,7 @@ const postType: ContentType = {
 	hierarchical: false,
 	page_kind: 'single',
 	default: true,
+	fields: [],
 }
 
 /** A page holding one summary. */

--- a/sdk/astro/test/related.test.ts
+++ b/sdk/astro/test/related.test.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from 'vitest'
+
+import { relatedFields, relatedItems } from '../index.ts'
+import type { Post } from '../index.ts'
+
+/**
+ * Returns a published post carrying the given values.
+ * @param fields - The values the post holds.
+ * @returns The post.
+ */
+function posting(fields: Record<string, unknown>): Post {
+	return {
+		id: '1',
+		type: 'post',
+		path: 'hello-world',
+		slug: 'hello-world',
+		title: 'Hello world',
+		excerpt: '',
+		content: '',
+		fields,
+		published_at: '2026-08-04T12:00:00Z',
+		updated_at: '2026-08-04T12:00:00Z',
+	}
+}
+
+const NEWS = { id: 'a1', title: 'News', path: 'categories/news' }
+
+describe('the targets a value names', () => {
+	test('reads the items a relation value holds', () => {
+		expect(relatedItems([NEWS])).toEqual([NEWS])
+	})
+
+	test('reads nothing from a value that is not a list of targets', () => {
+		expect(relatedItems('red')).toBeUndefined()
+		expect(relatedItems(4)).toBeUndefined()
+		expect(relatedItems([1, 2])).toBeUndefined()
+		expect(relatedItems([{ id: 'a1' }])).toBeUndefined()
+	})
+
+	test('reads an empty list as a field holding no targets', () => {
+		expect(relatedItems([])).toEqual([])
+	})
+})
+
+describe('the relations a post carries', () => {
+	test('names each relation field and what it points at', () => {
+		const held = relatedFields(posting({ color: 'red', categories: [NEWS] }))
+
+		expect(held).toEqual([{ key: 'categories', items: [NEWS] }])
+	})
+
+	test('leaves out a relation pointing at nothing', () => {
+		expect(relatedFields(posting({ categories: [] }))).toEqual([])
+	})
+
+	test('names the relations in the order their keys read', () => {
+		const guides = { id: 'a2', title: 'Guides', path: 'categories/guides' }
+
+		const held = relatedFields(posting({ series: [guides], categories: [NEWS] }))
+
+		expect(held.map((field) => field.key)).toEqual(['categories', 'series'])
+	})
+})

--- a/sdk/astro/test/theme.test.ts
+++ b/sdk/astro/test/theme.test.ts
@@ -4,7 +4,16 @@ import type { AstroComponentFactory } from 'astro/runtime/server/index.js'
 import { describe, expect, expectTypeOf, test } from 'vitest'
 
 import { defineTheme } from '../index.ts'
-import type { BlockComponentMap, GophenbergTheme, ThemeLayouts, ThemeSeo } from '../index.ts'
+import type {
+	BlockComponentMap,
+	ContentType,
+	ContentTypeField,
+	GophenbergTheme,
+	Post,
+	Resolved,
+	ThemeLayouts,
+	ThemeSeo,
+} from '../index.ts'
 
 /** A stand-in for the layout components a real theme compiles. */
 const layout = (() => undefined) as unknown as AstroComponentFactory
@@ -12,7 +21,7 @@ const layout = (() => undefined) as unknown as AstroComponentFactory
 describe('defineTheme', () => {
 	test('hands back the theme it was given', () => {
 		const declared = {
-			layouts: { Base: layout, Post: layout, Archive: layout },
+			layouts: { Base: layout, Post: layout, Archive: layout, Term: layout },
 			seo: { siteName: 'Example Site' },
 		}
 
@@ -31,11 +40,12 @@ describe('defineTheme', () => {
 })
 
 describe('the contract a theme declares', () => {
-	test('asks for the three layouts the routes render through, and one the kit falls back for', () => {
+	test('asks for the four layouts the routes render through, and one the kit falls back for', () => {
 		expectTypeOf<ThemeLayouts>().toEqualTypeOf<{
 			Base: AstroComponentFactory
 			Post: AstroComponentFactory
 			Archive: AstroComponentFactory
+			Term: AstroComponentFactory
 			NotFound?: AstroComponentFactory
 		}>()
 	})
@@ -51,5 +61,51 @@ describe('the contract a theme declares', () => {
 
 	test('names the site in one field a theme cannot forget', () => {
 		expectTypeOf<ThemeSeo>().toEqualTypeOf<{ siteName: string }>()
+	})
+})
+
+describe('what a public address holds', () => {
+	test('names a term page beside an item and an archive', () => {
+		expectTypeOf<Resolved['kind']>().toEqualTypeOf<'item' | 'archive' | 'term'>()
+	})
+
+	test('carries the item and its page together for a term', () => {
+		const held: Resolved = {
+			kind: 'term',
+			type: {
+				key: 'category',
+				singular_label: 'Category',
+				plural_label: 'Categories',
+				route_word: 'categories',
+				hierarchical: false,
+				page_kind: 'archive',
+				default: false,
+				fields: [],
+			},
+			item: {
+				id: '1',
+				type: 'category',
+				path: 'categories/news',
+				slug: 'news',
+				title: 'News',
+				excerpt: '',
+				content: '',
+				fields: {},
+				published_at: '',
+				updated_at: '',
+			},
+			page: { items: [], total: 0, page: 1, per_page: 10 },
+		}
+
+		expect(held.item?.title).toBe('News')
+		expect(held.page?.total).toBe(0)
+	})
+
+	test('carries the values an item holds under its declared fields', () => {
+		expectTypeOf<Post['fields']>().toEqualTypeOf<Record<string, unknown>>()
+	})
+
+	test('advertises the fields a type declares', () => {
+		expectTypeOf<ContentType['fields']>().toEqualTypeOf<ContentTypeField[]>()
 	})
 })

--- a/sdk/astro/theme.ts
+++ b/sdk/astro/theme.ts
@@ -9,6 +9,7 @@ export interface ThemeLayouts {
 	Base: AstroComponentFactory
 	Post: AstroComponentFactory
 	Archive: AstroComponentFactory
+	Term: AstroComponentFactory
 	NotFound?: AstroComponentFactory
 }
 

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -32,3 +32,8 @@ sql:
             go_type:
               type: "time.Time"
               pointer: true
+          - db_type: "text"
+            nullable: true
+            go_type:
+              type: "string"
+              pointer: true

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -15,6 +15,14 @@ sql:
             go_type:
               import: "github.com/gopherium/gophenberg/internal/media"
               type: "RenditionMap"
+          - column: "core.content.fields"
+            go_type:
+              import: "github.com/gopherium/gophenberg/internal/content"
+              type: "Values"
+          - column: "core.content_revisions.fields"
+            go_type:
+              import: "github.com/gopherium/gophenberg/internal/content"
+              type: "Values"
           - db_type: "uuid"
             go_type:
               import: "github.com/google/uuid"

--- a/test/e2e/tests/public-site.spec.ts
+++ b/test/e2e/tests/public-site.spec.ts
@@ -119,3 +119,30 @@ test('serves a nested page at the chain of its parents', async ({ page }) => {
 
 	await expect(page.getByRole('heading', { name: 'Team', level: 1 })).toBeVisible()
 })
+
+test('walks from a post to its category through the link the theme built', async ({ page }) => {
+	await page.goto('/welcome-to-gophenberg')
+
+	await page.getByRole('link', { name: 'News' }).click()
+
+	await expect(page).toHaveURL('/categories/news')
+	await expect(page.getByRole('heading', { name: 'News', level: 1 })).toBeVisible()
+	await expect(page.getByRole('link', { name: 'Welcome to Gophenberg' })).toBeVisible()
+
+	await page.getByRole('link', { name: 'Welcome to Gophenberg' }).click()
+
+	await expect(page).toHaveURL('/welcome-to-gophenberg')
+})
+
+test('serves a term page carrying the category body above what points at it', async ({ page }) => {
+	await page.goto('/categories/news')
+
+	await expect(page.getByText('Everything filed under News shows up below.')).toBeVisible()
+	await expect(page.getByRole('link', { name: 'Welcome to Gophenberg' })).toBeVisible()
+})
+
+test('lists the seeded categories under their own address', async ({ page }) => {
+	await page.goto('/categories')
+
+	await expect(page.getByRole('link', { name: 'News' })).toBeVisible()
+})

--- a/test/features/features/content-fields.feature
+++ b/test/features/features/content-fields.feature
@@ -1,0 +1,106 @@
+Feature: Managing content fields
+  A type declares typed fields. The definitions drive the editor, the
+  write path and the public payloads, so changing them must stay safe
+  while values exist.
+
+  Background:
+    Given a running Gophenberg with the default content types
+    And a signed in administrator
+
+  Scenario: A type starts with no fields
+    When the administrator lists the fields of "post"
+    Then no fields are listed
+
+  Scenario: Adding a text field
+    When the administrator adds the "text" field "color" labeled "Color" to "post"
+    Then the field "color" is listed on "post"
+
+  Scenario: A taken field key is refused
+    Given the "text" field "color" labeled "Color" on "post"
+    When the administrator adds the "number" field "color" labeled "Colour" to "post"
+    Then the request is refused
+
+  Scenario: An unknown field kind is refused
+    When the administrator adds the "flavor" field "taste" labeled "Taste" to "post"
+    Then the request is refused
+
+  Scenario: A relation field needs a target type
+    When the administrator adds the "relation" field "engine" labeled "Engine" to "post" without a target
+    Then the request is refused
+
+  Scenario: Deleting a type a field targets is refused
+    Given the type "category" labeled "Category" and "Categories" under "categories"
+    And the "relation" field "categories" on "post" targeting "category"
+    When the administrator deletes the type "category"
+    Then the request is refused
+
+  @wip
+  Scenario: A stored value survives a relabel
+    Given the "text" field "color" labeled "Color" on "post"
+    And a published post "Hello world" holding "red" in "color"
+    When the administrator relabels the field "color" on "post" as "Paint"
+    Then the post "Hello world" holds "red" in "color"
+
+  @wip
+  Scenario: A value of the wrong shape is refused
+    Given the "number" field "doors" labeled "Doors" on "post"
+    And the post "Hello world"
+    When the administrator saves "many" into "doors" of "Hello world"
+    Then the request is refused
+
+  @wip
+  Scenario: An unknown field key is refused
+    Given the post "Hello world"
+    When the administrator saves "red" into "finish" of "Hello world"
+    Then the request is refused
+
+  @wip
+  Scenario: A draft lives without a required field
+    Given the required "text" field "color" labeled "Color" on "post"
+    When the administrator creates the post "Hello world"
+    Then the post "Hello world" holds no field "color"
+
+  @wip
+  Scenario: Publishing without a required field is refused
+    Given the required "text" field "color" labeled "Color" on "post"
+    And the post "Hello world"
+    When the administrator publishes "Hello world"
+    Then the request is refused
+
+  @wip
+  Scenario: Emptying a required field of a published post is refused
+    Given the required "text" field "color" labeled "Color" on "post"
+    And a published post "Hello world" holding "red" in "color"
+    When the administrator clears "color" of "Hello world"
+    Then the request is refused
+
+  @wip
+  Scenario: An autosave carries field values
+    Given the "text" field "color" labeled "Color" on "post"
+    And the post "Hello world"
+    When the editor autosaves "Hello world" holding "red" in "color"
+    Then the autosave of "Hello world" holds "red" in "color"
+
+  @wip
+  Scenario: Deleting a field removes its values
+    Given the "text" field "color" labeled "Color" on "post"
+    And a published post "Hello world" holding "red" in "color"
+    When the administrator deletes the field "color" on "post"
+    Then the post "Hello world" holds no field "color"
+
+  @wip
+  Scenario: A restored revision brings its values back
+    Given the "text" field "color" labeled "Color" on "post"
+    And a published post "Hello world" holding "red" in "color"
+    When the administrator saves "blue" into "color" of "Hello world"
+    And the administrator restores the previous revision of "Hello world"
+    Then the post "Hello world" holds "red" in "color"
+
+  @wip
+  Scenario: A restored revision holds no deleted field
+    Given the "text" field "color" labeled "Color" on "post"
+    And a published post "Hello world" holding "red" in "color"
+    When the administrator saves "blue" into "color" of "Hello world"
+    And the administrator deletes the field "color" on "post"
+    And the administrator restores the previous revision of "Hello world"
+    Then the post "Hello world" holds no field "color"

--- a/test/features/features/content-fields.feature
+++ b/test/features/features/content-fields.feature
@@ -34,61 +34,53 @@ Feature: Managing content fields
     When the administrator deletes the type "category"
     Then the request is refused
 
-  @wip
   Scenario: A stored value survives a relabel
     Given the "text" field "color" labeled "Color" on "post"
     And a published post "Hello world" holding "red" in "color"
     When the administrator relabels the field "color" on "post" as "Paint"
     Then the post "Hello world" holds "red" in "color"
 
-  @wip
   Scenario: A value of the wrong shape is refused
     Given the "number" field "doors" labeled "Doors" on "post"
     And the post "Hello world"
     When the administrator saves "many" into "doors" of "Hello world"
     Then the request is refused
 
-  @wip
   Scenario: An unknown field key is refused
     Given the post "Hello world"
     When the administrator saves "red" into "finish" of "Hello world"
     Then the request is refused
 
-  @wip
   Scenario: A draft lives without a required field
     Given the required "text" field "color" labeled "Color" on "post"
     When the administrator creates the post "Hello world"
     Then the post "Hello world" holds no field "color"
 
-  @wip
   Scenario: Publishing without a required field is refused
     Given the required "text" field "color" labeled "Color" on "post"
     And the post "Hello world"
     When the administrator publishes "Hello world"
     Then the request is refused
 
-  @wip
   Scenario: Emptying a required field of a published post is refused
     Given the required "text" field "color" labeled "Color" on "post"
     And a published post "Hello world" holding "red" in "color"
     When the administrator clears "color" of "Hello world"
     Then the request is refused
 
-  @wip
   Scenario: An autosave carries field values
     Given the "text" field "color" labeled "Color" on "post"
     And the post "Hello world"
     When the editor autosaves "Hello world" holding "red" in "color"
-    Then the autosave of "Hello world" holds "red" in "color"
+    Then the buffer it saved holds "red" in "color"
+    And the post "Hello world" holds "red" in "color"
 
-  @wip
   Scenario: Deleting a field removes its values
     Given the "text" field "color" labeled "Color" on "post"
     And a published post "Hello world" holding "red" in "color"
     When the administrator deletes the field "color" on "post"
     Then the post "Hello world" holds no field "color"
 
-  @wip
   Scenario: A restored revision brings its values back
     Given the "text" field "color" labeled "Color" on "post"
     And a published post "Hello world" holding "red" in "color"
@@ -96,7 +88,6 @@ Feature: Managing content fields
     And the administrator restores the previous revision of "Hello world"
     Then the post "Hello world" holds "red" in "color"
 
-  @wip
   Scenario: A restored revision holds no deleted field
     Given the "text" field "color" labeled "Color" on "post"
     And a published post "Hello world" holding "red" in "color"

--- a/test/features/features/content-relations.feature
+++ b/test/features/features/content-relations.feature
@@ -19,7 +19,7 @@ Feature: Relating content
     And the categories "News" and "Guides"
     And the post "Hello world"
     When the administrator files "Hello world" in "series" under "News" and "Guides"
-    Then the request is refused explaining content: field holds one target: series
+    Then the request is refused because the field holds one target
 
   Scenario: A single target is replaced, not appended
     Given the "relation" field "series" on "post" targeting "category" holding one
@@ -32,7 +32,7 @@ Feature: Relating content
     Given the post "Hello world"
     And the post "Second post"
     When the administrator files "Hello world" under "Second post"
-    Then the request is refused explaining content: target is not the type the field points at: categories holds post
+    Then the request is refused because the target is the wrong type
 
   Scenario: A target that does not exist is refused
     Given the post "Hello world"

--- a/test/features/features/content-relations.feature
+++ b/test/features/features/content-relations.feature
@@ -1,0 +1,73 @@
+Feature: Relating content
+  One field kind points at another type. The rows carry the term page, so
+  what an item points at must stay true as the item is published or trashed.
+
+  Background:
+    Given a running Gophenberg with the default content types
+    And a signed in administrator
+    And the type "category" labeled "Category" and "Categories" under "categories"
+    And the "relation" field "categories" on "post" targeting "category" holding many
+
+  Scenario: Filing a post under a category
+    Given the category "News"
+    And the post "Hello world"
+    When the administrator files "Hello world" under "News"
+    Then "Hello world" lists "News" in "categories"
+
+  Scenario: A single target field refuses a second
+    Given the "relation" field "series" on "post" targeting "category" holding one
+    And the categories "News" and "Guides"
+    And the post "Hello world"
+    When the administrator files "Hello world" in "series" under "News" and "Guides"
+    Then the request is refused explaining content: field holds one target: series
+
+  Scenario: A single target is replaced, not appended
+    Given the "relation" field "series" on "post" targeting "category" holding one
+    And the categories "News" and "Guides"
+    And the post "Hello world" filed in "series" under "News"
+    When the administrator files "Hello world" in "series" under "Guides"
+    Then "Hello world" lists "Guides" in "series"
+
+  Scenario: A target of the wrong type is refused
+    Given the post "Hello world"
+    And the post "Second post"
+    When the administrator files "Hello world" under "Second post"
+    Then the request is refused explaining content: target is not the type the field points at: categories holds post
+
+  Scenario: A target that does not exist is refused
+    Given the post "Hello world"
+    When the administrator files "Hello world" under a category that was never stored
+    Then the request is refused as unfindable
+
+  Scenario: The author's order is kept
+    Given the categories "Guides" and "News"
+    And the post "Hello world"
+    When the administrator files "Hello world" under "Guides" and "News"
+    Then "Hello world" lists "Guides" then "News" in "categories"
+
+  Scenario: Clearing a relation unfiles the post
+    Given the category "News"
+    And the post "Hello world" filed under "News"
+    When the administrator clears "categories" of "Hello world"
+    Then "Hello world" lists nothing in "categories"
+
+  Scenario: Permanently deleting a category unfiles its posts
+    Given the category "News"
+    And the post "Hello world" filed under "News"
+    When the administrator permanently deletes the category "News"
+    Then "Hello world" lists nothing in "categories"
+
+  Scenario: Deleting the field unfiles every post
+    Given the category "News"
+    And the post "Hello world" filed under "News"
+    When the administrator deletes the field "categories" on "post"
+    Then "Hello world" lists no field "categories"
+
+  Scenario: Registering a cars site needs no new machinery
+    Given the type "car" labeled "Car" and "Cars" under "cars"
+    And the type "engine-type" labeled "Engine Type" and "Engine Types" under "engine-types"
+    And the required "relation" field "engine" on "car" targeting "engine-type" holding one
+    And the engine-type "V8"
+    When the administrator files the car "Ford Focus" under "V8"
+    Then the car "Ford Focus" lists "V8" in "engine"
+    And publishing a car holding no engine is refused

--- a/test/features/features/content-terms.feature
+++ b/test/features/features/content-terms.feature
@@ -1,0 +1,62 @@
+Feature: Serving term pages
+  An item whose type serves term pages answers with itself and the published
+  content pointing at it, so a category carries a body and its posts at once.
+
+  Background:
+    Given a running Gophenberg with the default content types
+    And a signed in administrator
+    And the type "category" labeled "Category" and "Categories" under "categories" serving term pages
+    And the "relation" field "categories" on "post" targeting "category" holding many
+    And the published category "News"
+
+  Scenario: A term page carries the item and what points at it
+    Given the published post "Hello world" filed under "News"
+    When a visitor resolves "/categories/news"
+    Then the answer is a term of "category"
+    And the answer carries the item "News"
+    And "Hello world" is among the related content
+
+  Scenario: The archive lists the terms themselves
+    When a visitor resolves "/categories"
+    Then the answer is an archive of "category"
+
+  Scenario: A draft does not reach the term page
+    Given the post "Not yet" filed under "News"
+    When a visitor resolves "/categories/news"
+    Then "Not yet" is not among the related content
+
+  Scenario: Trashing a post takes it off the term page
+    Given the published post "Old news" filed under "News"
+    When the administrator trashes "Old news"
+    And a visitor resolves "/categories/news"
+    Then "Old news" is not among the related content
+
+  Scenario: Deactivating the pointing type empties the term page
+    Given the type "guide" labeled "Guide" and "Guides" under "guides"
+    And the "relation" field "categories" on "guide" targeting "category" holding many
+    And the published guide "Getting started" filed under "News"
+    When the administrator deactivates the type "guide"
+    And a visitor resolves "/categories/news"
+    Then no related content is listed
+
+  Scenario: A post filed twice is listed once
+    Given the "relation" field "series" on "post" targeting "category" holding one
+    And the published post "Hello world" filed under "News" through both fields
+    When a visitor resolves "/categories/news"
+    Then "Hello world" is among the related content
+    And one item is related
+
+  Scenario: A term page paginates behind the page word
+    Given three published posts filed under "News"
+    When a visitor resolves "/categories/news/page/2" one item at a time
+    Then the answer is a term of "category"
+    And it holds "Second filed" alone of 3 related items
+
+  Scenario: A page suffix on a single item answers nothing
+    Given the published post "Hello world"
+    Then "/hello-world/page/2" answers not found
+
+  Scenario: A term page holds no validator of its own
+    Given the published post "Hello world" filed under "News"
+    When a visitor resolves "/categories/news"
+    Then the answer carries no entity tag

--- a/test/features/features_test.go
+++ b/test/features/features_test.go
@@ -38,6 +38,10 @@ func TestContentTypes(t *testing.T) {
 	runFeature(t, "features/content-types.feature", initializeContentTypes)
 }
 
+func TestContentFields(t *testing.T) {
+	runFeature(t, "features/content-fields.feature", initializeContentFields)
+}
+
 func TestContentHierarchy(t *testing.T) {
 	runFeature(t, "features/content-hierarchy.feature", initializeContentHierarchy)
 }

--- a/test/features/features_test.go
+++ b/test/features/features_test.go
@@ -46,6 +46,10 @@ func TestContentRelations(t *testing.T) {
 	runFeature(t, "features/content-relations.feature", initializeContentRelations)
 }
 
+func TestContentTerms(t *testing.T) {
+	runFeature(t, "features/content-terms.feature", initializeContentTerms)
+}
+
 func TestContentHierarchy(t *testing.T) {
 	runFeature(t, "features/content-hierarchy.feature", initializeContentHierarchy)
 }

--- a/test/features/features_test.go
+++ b/test/features/features_test.go
@@ -42,6 +42,10 @@ func TestContentFields(t *testing.T) {
 	runFeature(t, "features/content-fields.feature", initializeContentFields)
 }
 
+func TestContentRelations(t *testing.T) {
+	runFeature(t, "features/content-relations.feature", initializeContentRelations)
+}
+
 func TestContentHierarchy(t *testing.T) {
 	runFeature(t, "features/content-hierarchy.feature", initializeContentHierarchy)
 }

--- a/test/features/memorycontent_test.go
+++ b/test/features/memorycontent_test.go
@@ -4,6 +4,7 @@ package features_test
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strconv"
 	"strings"
@@ -22,6 +23,7 @@ type memoryContent struct {
 	items     map[uuid.UUID]content.Content
 	revisions map[uuid.UUID][]content.Revision
 	autosaves map[autosaveKey]content.Revision
+	types     *memoryTypes
 }
 
 // autosaveKey names one author's parked buffer over one item.
@@ -36,6 +38,55 @@ func newMemoryContent() *memoryContent {
 		items:     make(map[uuid.UUID]content.Content),
 		revisions: make(map[uuid.UUID][]content.Revision),
 		autosaves: make(map[autosaveKey]content.Revision),
+	}
+}
+
+// holdTargets reports whether every target exists and is the type its field points at.
+func (s *memoryContent) holdTargets(c content.Content) error {
+	for key, targets := range c.Relations {
+		for _, target := range targets {
+			held, found := s.items[target]
+			if !found {
+				return fmt.Errorf("%w: %s", content.ErrTargetNotFound, target)
+			}
+			if s.types != nil {
+				if err := s.types.targeted(c.Type, key, held.Type); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// clearRelation drops the field's targets from every item of the type.
+func (s *memoryContent) clearRelation(typeKey, key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, stored := range s.items {
+		if stored.Type != typeKey {
+			continue
+		}
+		delete(stored.Relations, key)
+		s.items[id] = stored
+	}
+}
+
+// unfileTarget drops every pointer at the removed item.
+func (s *memoryContent) unfileTarget(gone uuid.UUID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, stored := range s.items {
+		for key, targets := range stored.Relations {
+			kept := make([]uuid.UUID, 0, len(targets))
+			for _, target := range targets {
+				if target != gone {
+					kept = append(kept, target)
+				}
+			}
+			stored.Relations[key] = kept
+		}
+		s.items[id] = stored
 	}
 }
 
@@ -109,6 +160,21 @@ func (s *memoryContent) Autosave(
 		return content.Revision{}, content.ErrRevisionNotFound
 	}
 	return parked, nil
+}
+
+// Delete removes the item outright, unfiling everything that pointed at it.
+func (s *memoryContent) Delete(_ context.Context, id uuid.UUID) error {
+	s.mu.Lock()
+	_, found := s.items[id]
+	if found {
+		delete(s.items, id)
+	}
+	s.mu.Unlock()
+	if !found {
+		return content.ErrNotFound
+	}
+	s.unfileTarget(id)
+	return nil
 }
 
 // DeleteAutosave removes the author's autosave of the item.
@@ -279,6 +345,9 @@ func (s *memoryContent) Update(
 	}
 	if snapshot != nil {
 		s.revisions[c.ID] = append(s.revisions[c.ID], *snapshot)
+	}
+	if err := s.holdTargets(c); err != nil {
+		return content.Content{}, err
 	}
 	prefix := content.AddressPrefix(c.Path, c.Slug)
 	for attempt := 1; attempt <= slugAttempts; attempt++ {

--- a/test/features/memorycontent_test.go
+++ b/test/features/memorycontent_test.go
@@ -343,11 +343,11 @@ func (s *memoryContent) Update(
 	if !stored.UpdatedAt.Equal(expectedUpdatedAt) {
 		return content.Content{}, content.ErrConflict
 	}
-	if snapshot != nil {
-		s.revisions[c.ID] = append(s.revisions[c.ID], *snapshot)
-	}
 	if err := s.holdTargets(c); err != nil {
 		return content.Content{}, err
+	}
+	if snapshot != nil {
+		s.revisions[c.ID] = append(s.revisions[c.ID], *snapshot)
 	}
 	prefix := content.AddressPrefix(c.Path, c.Slug)
 	for attempt := 1; attempt <= slugAttempts; attempt++ {
@@ -419,9 +419,7 @@ func (s *memoryContent) RelatedTo(
 	slices.SortFunc(matched, func(a, b content.Content) int {
 		return sortedAt(b).Compare(sortedAt(a))
 	})
-	total := len(matched)
-	start := min((page-1)*perPage, total)
-	return matched[start:min(start+perPage, total)], total, nil
+	return paged(matched, content.Filter{Page: page, PerPage: perPage}), len(matched), nil
 }
 
 // pointsAt reports whether any of the item's fields names the target.
@@ -446,6 +444,8 @@ func sortedAt(c content.Content) time.Time {
 
 // TargetsOf returns the published targets of active types the item points at.
 func (s *memoryContent) TargetsOf(_ context.Context, from uuid.UUID) (content.Targets, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	held, found := s.items[from]
 	if !found {
 		return nil, nil
@@ -455,6 +455,9 @@ func (s *memoryContent) TargetsOf(_ context.Context, from uuid.UUID) (content.Ta
 		for _, id := range listed {
 			pointed, stored := s.items[id]
 			if !stored || pointed.Status != content.StatusPublished {
+				continue
+			}
+			if s.types != nil && !s.types.serving(pointed.Type) {
 				continue
 			}
 			targets[key] = append(targets[key], content.Target{

--- a/test/features/memorycontent_test.go
+++ b/test/features/memorycontent_test.go
@@ -346,14 +346,14 @@ func (s *memoryContent) Update(
 	if err := s.holdTargets(c); err != nil {
 		return content.Content{}, err
 	}
-	if snapshot != nil {
-		s.revisions[c.ID] = append(s.revisions[c.ID], *snapshot)
-	}
 	prefix := content.AddressPrefix(c.Path, c.Slug)
 	for attempt := 1; attempt <= slugAttempts; attempt++ {
 		slug := numberedSlug(c.Slug, attempt)
 		if s.addressHeld(content.AddressUnder(prefix, slug), c.ID) {
 			continue
+		}
+		if snapshot != nil {
+			s.revisions[c.ID] = append(s.revisions[c.ID], *snapshot)
 		}
 		settled := c.Place(prefix, slug)
 		s.items[settled.ID] = settled
@@ -417,7 +417,10 @@ func (s *memoryContent) RelatedTo(
 		matched = append(matched, stored)
 	}
 	slices.SortFunc(matched, func(a, b content.Content) int {
-		return sortedAt(b).Compare(sortedAt(a))
+		if held := sortedAt(b).Compare(sortedAt(a)); held != 0 {
+			return held
+		}
+		return strings.Compare(a.ID.String(), b.ID.String())
 	})
 	return paged(matched, content.Filter{Page: page, PerPage: perPage}), len(matched), nil
 }

--- a/test/features/memorycontent_test.go
+++ b/test/features/memorycontent_test.go
@@ -399,3 +399,68 @@ func (s *memoryContent) Counts(_ context.Context, contentType string) (map[conte
 	}
 	return counts, nil
 }
+
+// RelatedTo returns the published items of active types pointing at the target, newest first.
+func (s *memoryContent) RelatedTo(
+	_ context.Context, target uuid.UUID, page, perPage int,
+) ([]content.Content, int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	matched := make([]content.Content, 0, len(s.items))
+	for _, stored := range s.items {
+		if stored.Status != content.StatusPublished || !pointsAt(stored.Relations, target) {
+			continue
+		}
+		if s.types != nil && !s.types.serving(stored.Type) {
+			continue
+		}
+		matched = append(matched, stored)
+	}
+	slices.SortFunc(matched, func(a, b content.Content) int {
+		return sortedAt(b).Compare(sortedAt(a))
+	})
+	total := len(matched)
+	start := min((page-1)*perPage, total)
+	return matched[start:min(start+perPage, total)], total, nil
+}
+
+// pointsAt reports whether any of the item's fields names the target.
+func pointsAt(held content.Relations, target uuid.UUID) bool {
+	for _, targets := range held {
+		for _, listed := range targets {
+			if listed == target {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// sortedAt returns the stamp a term page orders an item by.
+func sortedAt(c content.Content) time.Time {
+	if c.PublishedAt != nil {
+		return *c.PublishedAt
+	}
+	return c.CreatedAt
+}
+
+// TargetsOf returns the published targets of active types the item points at.
+func (s *memoryContent) TargetsOf(_ context.Context, from uuid.UUID) (content.Targets, error) {
+	held, found := s.items[from]
+	if !found {
+		return nil, nil
+	}
+	targets := make(content.Targets)
+	for key, listed := range held.Relations {
+		for _, id := range listed {
+			pointed, stored := s.items[id]
+			if !stored || pointed.Status != content.StatusPublished {
+				continue
+			}
+			targets[key] = append(targets[key], content.Target{
+				ID: pointed.ID, Title: pointed.Title, Path: pointed.Path,
+			})
+		}
+	}
+	return targets, nil
+}

--- a/test/features/memorycontent_test.go
+++ b/test/features/memorycontent_test.go
@@ -18,13 +18,105 @@ import (
 // memoryContent holds one scenario's content in memory.
 type memoryContent struct {
 	content.Store
-	mu    sync.Mutex
-	items map[uuid.UUID]content.Content
+	mu        sync.Mutex
+	items     map[uuid.UUID]content.Content
+	revisions map[uuid.UUID][]content.Revision
+	autosaves map[autosaveKey]content.Revision
+}
+
+// autosaveKey names one author's parked buffer over one item.
+type autosaveKey struct {
+	contentID uuid.UUID
+	authorID  uuid.UUID
 }
 
 // newMemoryContent returns an empty in-memory content store.
 func newMemoryContent() *memoryContent {
-	return &memoryContent{items: make(map[uuid.UUID]content.Content)}
+	return &memoryContent{
+		items:     make(map[uuid.UUID]content.Content),
+		revisions: make(map[uuid.UUID][]content.Revision),
+		autosaves: make(map[autosaveKey]content.Revision),
+	}
+}
+
+// clearField sweeps the field's values from the type's items and their snapshots.
+func (s *memoryContent) clearField(typeKey, key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, stored := range s.items {
+		if stored.Type != typeKey {
+			continue
+		}
+		delete(stored.Fields, key)
+		s.items[id] = stored
+		for i := range s.revisions[id] {
+			delete(s.revisions[id][i].Fields, key)
+		}
+		for held, parked := range s.autosaves {
+			if held.contentID == id {
+				delete(parked.Fields, key)
+			}
+		}
+	}
+}
+
+// Revisions returns the item's revisions newest first, without their content.
+func (s *memoryContent) Revisions(_ context.Context, contentID uuid.UUID) ([]content.Revision, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	held := s.revisions[contentID]
+	listed := make([]content.Revision, len(held))
+	for i, stored := range held {
+		listed[len(held)-1-i] = stored
+		listed[len(held)-1-i].Content = ""
+	}
+	return listed, nil
+}
+
+// RevisionByID returns the item's revision, or [content.ErrRevisionNotFound].
+func (s *memoryContent) RevisionByID(
+	_ context.Context, contentID, revisionID uuid.UUID,
+) (content.Revision, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, stored := range s.revisions[contentID] {
+		if stored.ID == revisionID {
+			return stored, nil
+		}
+	}
+	return content.Revision{}, content.ErrRevisionNotFound
+}
+
+// SaveAutosave stores the author's autosave of the item, replacing any earlier one.
+func (s *memoryContent) SaveAutosave(_ context.Context, autosave content.Revision) (content.Revision, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, found := s.items[autosave.ContentID]; !found {
+		return content.Revision{}, content.ErrNotFound
+	}
+	s.autosaves[autosaveKey{autosave.ContentID, autosave.AuthorID}] = autosave
+	return autosave, nil
+}
+
+// Autosave returns the author's autosave of the item, or [content.ErrRevisionNotFound].
+func (s *memoryContent) Autosave(
+	_ context.Context, contentID, authorID uuid.UUID,
+) (content.Revision, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	parked, found := s.autosaves[autosaveKey{contentID, authorID}]
+	if !found {
+		return content.Revision{}, content.ErrRevisionNotFound
+	}
+	return parked, nil
+}
+
+// DeleteAutosave removes the author's autosave of the item.
+func (s *memoryContent) DeleteAutosave(_ context.Context, contentID, authorID uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.autosaves, autosaveKey{contentID, authorID})
+	return nil
 }
 
 // Create stores a new content item, suffixing its slug until its address is free.
@@ -174,7 +266,7 @@ func paged(matched []content.Content, f content.Filter) []content.Content {
 
 // Update stores the item's editable fields, or reports it missing or stale.
 func (s *memoryContent) Update(
-	_ context.Context, c content.Content, expectedUpdatedAt time.Time, _ *content.Revision, _ int,
+	_ context.Context, c content.Content, expectedUpdatedAt time.Time, snapshot *content.Revision, _ int,
 ) (content.Content, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -184,6 +276,9 @@ func (s *memoryContent) Update(
 	}
 	if !stored.UpdatedAt.Equal(expectedUpdatedAt) {
 		return content.Content{}, content.ErrConflict
+	}
+	if snapshot != nil {
+		s.revisions[c.ID] = append(s.revisions[c.ID], *snapshot)
 	}
 	prefix := content.AddressPrefix(c.Path, c.Slug)
 	for attempt := 1; attempt <= slugAttempts; attempt++ {

--- a/test/features/memorytypes_test.go
+++ b/test/features/memorytypes_test.go
@@ -4,6 +4,7 @@ package features_test
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -144,6 +145,18 @@ func (s *memoryTypes) UpdateField(_ context.Context, f content.Field) (content.F
 
 // DeleteField removes the field from its type, or reports it missing.
 func (s *memoryTypes) DeleteField(_ context.Context, typeKey, key string) error {
+	if !s.dropField(typeKey, key) {
+		return content.ErrFieldNotFound
+	}
+	if s.content != nil {
+		s.content.clearField(typeKey, key)
+		s.content.clearRelation(typeKey, key)
+	}
+	return nil
+}
+
+// dropField removes the declaration, reporting whether the type held one.
+func (s *memoryTypes) dropField(typeKey, key string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for i, stored := range s.types {
@@ -153,14 +166,31 @@ func (s *memoryTypes) DeleteField(_ context.Context, typeKey, key string) error 
 		for j, held := range stored.Fields {
 			if held.Key == key {
 				s.types[i].Fields = append(stored.Fields[:j], stored.Fields[j+1:]...)
-				if s.content != nil {
-					s.content.clearField(typeKey, key)
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// targeted reports whether the field of the type may point at an item of the stored type.
+func (s *memoryTypes) targeted(typeKey, key, stored string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, held := range s.types {
+		if held.Key != typeKey {
+			continue
+		}
+		for _, f := range held.Fields {
+			if f.Key == key {
+				if f.RelatesTo != stored {
+					return fmt.Errorf("%w: %s holds %s", content.ErrTargetType, key, stored)
 				}
 				return nil
 			}
 		}
 	}
-	return content.ErrFieldNotFound
+	return nil
 }
 
 // Delete removes the type, or reports it missing or still holding content.

--- a/test/features/memorytypes_test.go
+++ b/test/features/memorytypes_test.go
@@ -153,6 +153,9 @@ func (s *memoryTypes) DeleteField(_ context.Context, typeKey, key string) error 
 		for j, held := range stored.Fields {
 			if held.Key == key {
 				s.types[i].Fields = append(stored.Fields[:j], stored.Fields[j+1:]...)
+				if s.content != nil {
+					s.content.clearField(typeKey, key)
+				}
 				return nil
 			}
 		}

--- a/test/features/memorytypes_test.go
+++ b/test/features/memorytypes_test.go
@@ -12,9 +12,10 @@ import (
 
 // memoryTypes holds one scenario's content type registry in memory.
 type memoryTypes struct {
-	mu      sync.Mutex
-	types   []content.Type
-	content *memoryContent
+	mu       sync.Mutex
+	types    []content.Type
+	fieldIDs int
+	content  *memoryContent
 }
 
 // newMemoryTypes returns a registry holding the built-in post type the migration registers.
@@ -104,6 +105,59 @@ func (s *memoryTypes) handRootOver() {
 		}
 		return
 	}
+}
+
+// CreateField stores a field on its type, mirroring the schema's identity column.
+func (s *memoryTypes) CreateField(_ context.Context, f content.Field) (content.Field, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, stored := range s.types {
+		if stored.Key != f.TypeKey {
+			continue
+		}
+		s.fieldIDs++
+		f.ID = s.fieldIDs
+		s.types[i].Fields = append(s.types[i].Fields, f)
+		return f, nil
+	}
+	return content.Field{}, content.ErrTypeNotFound
+}
+
+// UpdateField stores the edited field on its type, or reports it missing.
+func (s *memoryTypes) UpdateField(_ context.Context, f content.Field) (content.Field, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, stored := range s.types {
+		if stored.Key != f.TypeKey {
+			continue
+		}
+		for j, held := range stored.Fields {
+			if held.Key == f.Key {
+				f.ID = held.ID
+				s.types[i].Fields[j] = f
+				return f, nil
+			}
+		}
+	}
+	return content.Field{}, content.ErrFieldNotFound
+}
+
+// DeleteField removes the field from its type, or reports it missing.
+func (s *memoryTypes) DeleteField(_ context.Context, typeKey, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, stored := range s.types {
+		if stored.Key != typeKey {
+			continue
+		}
+		for j, held := range stored.Fields {
+			if held.Key == key {
+				s.types[i].Fields = append(stored.Fields[:j], stored.Fields[j+1:]...)
+				return nil
+			}
+		}
+	}
+	return content.ErrFieldNotFound
 }
 
 // Delete removes the type, or reports it missing or still holding content.

--- a/test/features/memorytypes_test.go
+++ b/test/features/memorytypes_test.go
@@ -217,3 +217,15 @@ func (s *memoryTypes) holdsContent(ctx context.Context, key string) bool {
 	items, _, err := s.content.List(ctx, content.Filter{Type: key})
 	return err == nil && len(items) > 0
 }
+
+// serving reports whether the type is active enough to appear on a term page.
+func (s *memoryTypes) serving(key string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, stored := range s.types {
+		if stored.Key == key {
+			return stored.Active
+		}
+	}
+	return false
+}

--- a/test/features/steps_content_fields_test.go
+++ b/test/features/steps_content_fields_test.go
@@ -1,0 +1,448 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package features_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/cucumber/godog"
+)
+
+// listedField is one field definition as the admin registry reports it.
+type listedField struct {
+	Key      string `json:"key"`
+	Label    string `json:"label"`
+	Kind     string `json:"kind"`
+	Required bool   `json:"required"`
+}
+
+// fieldedContent is one content item with its field values as the admin API reports it.
+type fieldedContent struct {
+	ID        string                     `json:"id"`
+	Title     string                     `json:"title"`
+	UpdatedAt string                     `json:"updated_at"`
+	Fields    map[string]json.RawMessage `json:"fields"`
+}
+
+// fieldsPathOf returns where the named type's field definitions answer.
+func fieldsPathOf(typeKey string) string {
+	return typesPath + "/" + typeKey + "/fields"
+}
+
+// theAdministratorListsTheFieldsOf asks the registry for a type's field definitions.
+func theAdministratorListsTheFieldsOf(ctx context.Context, typeKey string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	return w.get(fieldsPathOf(typeKey))
+}
+
+// noFieldsAreListed asserts the registry answered an empty definition list.
+func noFieldsAreListed(ctx context.Context) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	if err := w.expect(http.StatusOK); err != nil {
+		return fmt.Errorf("listing the fields: %w", err)
+	}
+	var listed struct {
+		Items []listedField `json:"items"`
+	}
+	if err := w.answer.decode(&listed); err != nil {
+		return err
+	}
+	if len(listed.Items) != 0 {
+		return fmt.Errorf("the registry lists %d fields, want none", len(listed.Items))
+	}
+	return nil
+}
+
+// addField sends one field definition to the registry and keeps the answer.
+func addField(ctx context.Context, typeKey, body string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	return w.postJSON(fieldsPathOf(typeKey), body)
+}
+
+// theAdministratorAddsTheField asks the registry to hold a new field on a type.
+func theAdministratorAddsTheField(ctx context.Context, kind, key, label, typeKey string) error {
+	return addField(ctx, typeKey, fmt.Sprintf(`{"key":%q,"label":%q,"kind":%q}`, key, label, kind))
+}
+
+// theAdministratorAddsTheFieldWithoutATarget asks for a relation field naming no target type.
+func theAdministratorAddsTheFieldWithoutATarget(ctx context.Context, kind, key, label, typeKey string) error {
+	return theAdministratorAddsTheField(ctx, kind, key, label, typeKey)
+}
+
+// theFieldExists registers a field definition the scenario builds on.
+func theFieldExists(ctx context.Context, kind, key, label, typeKey string) error {
+	if err := theAdministratorAddsTheField(ctx, kind, key, label, typeKey); err != nil {
+		return err
+	}
+	return expectFieldStored(ctx, key)
+}
+
+// theRequiredFieldExists registers a field definition publishing demands a value for.
+func theRequiredFieldExists(ctx context.Context, kind, key, label, typeKey string) error {
+	body := fmt.Sprintf(`{"key":%q,"label":%q,"kind":%q,"required":true}`, key, label, kind)
+	if err := addField(ctx, typeKey, body); err != nil {
+		return err
+	}
+	return expectFieldStored(ctx, key)
+}
+
+// theRelationFieldExists registers a relation field pointing at the named type.
+func theRelationFieldExists(ctx context.Context, key, typeKey, target string) error {
+	body := fmt.Sprintf(`{"key":%q,"label":%q,"kind":"relation","relates_to":%q}`, key, key, target)
+	if err := addField(ctx, typeKey, body); err != nil {
+		return err
+	}
+	return expectFieldStored(ctx, key)
+}
+
+// expectFieldStored asserts the registry accepted the field the scenario builds on.
+func expectFieldStored(ctx context.Context, key string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	if err := w.expect(http.StatusCreated); err != nil {
+		return fmt.Errorf("registering the field %q: %w", key, err)
+	}
+	return nil
+}
+
+// theFieldIsListedOn asserts the registry lists the field on the type.
+func theFieldIsListedOn(ctx context.Context, key, typeKey string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	if err := w.get(fieldsPathOf(typeKey)); err != nil {
+		return err
+	}
+	if err := w.expect(http.StatusOK); err != nil {
+		return fmt.Errorf("listing the fields of %q: %w", typeKey, err)
+	}
+	var listed struct {
+		Items []listedField `json:"items"`
+	}
+	if err := w.answer.decode(&listed); err != nil {
+		return err
+	}
+	for _, found := range listed.Items {
+		if found.Key == key {
+			return nil
+		}
+	}
+	return fmt.Errorf("the type %q lists no field %q", typeKey, key)
+}
+
+// theAdministratorRelabelsTheField asks the registry to carry a new label for a field.
+func theAdministratorRelabelsTheField(ctx context.Context, key, typeKey, label string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	if err := w.patchJSON(fieldsPathOf(typeKey)+"/"+key, fmt.Sprintf(`{"label":%q}`, label)); err != nil {
+		return err
+	}
+	return w.expect(http.StatusOK)
+}
+
+// theAdministratorDeletesTheField asks the registry to forget a field and its values.
+func theAdministratorDeletesTheField(ctx context.Context, key, typeKey string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	if err := w.deleteAt(fieldsPathOf(typeKey) + "/" + key); err != nil {
+		return err
+	}
+	return w.expect(http.StatusNoContent)
+}
+
+// freshPost re-reads the remembered post so the next edit carries a current version.
+func freshPost(w *world, title string) (fieldedContent, error) {
+	held, found := w.nested[title]
+	if !found {
+		return fieldedContent{}, fmt.Errorf("the scenario stored no post titled %q", title)
+	}
+	if err := w.get(contentPath + "/" + held.ID); err != nil {
+		return fieldedContent{}, err
+	}
+	if err := w.expect(http.StatusOK); err != nil {
+		return fieldedContent{}, fmt.Errorf("reading %q: %w", title, err)
+	}
+	var stored fieldedContent
+	if err := w.answer.decode(&stored); err != nil {
+		return fieldedContent{}, err
+	}
+	w.nested[title] = nestedContent{ID: stored.ID, UpdatedAt: stored.UpdatedAt}
+	return stored, nil
+}
+
+// saveFieldValues sends a fields edit to the remembered post and keeps the answer.
+func saveFieldValues(w *world, title, fields string) error {
+	stored, err := freshPost(w, title)
+	if err != nil {
+		return err
+	}
+	body := fmt.Sprintf(`{"updated_at":%q,"fields":%s}`, stored.UpdatedAt, fields)
+	return w.patchJSON(contentPath+"/"+stored.ID, body)
+}
+
+// aPublishedPostHolding stores a post carrying the value and publishes it.
+func aPublishedPostHolding(ctx context.Context, title, value, key string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	if err := thePostExists(ctx, title); err != nil {
+		return err
+	}
+	if err := saveFieldValues(w, title, fmt.Sprintf(`{%q:%q}`, key, value)); err != nil {
+		return err
+	}
+	if err := w.expect(http.StatusOK); err != nil {
+		return fmt.Errorf("filling %q of %q: %w", key, title, err)
+	}
+	return publishPost(ctx, title)
+}
+
+// publishPost moves the remembered post to published.
+func publishPost(ctx context.Context, title string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	if err := theAdministratorPublishes(ctx, title); err != nil {
+		return err
+	}
+	if err := w.expect(http.StatusOK); err != nil {
+		return fmt.Errorf("publishing %q: %w", title, err)
+	}
+	return nil
+}
+
+// theAdministratorPublishes asks for the remembered post to be published.
+func theAdministratorPublishes(ctx context.Context, title string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	stored, err := freshPost(w, title)
+	if err != nil {
+		return err
+	}
+	body := fmt.Sprintf(`{"updated_at":%q,"status":"published"}`, stored.UpdatedAt)
+	return w.patchJSON(contentPath+"/"+stored.ID, body)
+}
+
+// theAdministratorSavesInto sends one field value to the remembered post.
+func theAdministratorSavesInto(ctx context.Context, value, key, title string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	return saveFieldValues(w, title, fmt.Sprintf(`{%q:%q}`, key, value))
+}
+
+// theAdministratorClears empties one field of the remembered post.
+func theAdministratorClears(ctx context.Context, key, title string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	return saveFieldValues(w, title, fmt.Sprintf(`{%q:null}`, key))
+}
+
+// theEditorAutosavesHolding parks an autosave carrying the value for the remembered post.
+func theEditorAutosavesHolding(ctx context.Context, title, value, key string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	stored, err := freshPost(w, title)
+	if err != nil {
+		return err
+	}
+	body := fmt.Sprintf(`{"updated_at":%q,"title":%q,"fields":{%q:%q}}`, stored.UpdatedAt, title, key, value)
+	return w.postJSON(contentPath+"/"+stored.ID+"/autosave", body)
+}
+
+// theAutosaveHolds asserts the parked autosave carries the value.
+func theAutosaveHolds(ctx context.Context, title, value, key string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	held, found := w.nested[title]
+	if !found {
+		return fmt.Errorf("the scenario stored no post titled %q", title)
+	}
+	if err := w.get(contentPath + "/" + held.ID + "/autosave"); err != nil {
+		return err
+	}
+	if err := w.expect(http.StatusOK); err != nil {
+		return fmt.Errorf("reading the autosave of %q: %w", title, err)
+	}
+	var parked fieldedContent
+	if err := w.answer.decode(&parked); err != nil {
+		return err
+	}
+	return holdsValue(parked.Fields, key, value, "the autosave of "+title)
+}
+
+// theAdministratorRestoresThePreviousRevisionOf writes the newest revision back over the post.
+func theAdministratorRestoresThePreviousRevisionOf(ctx context.Context, title string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	held, found := w.nested[title]
+	if !found {
+		return fmt.Errorf("the scenario stored no post titled %q", title)
+	}
+	snapshot, err := newestRevision(w, held.ID)
+	if err != nil {
+		return err
+	}
+	stored, err := freshPost(w, title)
+	if err != nil {
+		return err
+	}
+	fields, err := json.Marshal(snapshot.Fields)
+	if err != nil {
+		return fmt.Errorf("carrying the revision fields: %w", err)
+	}
+	body := fmt.Sprintf(`{"updated_at":%q,"title":%q,"fields":%s}`, stored.UpdatedAt, snapshot.Title, fields)
+	if err := w.patchJSON(contentPath+"/"+stored.ID, body); err != nil {
+		return err
+	}
+	return w.expect(http.StatusOK)
+}
+
+// newestRevision returns the most recent revision snapshot of the item.
+func newestRevision(w *world, id string) (fieldedContent, error) {
+	if err := w.get(contentPath + "/" + id + "/revisions"); err != nil {
+		return fieldedContent{}, err
+	}
+	if err := w.expect(http.StatusOK); err != nil {
+		return fieldedContent{}, fmt.Errorf("listing the revisions: %w", err)
+	}
+	var listed struct {
+		Items []fieldedContent `json:"items"`
+	}
+	if err := w.answer.decode(&listed); err != nil {
+		return fieldedContent{}, err
+	}
+	if len(listed.Items) == 0 {
+		return fieldedContent{}, fmt.Errorf("the item %s holds no revisions", id)
+	}
+	newest := listed.Items[0]
+	if err := w.get(contentPath + "/" + id + "/revisions/" + newest.ID); err != nil {
+		return fieldedContent{}, err
+	}
+	if err := w.expect(http.StatusOK); err != nil {
+		return fieldedContent{}, fmt.Errorf("reading the revision: %w", err)
+	}
+	var detail fieldedContent
+	if err := w.answer.decode(&detail); err != nil {
+		return fieldedContent{}, err
+	}
+	return detail, nil
+}
+
+// thePostHolds asserts the stored post carries the value.
+func thePostHolds(ctx context.Context, title, value, key string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	stored, err := freshPost(w, title)
+	if err != nil {
+		return err
+	}
+	return holdsValue(stored.Fields, key, value, "the post "+title)
+}
+
+// thePostHoldsNoField asserts the stored post carries nothing under the key.
+func thePostHoldsNoField(ctx context.Context, title, key string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	stored, err := freshPost(w, title)
+	if err != nil {
+		return err
+	}
+	if _, found := stored.Fields[key]; found {
+		return fmt.Errorf("the post %q still holds %q, want the field gone", title, key)
+	}
+	return nil
+}
+
+// holdsValue asserts the fields object carries the string value under the key.
+func holdsValue(fields map[string]json.RawMessage, key, value, owner string) error {
+	raw, found := fields[key]
+	if !found {
+		return fmt.Errorf("%s holds no %q, want %q", owner, key, value)
+	}
+	var held string
+	if err := json.Unmarshal(raw, &held); err != nil {
+		return fmt.Errorf("%s holds %s in %q, want the string %q", owner, raw, key, value)
+	}
+	if held != value {
+		return fmt.Errorf("%s holds %q in %q, want %q", owner, held, key, value)
+	}
+	return nil
+}
+
+// initializeContentFields registers the steps of the content fields feature.
+func initializeContentFields(sc *godog.ScenarioContext) {
+	sc.Before(provisionWorld)
+	sc.After(retireWorld)
+	sc.Given(`^a running Gophenberg with the default content types$`, aRunningGophenbergWithTheDefaultContentTypes)
+	sc.Given(`^a signed in administrator$`, aSignedInAdministrator)
+	sc.Given(`^the type "([^"]*)" labeled "([^"]*)" and "([^"]*)" under "([^"]*)"$`, theTypeExists)
+	sc.Given(`^the "([^"]*)" field "([^"]*)" labeled "([^"]*)" on "([^"]*)"$`, theFieldExists)
+	sc.Given(`^the required "([^"]*)" field "([^"]*)" labeled "([^"]*)" on "([^"]*)"$`, theRequiredFieldExists)
+	sc.Given(`^the "relation" field "([^"]*)" on "([^"]*)" targeting "([^"]*)"$`, theRelationFieldExists)
+	sc.Given(`^the post "([^"]*)"$`, thePostExists)
+	sc.Given(`^a published post "([^"]*)" holding "([^"]*)" in "([^"]*)"$`, aPublishedPostHolding)
+	sc.When(`^the administrator lists the fields of "([^"]*)"$`, theAdministratorListsTheFieldsOf)
+	sc.When(
+		`^the administrator adds the "([^"]*)" field "([^"]*)" labeled "([^"]*)" to "([^"]*)"$`,
+		theAdministratorAddsTheField,
+	)
+	sc.When(
+		`^the administrator adds the "([^"]*)" field "([^"]*)" labeled "([^"]*)" to "([^"]*)" without a target$`,
+		theAdministratorAddsTheFieldWithoutATarget,
+	)
+	sc.When(`^the administrator deletes the type "([^"]*)"$`, theAdministratorDeletesTheType)
+	sc.When(`^the administrator relabels the field "([^"]*)" on "([^"]*)" as "([^"]*)"$`, theAdministratorRelabelsTheField)
+	sc.When(`^the administrator deletes the field "([^"]*)" on "([^"]*)"$`, theAdministratorDeletesTheField)
+	sc.When(`^the administrator saves "([^"]*)" into "([^"]*)" of "([^"]*)"$`, theAdministratorSavesInto)
+	sc.When(`^the administrator clears "([^"]*)" of "([^"]*)"$`, theAdministratorClears)
+	sc.When(`^the administrator creates the post "([^"]*)"$`, theAdministratorCreatesThePost)
+	sc.When(`^the administrator publishes "([^"]*)"$`, theAdministratorPublishes)
+	sc.When(`^the editor autosaves "([^"]*)" holding "([^"]*)" in "([^"]*)"$`, theEditorAutosavesHolding)
+	sc.When(
+		`^the administrator restores the previous revision of "([^"]*)"$`,
+		theAdministratorRestoresThePreviousRevisionOf,
+	)
+	sc.Then(`^no fields are listed$`, noFieldsAreListed)
+	sc.Then(`^the field "([^"]*)" is listed on "([^"]*)"$`, theFieldIsListedOn)
+	sc.Then(`^the request is refused$`, theRequestIsRefused)
+	sc.Then(`^the post "([^"]*)" holds "([^"]*)" in "([^"]*)"$`, thePostHolds)
+	sc.Then(`^the post "([^"]*)" holds no field "([^"]*)"$`, thePostHoldsNoField)
+	sc.Then(`^the autosave of "([^"]*)" holds "([^"]*)" in "([^"]*)"$`, theAutosaveHolds)
+}

--- a/test/features/steps_content_fields_test.go
+++ b/test/features/steps_content_fields_test.go
@@ -278,27 +278,20 @@ func theEditorAutosavesHolding(ctx context.Context, title, value, key string) er
 	return w.postJSON(contentPath+"/"+stored.ID+"/autosave", body)
 }
 
-// theAutosaveHolds asserts the parked autosave carries the value.
-func theAutosaveHolds(ctx context.Context, title, value, key string) error {
+// theBufferItSavedHolds asserts the answer to the autosave carries the value.
+func theBufferItSavedHolds(ctx context.Context, value, key string) error {
 	w, err := worldOf(ctx)
 	if err != nil {
 		return err
 	}
-	held, found := w.nested[title]
-	if !found {
-		return fmt.Errorf("the scenario stored no post titled %q", title)
-	}
-	if err := w.get(contentPath + "/" + held.ID + "/autosave"); err != nil {
-		return err
-	}
 	if err := w.expect(http.StatusOK); err != nil {
-		return fmt.Errorf("reading the autosave of %q: %w", title, err)
+		return fmt.Errorf("saving the buffer: %w", err)
 	}
-	var parked fieldedContent
-	if err := w.answer.decode(&parked); err != nil {
+	var saved fieldedContent
+	if err := w.answer.decode(&saved); err != nil {
 		return err
 	}
-	return holdsValue(parked.Fields, key, value, "the autosave of "+title)
+	return holdsValue(saved.Fields, key, value, "the buffer")
 }
 
 // theAdministratorRestoresThePreviousRevisionOf writes the newest revision back over the post.
@@ -444,5 +437,5 @@ func initializeContentFields(sc *godog.ScenarioContext) {
 	sc.Then(`^the request is refused$`, theRequestIsRefused)
 	sc.Then(`^the post "([^"]*)" holds "([^"]*)" in "([^"]*)"$`, thePostHolds)
 	sc.Then(`^the post "([^"]*)" holds no field "([^"]*)"$`, thePostHoldsNoField)
-	sc.Then(`^the autosave of "([^"]*)" holds "([^"]*)" in "([^"]*)"$`, theAutosaveHolds)
+	sc.Then(`^the buffer it saved holds "([^"]*)" in "([^"]*)"$`, theBufferItSavedHolds)
 }

--- a/test/features/steps_content_relations_test.go
+++ b/test/features/steps_content_relations_test.go
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package features_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/cucumber/godog"
+	"github.com/google/uuid"
+
+	"github.com/gopherium/gophenberg/internal/content"
+)
+
+// theRelationFieldHolding registers a relation field naming how many targets it takes.
+func theRelationFieldHolding(ctx context.Context, key, typeKey, target, cardinality string) error {
+	return relationField(ctx, key, typeKey, target, cardinality, false)
+}
+
+// theRequiredRelationFieldHolding registers a relation field publishing demands a target for.
+func theRequiredRelationFieldHolding(ctx context.Context, key, typeKey, target, cardinality string) error {
+	return relationField(ctx, key, typeKey, target, cardinality, true)
+}
+
+// relationField registers one relation field on a type.
+func relationField(ctx context.Context, key, typeKey, target, cardinality string, required bool) error {
+	body := fmt.Sprintf(
+		`{"key":%q,"label":%q,"kind":"relation","relates_to":%q,"many":%t,"required":%t}`,
+		key, key, target, cardinality == "many", required,
+	)
+	if err := addField(ctx, typeKey, body); err != nil {
+		return err
+	}
+	return expectFieldStored(ctx, key)
+}
+
+// theItemExists stores one item of the type and remembers it by title.
+func theItemExists(ctx context.Context, typeKey, title string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	if err := storeItem(w, typeKey, title, ""); err != nil {
+		return err
+	}
+	return w.expect(http.StatusCreated)
+}
+
+// theCategoryExists stores one category.
+func theCategoryExists(ctx context.Context, title string) error {
+	return theItemExists(ctx, "category", title)
+}
+
+// theCategoriesExist stores two categories in the order they are named.
+func theCategoriesExist(ctx context.Context, first, second string) error {
+	if err := theCategoryExists(ctx, first); err != nil {
+		return err
+	}
+	return theCategoryExists(ctx, second)
+}
+
+// theEngineTypeExists stores one engine type.
+func theEngineTypeExists(ctx context.Context, title string) error {
+	return theItemExists(ctx, "engine-type", title)
+}
+
+// theCarExists stores one car.
+func theCarExists(ctx context.Context, title string) error {
+	return theItemExists(ctx, "car", title)
+}
+
+// filedUnder points the item's relation field at the named targets, keeping the answer.
+func filedUnder(ctx context.Context, title, key string, targets []string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	ids := make([]string, len(targets))
+	for i, target := range targets {
+		held, found := w.nested[target]
+		if !found {
+			return fmt.Errorf("the scenario stored nothing titled %q", target)
+		}
+		ids[i] = held.ID
+	}
+	return saveRelation(w, title, key, ids)
+}
+
+// saveRelation sends the relation edit against the item's current version.
+func saveRelation(w *world, title, key string, ids []string) error {
+	stored, err := freshPost(w, title)
+	if err != nil {
+		return err
+	}
+	targets, err := json.Marshal(ids)
+	if err != nil {
+		return fmt.Errorf("building the targets: %w", err)
+	}
+	body := fmt.Sprintf(`{"updated_at":%q,"fields":{%q:%s}}`, stored.UpdatedAt, key, targets)
+	return w.patchJSON(contentPath+"/"+stored.ID, body)
+}
+
+// theAdministratorFilesUnderOne points the item's categories at one target.
+func theAdministratorFilesUnderOne(ctx context.Context, title, target string) error {
+	return filedUnder(ctx, title, "categories", []string{target})
+}
+
+// theAdministratorFilesUnderTwo points the item's categories at two targets in order.
+func theAdministratorFilesUnderTwo(ctx context.Context, title, first, second string) error {
+	return filedUnder(ctx, title, "categories", []string{first, second})
+}
+
+// theAdministratorFilesInFieldUnderOne points the named field at one target.
+func theAdministratorFilesInFieldUnderOne(ctx context.Context, title, key, target string) error {
+	return filedUnder(ctx, title, key, []string{target})
+}
+
+// theAdministratorFilesInFieldUnderTwo points the named field at two targets.
+func theAdministratorFilesInFieldUnderTwo(ctx context.Context, title, key, first, second string) error {
+	return filedUnder(ctx, title, key, []string{first, second})
+}
+
+// thePostFiledInFieldUnder stores a post already pointing at one target.
+func thePostFiledInFieldUnder(ctx context.Context, title, key, target string) error {
+	if err := thePostExists(ctx, title); err != nil {
+		return err
+	}
+	if err := theAdministratorFilesInFieldUnderOne(ctx, title, key, target); err != nil {
+		return err
+	}
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	return w.expect(http.StatusOK)
+}
+
+// thePostFiledUnder stores a post already filed under one category.
+func thePostFiledUnder(ctx context.Context, title, target string) error {
+	return thePostFiledInFieldUnder(ctx, title, "categories", target)
+}
+
+// theAdministratorFilesUnderAnUnstoredTarget points the item at an identity nothing holds.
+func theAdministratorFilesUnderAnUnstoredTarget(ctx context.Context, title string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	return saveRelation(w, title, "categories", []string{uuid.Must(uuid.NewV7()).String()})
+}
+
+// theAdministratorClearsTheRelation empties the item's relation field.
+func theAdministratorClearsTheRelation(ctx context.Context, key, title string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	stored, err := freshPost(w, title)
+	if err != nil {
+		return err
+	}
+	body := fmt.Sprintf(`{"updated_at":%q,"fields":{%q:null}}`, stored.UpdatedAt, key)
+	return w.patchJSON(contentPath+"/"+stored.ID, body)
+}
+
+// theAdministratorPermanentlyDeletes removes the item outright rather than trashing it.
+func theAdministratorPermanentlyDeletes(ctx context.Context, title string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	held, found := w.nested[title]
+	if !found {
+		return fmt.Errorf("the scenario stored nothing titled %q", title)
+	}
+	if err := w.deleteAt(contentPath + "/" + held.ID + "?force=true"); err != nil {
+		return err
+	}
+	return w.expect(http.StatusNoContent)
+}
+
+// theAdministratorFilesCarUnder stores a car and points its engine at one target.
+func theAdministratorFilesCarUnder(ctx context.Context, title, target string) error {
+	if err := theCarExists(ctx, title); err != nil {
+		return err
+	}
+	return filedUnder(ctx, title, "engine", []string{target})
+}
+
+// theItemListsTargets asserts the item points at the named targets in order.
+func theItemListsTargets(ctx context.Context, title, key string, want []string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	stored, err := freshPost(w, title)
+	if err != nil {
+		return err
+	}
+	held, found := stored.Fields[key]
+	if !found {
+		return fmt.Errorf("%q holds no %q, want %s", title, key, strings.Join(want, " then "))
+	}
+	var ids []string
+	if err := json.Unmarshal(held, &ids); err != nil {
+		return fmt.Errorf("%q holds %s in %q, want a list of targets", title, held, key)
+	}
+	return sameTargets(w, ids, want, title, key)
+}
+
+// sameTargets asserts the listed identities are the named items in order.
+func sameTargets(w *world, ids, want []string, title, key string) error {
+	if len(ids) != len(want) {
+		return fmt.Errorf("%q lists %d targets in %q, want %d", title, len(ids), key, len(want))
+	}
+	for i, target := range want {
+		held, found := w.nested[target]
+		if !found {
+			return fmt.Errorf("the scenario stored nothing titled %q", target)
+		}
+		if ids[i] != held.ID {
+			return fmt.Errorf("%q lists %q at place %d in %q, want %q", title, ids[i], i+1, key, target)
+		}
+	}
+	return nil
+}
+
+// theItemListsOne asserts the item points at one named target.
+func theItemListsOne(ctx context.Context, title, target, key string) error {
+	return theItemListsTargets(ctx, title, key, []string{target})
+}
+
+// theItemListsTwoInOrder asserts the item points at two targets in the order given.
+func theItemListsTwoInOrder(ctx context.Context, title, first, second, key string) error {
+	return theItemListsTargets(ctx, title, key, []string{first, second})
+}
+
+// theItemListsNothing asserts the item points at no target through the field.
+func theItemListsNothing(ctx context.Context, title, key string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	stored, err := freshPost(w, title)
+	if err != nil {
+		return err
+	}
+	held, found := stored.Fields[key]
+	if !found {
+		return nil
+	}
+	var ids []string
+	if err := json.Unmarshal(held, &ids); err != nil {
+		return fmt.Errorf("%q holds %s in %q, want a list of targets", title, held, key)
+	}
+	if len(ids) != 0 {
+		return fmt.Errorf("%q still lists %d targets in %q, want none", title, len(ids), key)
+	}
+	return nil
+}
+
+// publishingWithoutTheRequiredTargetIsRefused asserts the publish gate covers a relation field.
+func publishingWithoutTheRequiredTargetIsRefused(ctx context.Context) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	if err := theItemExists(ctx, "car", "Bare car"); err != nil {
+		return err
+	}
+	stored, err := freshPost(w, "Bare car")
+	if err != nil {
+		return err
+	}
+	body := fmt.Sprintf(`{"updated_at":%q,"status":"published"}`, stored.UpdatedAt)
+	if err := w.patchJSON(contentPath+"/"+stored.ID, body); err != nil {
+		return err
+	}
+	return theRequestIsRefused(ctx)
+}
+
+// theRequestIsRefusedAsUnfindable asserts the refusal names a target nothing holds.
+func theRequestIsRefusedAsUnfindable(ctx context.Context) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	if w.answer.status != http.StatusUnprocessableEntity {
+		return fmt.Errorf("status = %d, want %d", w.answer.status, http.StatusUnprocessableEntity)
+	}
+	if !strings.HasPrefix(w.answer.errorMessage(), content.ErrTargetNotFound.Error()) {
+		return fmt.Errorf("the refusal explains %q, want the target reported missing", w.answer.errorMessage())
+	}
+	return nil
+}
+
+// initializeContentRelations registers the steps of the content relations feature.
+func initializeContentRelations(sc *godog.ScenarioContext) {
+	sc.Before(provisionWorld)
+	sc.After(retireWorld)
+	sc.Given(`^a running Gophenberg with the default content types$`, aRunningGophenbergWithTheDefaultContentTypes)
+	sc.Given(`^a signed in administrator$`, aSignedInAdministrator)
+	sc.Given(`^the type "([^"]*)" labeled "([^"]*)" and "([^"]*)" under "([^"]*)"$`, theTypeExists)
+	sc.Given(
+		`^the "relation" field "([^"]*)" on "([^"]*)" targeting "([^"]*)" holding (one|many)$`,
+		theRelationFieldHolding,
+	)
+	sc.Given(
+		`^the required "relation" field "([^"]*)" on "([^"]*)" targeting "([^"]*)" holding (one|many)$`,
+		theRequiredRelationFieldHolding,
+	)
+	sc.Given(`^the category "([^"]*)"$`, theCategoryExists)
+	sc.Given(`^the categories "([^"]*)" and "([^"]*)"$`, theCategoriesExist)
+	sc.Given(`^the engine-type "([^"]*)"$`, theEngineTypeExists)
+	sc.Given(`^the post "([^"]*)"$`, thePostExists)
+	sc.Given(`^the post "([^"]*)" filed under "([^"]*)"$`, thePostFiledUnder)
+	sc.Given(`^the post "([^"]*)" filed in "([^"]*)" under "([^"]*)"$`, thePostFiledInFieldUnder)
+	sc.When(`^the administrator files "([^"]*)" under "([^"]*)"$`, theAdministratorFilesUnderOne)
+	sc.When(`^the administrator files "([^"]*)" under "([^"]*)" and "([^"]*)"$`, theAdministratorFilesUnderTwo)
+	sc.When(
+		`^the administrator files "([^"]*)" in "([^"]*)" under "([^"]*)"$`,
+		theAdministratorFilesInFieldUnderOne,
+	)
+	sc.When(
+		`^the administrator files "([^"]*)" in "([^"]*)" under "([^"]*)" and "([^"]*)"$`,
+		theAdministratorFilesInFieldUnderTwo,
+	)
+	sc.When(
+		`^the administrator files "([^"]*)" under a category that was never stored$`,
+		theAdministratorFilesUnderAnUnstoredTarget,
+	)
+	sc.When(`^the administrator files the car "([^"]*)" under "([^"]*)"$`, theAdministratorFilesCarUnder)
+	sc.When(`^the administrator clears "([^"]*)" of "([^"]*)"$`, theAdministratorClearsTheRelation)
+	sc.When(`^the administrator permanently deletes the category "([^"]*)"$`, theAdministratorPermanentlyDeletes)
+	sc.When(`^the administrator deletes the field "([^"]*)" on "([^"]*)"$`, theAdministratorDeletesTheField)
+	sc.Then(`^"([^"]*)" lists "([^"]*)" in "([^"]*)"$`, theItemListsOne)
+	sc.Then(`^"([^"]*)" lists "([^"]*)" then "([^"]*)" in "([^"]*)"$`, theItemListsTwoInOrder)
+	sc.Then(`^"([^"]*)" lists nothing in "([^"]*)"$`, theItemListsNothing)
+	sc.Then(`^"([^"]*)" lists no field "([^"]*)"$`, thePostHoldsNoField)
+	sc.Then(`^the car "([^"]*)" lists "([^"]*)" in "([^"]*)"$`, theItemListsOne)
+	sc.Then(`^publishing a car holding no engine is refused$`, publishingWithoutTheRequiredTargetIsRefused)
+	sc.Then(`^the request is refused$`, theRequestIsRefused)
+	sc.Then(`^the request is refused explaining (.+)$`, theRequestIsRefusedExplaining)
+	sc.Then(`^the request is refused as unfindable$`, theRequestIsRefusedAsUnfindable)
+}

--- a/test/features/steps_content_relations_test.go
+++ b/test/features/steps_content_relations_test.go
@@ -152,20 +152,6 @@ func theAdministratorFilesUnderAnUnstoredTarget(ctx context.Context, title strin
 	return saveRelation(w, title, "categories", []string{uuid.Must(uuid.NewV7()).String()})
 }
 
-// theAdministratorClearsTheRelation empties the item's relation field.
-func theAdministratorClearsTheRelation(ctx context.Context, key, title string) error {
-	w, err := worldOf(ctx)
-	if err != nil {
-		return err
-	}
-	stored, err := freshPost(w, title)
-	if err != nil {
-		return err
-	}
-	body := fmt.Sprintf(`{"updated_at":%q,"fields":{%q:null}}`, stored.UpdatedAt, key)
-	return w.patchJSON(contentPath+"/"+stored.ID, body)
-}
-
 // theAdministratorPermanentlyDeletes removes the item outright rather than trashing it.
 func theAdministratorPermanentlyDeletes(ctx context.Context, title string) error {
 	w, err := worldOf(ctx)
@@ -284,6 +270,21 @@ func publishingWithoutTheRequiredTargetIsRefused(ctx context.Context) error {
 
 // theRequestIsRefusedAsUnfindable asserts the refusal names a target nothing holds.
 func theRequestIsRefusedAsUnfindable(ctx context.Context) error {
+	return refusedFor(ctx, content.ErrTargetNotFound)
+}
+
+// theRequestIsRefusedAsOverfilled asserts the refusal names a field given more targets than it holds.
+func theRequestIsRefusedAsOverfilled(ctx context.Context) error {
+	return refusedFor(ctx, content.ErrTooManyTargets)
+}
+
+// theRequestIsRefusedAsMistyped asserts the refusal names a target of the wrong type.
+func theRequestIsRefusedAsMistyped(ctx context.Context) error {
+	return refusedFor(ctx, content.ErrTargetType)
+}
+
+// refusedFor asserts the answer turned the edit away for the given reason.
+func refusedFor(ctx context.Context, reason error) error {
 	w, err := worldOf(ctx)
 	if err != nil {
 		return err
@@ -291,8 +292,8 @@ func theRequestIsRefusedAsUnfindable(ctx context.Context) error {
 	if w.answer.status != http.StatusUnprocessableEntity {
 		return fmt.Errorf("status = %d, want %d", w.answer.status, http.StatusUnprocessableEntity)
 	}
-	if !strings.HasPrefix(w.answer.errorMessage(), content.ErrTargetNotFound.Error()) {
-		return fmt.Errorf("the refusal explains %q, want the target reported missing", w.answer.errorMessage())
+	if !strings.HasPrefix(w.answer.errorMessage(), reason.Error()) {
+		return fmt.Errorf("the refusal explains %q, want %q", w.answer.errorMessage(), reason)
 	}
 	return nil
 }
@@ -333,7 +334,7 @@ func initializeContentRelations(sc *godog.ScenarioContext) {
 		theAdministratorFilesUnderAnUnstoredTarget,
 	)
 	sc.When(`^the administrator files the car "([^"]*)" under "([^"]*)"$`, theAdministratorFilesCarUnder)
-	sc.When(`^the administrator clears "([^"]*)" of "([^"]*)"$`, theAdministratorClearsTheRelation)
+	sc.When(`^the administrator clears "([^"]*)" of "([^"]*)"$`, theAdministratorClears)
 	sc.When(`^the administrator permanently deletes the category "([^"]*)"$`, theAdministratorPermanentlyDeletes)
 	sc.When(`^the administrator deletes the field "([^"]*)" on "([^"]*)"$`, theAdministratorDeletesTheField)
 	sc.Then(`^"([^"]*)" lists "([^"]*)" in "([^"]*)"$`, theItemListsOne)
@@ -343,6 +344,7 @@ func initializeContentRelations(sc *godog.ScenarioContext) {
 	sc.Then(`^the car "([^"]*)" lists "([^"]*)" in "([^"]*)"$`, theItemListsOne)
 	sc.Then(`^publishing a car holding no engine is refused$`, publishingWithoutTheRequiredTargetIsRefused)
 	sc.Then(`^the request is refused$`, theRequestIsRefused)
-	sc.Then(`^the request is refused explaining (.+)$`, theRequestIsRefusedExplaining)
 	sc.Then(`^the request is refused as unfindable$`, theRequestIsRefusedAsUnfindable)
+	sc.Then(`^the request is refused because the field holds one target$`, theRequestIsRefusedAsOverfilled)
+	sc.Then(`^the request is refused because the target is the wrong type$`, theRequestIsRefusedAsMistyped)
 }

--- a/test/features/steps_content_terms_test.go
+++ b/test/features/steps_content_terms_test.go
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package features_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/cucumber/godog"
+)
+
+// relatedAnswer is a term page as the content API answers it.
+type relatedAnswer struct {
+	Kind string `json:"kind"`
+	Type struct {
+		Key string `json:"key"`
+	} `json:"type"`
+	Item *struct {
+		Title string `json:"title"`
+		Path  string `json:"path"`
+	} `json:"item"`
+	Page *struct {
+		Items []struct {
+			Title string `json:"title"`
+		} `json:"items"`
+		Total   int `json:"total"`
+		Page    int `json:"page"`
+		PerPage int `json:"per_page"`
+	} `json:"page"`
+}
+
+// theTermTypeExists registers a content type whose items list what points at them.
+func theTermTypeExists(ctx context.Context, key, singular, plural, routeWord string) error {
+	if err := theTypeExists(ctx, key, singular, plural, routeWord); err != nil {
+		return err
+	}
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	if err := w.patchJSON(typesPath+"/"+key, `{"page_kind":"archive"}`); err != nil {
+		return err
+	}
+	return w.expect(http.StatusOK)
+}
+
+// thePublishedCategory takes a category public.
+func thePublishedCategory(ctx context.Context, title string) error {
+	return publish(ctx, "category", title, "")
+}
+
+// thePublishedPostFiledUnder takes a post public filed under a category.
+func thePublishedPostFiledUnder(ctx context.Context, title, target string) error {
+	if err := thePublishedPost(ctx, title); err != nil {
+		return err
+	}
+	if err := theAdministratorFilesUnderOne(ctx, title, target); err != nil {
+		return err
+	}
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	return w.expect(http.StatusOK)
+}
+
+// thePostFiledUnderDraft stores an unpublished post filed under a category.
+func thePostFiledUnderDraft(ctx context.Context, title, target string) error {
+	if err := thePostExists(ctx, title); err != nil {
+		return err
+	}
+	if err := theAdministratorFilesUnderOne(ctx, title, target); err != nil {
+		return err
+	}
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	return w.expect(http.StatusOK)
+}
+
+// thePublishedPostFiledThroughBoth points both relation fields of a post at one category.
+func thePublishedPostFiledThroughBoth(ctx context.Context, title, target string) error {
+	if err := thePublishedPostFiledUnder(ctx, title, target); err != nil {
+		return err
+	}
+	if err := theAdministratorFilesInFieldUnderOne(ctx, title, "series", target); err != nil {
+		return err
+	}
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	return w.expect(http.StatusOK)
+}
+
+// threePublishedPostsFiledUnder takes three posts public under one category.
+func threePublishedPostsFiledUnder(ctx context.Context, target string) error {
+	for _, title := range []string{"First filed", "Second filed", "Third filed"} {
+		if err := thePublishedPostFiledUnder(ctx, title, target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// theAdministratorTrashes sends published content to the trash.
+func theAdministratorTrashes(ctx context.Context, title string) error {
+	return theAdministratorDeletes(ctx, title)
+}
+
+// thePublishedGuideFiledUnder takes a guide public filed under a category.
+func thePublishedGuideFiledUnder(ctx context.Context, title, target string) error {
+	if err := publish(ctx, "guide", title, ""); err != nil {
+		return err
+	}
+	if err := theAdministratorFilesUnderOne(ctx, title, target); err != nil {
+		return err
+	}
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	return w.expect(http.StatusOK)
+}
+
+// aVisitorResolvesOneAtATime asks the content API for an address a single item at a time.
+func aVisitorResolvesOneAtATime(ctx context.Context, address string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	return w.get("/api/content/v1/resolve?per_page=1&path=" + address)
+}
+
+// termAnswer returns the term page the last resolve answered with.
+func termAnswer(ctx context.Context) (relatedAnswer, error) {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return relatedAnswer{}, err
+	}
+	if err := w.expect(http.StatusOK); err != nil {
+		return relatedAnswer{}, fmt.Errorf("resolving the term page: %w", err)
+	}
+	var held relatedAnswer
+	if err := w.answer.decode(&held); err != nil {
+		return relatedAnswer{}, err
+	}
+	return held, nil
+}
+
+// theAnswerIsATermOf asserts the resolver named a term page of the type.
+func theAnswerIsATermOf(ctx context.Context, key string) error {
+	held, err := termAnswer(ctx)
+	if err != nil {
+		return err
+	}
+	if held.Kind != "term" || held.Type.Key != key {
+		return fmt.Errorf("the answer is a %q of %q, want a term of %q", held.Kind, held.Type.Key, key)
+	}
+	return nil
+}
+
+// theAnswerCarriesTheItem asserts the term page carries the addressed item itself.
+func theAnswerCarriesTheItem(ctx context.Context, title string) error {
+	held, err := termAnswer(ctx)
+	if err != nil {
+		return err
+	}
+	if held.Item == nil || held.Item.Title != title {
+		return fmt.Errorf("the answer carries %v, want the item %q", held.Item, title)
+	}
+	return nil
+}
+
+// isAmongTheRelatedContent asserts the term page lists the titled content.
+func isAmongTheRelatedContent(ctx context.Context, title string) error {
+	held, err := termAnswer(ctx)
+	if err != nil {
+		return err
+	}
+	if held.Page == nil {
+		return fmt.Errorf("the answer carries no page, want %q among the related content", title)
+	}
+	for _, listed := range held.Page.Items {
+		if listed.Title == title {
+			return nil
+		}
+	}
+	return fmt.Errorf("the term page lists %d items, none of them %q", len(held.Page.Items), title)
+}
+
+// isNotAmongTheRelatedContent asserts the term page leaves the titled content out.
+func isNotAmongTheRelatedContent(ctx context.Context, title string) error {
+	held, err := termAnswer(ctx)
+	if err != nil {
+		return err
+	}
+	if held.Page == nil {
+		return fmt.Errorf("the answer carries no page, want a listing without %q", title)
+	}
+	for _, listed := range held.Page.Items {
+		if listed.Title == title {
+			return fmt.Errorf("the term page still lists %q", title)
+		}
+	}
+	return nil
+}
+
+// noRelatedContentIsListed asserts the term page lists nothing at all.
+func noRelatedContentIsListed(ctx context.Context) error {
+	held, err := termAnswer(ctx)
+	if err != nil {
+		return err
+	}
+	if held.Page == nil {
+		return fmt.Errorf("the answer carries no page, want an empty listing")
+	}
+	if len(held.Page.Items) != 0 {
+		return fmt.Errorf("the term page lists %d items, want none", len(held.Page.Items))
+	}
+	return nil
+}
+
+// oneItemIsRelated asserts the term page lists exactly one item.
+func oneItemIsRelated(ctx context.Context) error {
+	held, err := termAnswer(ctx)
+	if err != nil {
+		return err
+	}
+	if held.Page == nil || len(held.Page.Items) != 1 {
+		return fmt.Errorf("the term page lists %v, want exactly one item", held.Page)
+	}
+	return nil
+}
+
+// theTermPageHoldsAloneOf asserts which item a page carries and how many the term holds.
+func theTermPageHoldsAloneOf(ctx context.Context, title string, total int) error {
+	held, err := termAnswer(ctx)
+	if err != nil {
+		return err
+	}
+	if held.Page == nil || len(held.Page.Items) != 1 {
+		return fmt.Errorf("the term page lists %v, want %q alone", held.Page, title)
+	}
+	if held.Page.Items[0].Title != title {
+		return fmt.Errorf("the term page lists %q, want %q", held.Page.Items[0].Title, title)
+	}
+	if held.Page.Total != total {
+		return fmt.Errorf("the term page counts %d, want %d behind it", held.Page.Total, total)
+	}
+	return nil
+}
+
+// theAnswerCarriesNoEntityTag asserts the term page offers no validator to cache against.
+func theAnswerCarriesNoEntityTag(ctx context.Context) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	if held := w.answer.header.Get("ETag"); held != "" {
+		return fmt.Errorf("the term page carries the validator %q, want none", held)
+	}
+	return nil
+}
+
+// initializeContentTerms registers the steps of the term page feature.
+func initializeContentTerms(sc *godog.ScenarioContext) {
+	sc.Before(provisionWorld)
+	sc.After(retireWorld)
+	sc.Given(`^a running Gophenberg with the default content types$`, aRunningGophenbergWithTheDefaultContentTypes)
+	sc.Given(`^a signed in administrator$`, aSignedInAdministrator)
+	sc.Given(
+		`^the type "([^"]*)" labeled "([^"]*)" and "([^"]*)" under "([^"]*)" serving term pages$`,
+		theTermTypeExists,
+	)
+	sc.Given(
+		`^the "relation" field "([^"]*)" on "([^"]*)" targeting "([^"]*)" holding (one|many)$`,
+		theRelationFieldHolding,
+	)
+	sc.Given(`^the published category "([^"]*)"$`, thePublishedCategory)
+	sc.Given(`^the published post "([^"]*)"$`, thePublishedPost)
+	sc.Given(`^the published post "([^"]*)" filed under "([^"]*)"$`, thePublishedPostFiledUnder)
+	sc.Given(`^the post "([^"]*)" filed under "([^"]*)"$`, thePostFiledUnderDraft)
+	sc.Given(
+		`^the published post "([^"]*)" filed under "([^"]*)" through both fields$`,
+		thePublishedPostFiledThroughBoth,
+	)
+	sc.Given(`^three published posts filed under "([^"]*)"$`, threePublishedPostsFiledUnder)
+	sc.Given(`^the published guide "([^"]*)" filed under "([^"]*)"$`, thePublishedGuideFiledUnder)
+	sc.Given(`^the type "([^"]*)" labeled "([^"]*)" and "([^"]*)" under "([^"]*)"$`, theTypeExists)
+	sc.When(`^a visitor resolves "([^"]*)"$`, aVisitorResolves)
+	sc.When(`^a visitor resolves "([^"]*)" one item at a time$`, aVisitorResolvesOneAtATime)
+	sc.When(`^the administrator trashes "([^"]*)"$`, theAdministratorTrashes)
+	sc.When(`^the administrator deactivates the type "([^"]*)"$`, theTypeIsDeactivated)
+	sc.Then(`^the answer is a term of "([^"]*)"$`, theAnswerIsATermOf)
+	sc.Then(`^the answer is an archive of "([^"]*)"$`, theAnswerIsAnArchiveOf)
+	sc.Then(`^the answer carries the item "([^"]*)"$`, theAnswerCarriesTheItem)
+	sc.Then(`^"([^"]*)" is among the related content$`, isAmongTheRelatedContent)
+	sc.Then(`^"([^"]*)" is not among the related content$`, isNotAmongTheRelatedContent)
+	sc.Then(`^no related content is listed$`, noRelatedContentIsListed)
+	sc.Then(`^one item is related$`, oneItemIsRelated)
+	sc.Then(`^it holds "([^"]*)" alone of (\d+) related items$`, theTermPageHoldsAloneOf)
+	sc.Then(`^the answer carries no entity tag$`, theAnswerCarriesNoEntityTag)
+	sc.Then(`^"([^"]*)" answers not found$`, theAddressAnswersNotFound)
+}

--- a/test/features/world_test.go
+++ b/test/features/world_test.go
@@ -109,6 +109,8 @@ func provisionWorld(ctx context.Context, _ *godog.Scenario) (context.Context, er
 		return ctx, errors.Join(err, os.RemoveAll(themes), os.RemoveAll(gates))
 	}
 	items := newMemoryContent()
+	types := newMemoryTypes(items)
+	items.types = types
 	return context.WithValue(ctx, worldKey{}, &world{
 		themesDir:    themes,
 		gateDir:      gates,
@@ -117,7 +119,7 @@ func provisionWorld(ctx context.Context, _ *godog.Scenario) (context.Context, er
 		settings:     &memorySettings{values: make(map[string]string)},
 		users:        newMemoryStore(),
 		contentItems: items,
-		contentTypes: newMemoryTypes(items),
+		contentTypes: types,
 		mediaStore:   newMemoryMedia(),
 		mediaFiles:   mediahost.New(mediahost.Config{Dir: uploads, MaxSize: mediaTestCap}),
 	}), nil

--- a/test/theme/src/layouts/Post.astro
+++ b/test/theme/src/layouts/Post.astro
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Blocks } from '@gophenberg/astro/components'
+import { relatedFields } from '@gophenberg/astro'
 
 import type { BlockComponentMap, Post } from '@gophenberg/astro'
 
@@ -14,6 +15,7 @@ interface Props {
 }
 
 const { post, blocks, seo } = Astro.props
+const related = relatedFields(post)
 ---
 
 <Base seo={seo} title={post.title}>
@@ -21,5 +23,16 @@ const { post, blocks, seo } = Astro.props
 		<h1>{post.title}</h1>
 		<time datetime={post.published_at}>{post.published_at.slice(0, 10)}</time>
 		<Blocks html={post.content} components={blocks} post={post} />
+		{
+			related.map((field) => (
+				<ul class="gophenberg-related">
+					{field.items.map((item) => (
+						<li>
+							<a href={`/${item.path}`}>{item.title}</a>
+						</li>
+					))}
+				</ul>
+			))
+		}
 	</article>
 </Base>

--- a/test/theme/src/layouts/Term.astro
+++ b/test/theme/src/layouts/Term.astro
@@ -1,0 +1,45 @@
+---
+// SPDX-License-Identifier: Apache-2.0
+
+import { Blocks } from '@gophenberg/astro/components'
+import type { BlockComponentMap, ContentType, Post, PostSummary } from '@gophenberg/astro'
+
+import Base from './Base.astro'
+
+interface Props {
+	term: Post
+	type: ContentType
+	posts: PostSummary[]
+	total: number
+	page: number
+	perPage: number
+	blocks?: BlockComponentMap
+	seo: { siteName: string }
+}
+
+const { term, posts, page, perPage, total, blocks, seo } = Astro.props
+const root = `/${term.path}`
+const older = page * perPage < total ? `${root}/page/${page + 1}` : undefined
+const newer = page > 1 ? (page === 2 ? root : `${root}/page/${page - 1}`) : undefined
+---
+
+<Base seo={seo} title={term.title}>
+	<article class="gophenberg-term">
+		<h1>{term.title}</h1>
+		<Blocks html={term.content} components={blocks} post={term} />
+	</article>
+	<ul>
+		{
+			posts.map((post) => (
+				<li>
+					<a href={`/${post.path}`}>{post.title}</a>
+					<p>{post.excerpt}</p>
+				</li>
+			))
+		}
+	</ul>
+	<nav>
+		{newer && <a rel="prev" href={newer}>Newer</a>}
+		{older && <a rel="next" href={older}>Older</a>}
+	</nav>
+</Base>

--- a/test/theme/src/theme.ts
+++ b/test/theme/src/theme.ts
@@ -7,9 +7,10 @@ import Archive from './layouts/Archive.astro'
 import Base from './layouts/Base.astro'
 import NotFound from './layouts/NotFound.astro'
 import Post from './layouts/Post.astro'
+import Term from './layouts/Term.astro'
 
 export default defineTheme({
-	layouts: { Base, Post, Archive, NotFound },
+	layouts: { Base, Post, Archive, Term, NotFound },
 	blocks: { 'core/quote': Quote },
 	pagination: { perPage: 2 },
 	seo: { siteName: 'Gophenberg Starter' },


### PR DESCRIPTION
Cloases #44 

A content type can now declare typed fields, and one field kind points at another type. Values live on the item, relations live in their own indexed table, and an item whose type serves term pages answers with itself and the published content pointing at it. Categories are that machinery seeded: an ordinary hierarchical type plus a relation field on Posts, so a category carries its own body and its posts on one page.

Two migrations run on start, one for field definitions and values, one for the relation table. Back up the database first. Themes must move with this release: the kit requires a `Term` layout and item payloads gained a `fields` member, so
a theme on the previous kit will not serve.

## Testing

Everything below runs against a development database. `make seed` is
idempotent, so an existing database keeps what it already holds.

```sh
make seed
make dev
```

In a second terminal:

```sh
pnpm install && pnpm --filter @gophenberg/frontend dev
```

### The public site

Open these on the backend at `http://localhost:8081`:

- `/categories` lists the seeded **News** category
- `/categories/news` carries the category's own body above **Welcome to Gophenberg**
- `/welcome-to-gophenberg` links to **News**, and the link walks to the category page
- `/welcome-to-gophenberg/page/2` answers 404, since a page word belongs to a listing
- `/categories/news/page/2` answers the second page of the term
- `/api/content/v1` carries a `fields` array on the `post` type naming `categories`
- `/api/content/v1/resolve?path=/categories/news` answers `"kind": "term"` with an `item` and a `page` together, and no `ETag` header
- `/api/content/v1/resolve?path=/welcome-to-gophenberg` carries `fields.categories` as a list of `{id, title, path}`

### The admin

Sign in at `http://localhost:5174/admin/` with `admin@example.com` and `password1234`.

1. Open **Content Types**. The table lists **Categories** beside Posts and Pages.
2. Press **Fields** on the Posts row. The view lists the seeded `categories`  relation.
3. In the same view enter `Colour` under Name, leave the kind on Text, and press **Add field**. It appears in the list.
4. Open **Posts**, then **Welcome to Gophenberg**. The Document panel now shows a **Colour** box and a **Categories** list holding News, with a select to add another and a **Remove News** button.
5. Type into Colour and press **Save draft**. Reload the editor and the value is still there.
6. Press **Rename Colour**, change the name to `Paint`, and confirm. The editor shows Paint, and the value it held is untouched.
7. Press **Delete Paint**. The dialog states that every value goes with it, in every post and in the revisions behind them. Confirm, reload the editor, and the box is gone.

### Refusals worth checking

- Declare a second field named `Categories` on Posts. The registry refuses the taken key.
- On the Categories row press **Delete**. It is refused while a field of Posts still points at the type.
- Through the API, publish an item holding no value for a required field. The publish is refused and the message names the field, while saving it as a draft is allowed.
- Deactivate the Posts type through the API, then open `/categories/news`. The term page lists nothing, and reactivating brings the post back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable text, number, boolean, date, media, and relation fields.
  * Added field management, required-field validation, and single- or multi-item relations.
  * Added field values to editing, autosave, revisions, publishing, and API responses.
  * Added category term pages with related published content, filtering, and pagination.
  * Added theme support for term pages and related content.
  * Added support for archive page types and complete-content ETag updates.

* **Documentation**
  * Added guides covering fields, relations, term layouts, API behavior, and upgrade requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->