### PR TITLE
Translations: carry only the languages the site answers in

### DIFF
--- a/frontend/scripts/poeditor.ts
+++ b/frontend/scripts/poeditor.ts
@@ -37,7 +37,10 @@ export function localeFor(code: string, supported: string[]): string | undefined
 	if (supported.includes(code)) {
 		return code
 	}
-	const sharing = supported.filter((held) => held.split('-')[0] === code.split('-')[0])
+	if (code.includes('-')) {
+		return undefined
+	}
+	const sharing = supported.filter((held) => held.split('-')[0] === code)
 	return sharing.length === 1 ? sharing[0] : undefined
 }
 

--- a/frontend/scripts/poeditor.ts
+++ b/frontend/scripts/poeditor.ts
@@ -1,6 +1,87 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
 import { po } from 'gettext-parser'
+
+/** Where the application declares the languages it answers in. */
+const LOCALE_SOURCE = ['internal', 'content', 'locale.go']
+
+/**
+ * Returns the languages the application answers in, as it declares them.
+ * @param root - The repository root the declaration sits under.
+ * @returns The languages, the fallback first.
+ */
+export function supportedLocales(root: string): string[] {
+	const source = readFileSync(join(root, ...LOCALE_SOURCE), 'utf8')
+	const declared = /DefaultLocale\s*=\s*"([^"]+)"/.exec(source)
+	const listed = /SupportedLocales\s*=\s*\[\]string\{([^}]*)\}/.exec(source)
+	if (declared === null || listed === null) {
+		throw new Error('the application declares no supported languages')
+	}
+	return listed[1]
+		.split(',')
+		.map((held) => held.trim())
+		.filter((held) => held !== '')
+		.map((held) => (held === 'DefaultLocale' ? declared[1] : held.replace(/"/g, '')))
+}
+
+/**
+ * Returns the language the application knows a platform code as, if it knows one.
+ * @param code - The language as the platform names it.
+ * @param supported - The languages the application answers in.
+ * @returns The application's own name for it, or nothing when it answers in no such language.
+ */
+export function localeFor(code: string, supported: string[]): string | undefined {
+	if (supported.includes(code)) {
+		return code
+	}
+	const sharing = supported.filter((held) => held.split('-')[0] === code.split('-')[0])
+	return sharing.length === 1 ? sharing[0] : undefined
+}
+
+/**
+ * Returns how many messages a catalogue answers.
+ * @param source - The catalogue as PO text.
+ * @returns The count of messages carrying a translation.
+ */
+export function translated(source: string): number {
+	let held = 0
+	for (const entries of Object.values(po.parse(source).translations)) {
+		for (const [msgid, entry] of Object.entries(entries)) {
+			if (msgid !== '' && entry.msgstr.some((form) => form !== '')) {
+				held += 1
+			}
+		}
+	}
+	return held
+}
+
+/**
+ * Returns an incoming catalogue under the plural rule the committed one declares.
+ * @param current - The catalogue as committed.
+ * @param incoming - The catalogue the platform exported.
+ * @returns The incoming catalogue, carrying the committed plural rule and no form beyond it.
+ */
+export function withPluralRuleOf(current: string, incoming: string): string {
+	const parsed = po.parse(current)
+	const rule = parsed.headers['Plural-Forms']
+	if (rule === undefined) {
+		return incoming
+	}
+	const held = po.parse(incoming)
+	held.headers['Plural-Forms'] = rule
+	const forms = Number(/nplurals\s*=\s*(\d+)/.exec(rule)?.[1] ?? 1)
+	for (const entries of Object.values(held.translations)) {
+		for (const entry of Object.values(entries)) {
+			if (entry.msgstr.length > forms) {
+				entry.msgstr = entry.msgstr.slice(0, forms)
+			}
+		}
+	}
+	return po.compile(held, { foldLength: 0, eol: '\n' }).toString()
+}
 
 /** How long any one call to the platform may take. */
 const REQUEST_TIMEOUT = 30_000

--- a/frontend/scripts/sync-translations.ts
+++ b/frontend/scripts/sync-translations.ts
@@ -3,7 +3,14 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
-import { meaningfulChange, poeditorAt } from './poeditor.ts'
+import {
+	localeFor,
+	meaningfulChange,
+	poeditorAt,
+	supportedLocales,
+	translated,
+	withPluralRuleOf,
+} from './poeditor.ts'
 import { repositoryRoot } from './pot.ts'
 
 const token = process.env.POEDITOR_API_TOKEN
@@ -15,13 +22,26 @@ if (token === undefined || project === undefined) {
 }
 
 const platform = poeditorAt(token, project)
-const languages = join(repositoryRoot(), 'languages')
+const root = repositoryRoot()
+const languages = join(root, 'languages')
+const supported = supportedLocales(root)
 const moved: string[] = []
+const skipped: string[] = []
 
-for (const locale of await platform.languages()) {
+for (const named of await platform.languages()) {
+	const locale = localeFor(named, supported)
+	if (locale === undefined) {
+		skipped.push(`${named}, which the site does not answer in`)
+		continue
+	}
 	const target = join(languages, `${locale}.po`)
-	const incoming = await platform.exportPo(locale)
 	const current = existsSync(target) ? readFileSync(target, 'utf8') : undefined
+	const exported = await platform.exportPo(locale)
+	if (translated(exported) === 0) {
+		skipped.push(`${named}, which nobody has translated yet`)
+		continue
+	}
+	const incoming = current === undefined ? exported : withPluralRuleOf(current, exported)
 	if (!meaningfulChange(current, incoming)) {
 		continue
 	}
@@ -30,3 +50,6 @@ for (const locale of await platform.languages()) {
 }
 
 console.log(moved.length === 0 ? 'no translation moved' : `translations moved: ${moved.join(', ')}`)
+for (const held of skipped) {
+	console.log(`skipped ${held}`)
+}

--- a/frontend/scripts/sync-translations.ts
+++ b/frontend/scripts/sync-translations.ts
@@ -36,7 +36,7 @@ for (const named of await platform.languages()) {
 	}
 	const target = join(languages, `${locale}.po`)
 	const current = existsSync(target) ? readFileSync(target, 'utf8') : undefined
-	const exported = await platform.exportPo(locale)
+	const exported = await platform.exportPo(named)
 	if (translated(exported) === 0) {
 		skipped.push(`${named}, which nobody has translated yet`)
 		continue

--- a/frontend/src/test/poeditor.test.ts
+++ b/frontend/src/test/poeditor.test.ts
@@ -258,3 +258,25 @@ msgstr[1] "%d entradas"
 
 	expect(withPluralRuleOf(ours, theirs)).not.toMatch(/msgstr\[1\]/)
 })
+
+test('refuses a region the application does not answer in, rather than taking another', () => {
+	expect(localeFor('es-MX', ['en-US', 'es-ES'])).toBeUndefined()
+})
+
+test('asks the platform for a language under the platform own name', async () => {
+	const asked: string[] = []
+	const fetched = vi.fn(async (url: string, init?: { body?: URLSearchParams }) => {
+		if (init?.body !== undefined) {
+			asked.push(init.body.get('language') ?? '')
+			return {
+				ok: true,
+				json: async () => ({ response: { status: 'success' }, result: { url: 'https://held/es.po' } }),
+			}
+		}
+		return { ok: true, text: async () => 'msgid ""\nmsgstr ""\n' }
+	})
+
+	await poeditorAt('t', '1', fetched as never).exportPo('es')
+
+	expect(asked[0]).toBe('es')
+})

--- a/frontend/src/test/poeditor.test.ts
+++ b/frontend/src/test/poeditor.test.ts
@@ -265,7 +265,7 @@ test('refuses a region the application does not answer in, rather than taking an
 
 test('asks the platform for a language under the platform own name', async () => {
 	const asked: string[] = []
-	const fetched = vi.fn(async (url: string, init?: { body?: URLSearchParams }) => {
+	const fetched = vi.fn(async (_url: string, init?: { body?: URLSearchParams }) => {
 		if (init?.body !== undefined) {
 			asked.push(init.body.get('language') ?? '')
 			return {

--- a/frontend/src/test/poeditor.test.ts
+++ b/frontend/src/test/poeditor.test.ts
@@ -1,8 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { expect, test, vi } from 'vitest'
 
-import { localeOf, meaningfulChange, poeditorAt } from '../../scripts/poeditor.ts'
+import {
+	localeFor,
+	localeOf,
+	meaningfulChange,
+	poeditorAt,
+	supportedLocales,
+	translated,
+	withPluralRuleOf,
+} from '../../scripts/poeditor.ts'
+import { repositoryRoot } from '../../scripts/pot.ts'
 
 const HEADER = `msgid ""
 msgstr ""
@@ -147,4 +159,102 @@ test('names no reason when the platform refused without one', async () => {
 	const fetched = vi.fn(async () => ({ ok: true, json: async () => ({ response: { status: 'fail' } }) }))
 
 	await expect(poeditorAt('t', '1', fetched as never).languages()).rejects.toThrow(/no reason given/)
+})
+
+test('reads the languages the application says it answers in', () => {
+	expect(supportedLocales(repositoryRoot())).toEqual(['en-US', 'es-ES'])
+})
+
+test('matches a language named exactly as the application names it', () => {
+	expect(localeFor('es-ES', ['en-US', 'es-ES'])).toBe('es-ES')
+})
+
+test('matches a bare language against the one region the application supports', () => {
+	expect(localeFor('es', ['en-US', 'es-ES'])).toBe('es-ES')
+})
+
+test('refuses a bare language when two regions of it are supported', () => {
+	expect(localeFor('es', ['es-ES', 'es-MX'])).toBeUndefined()
+})
+
+test('refuses a language the application does not answer in', () => {
+	expect(localeFor('fr', ['en-US', 'es-ES'])).toBeUndefined()
+})
+
+test('reports a catalogue nobody has translated yet', () => {
+	const bare = `msgid ""
+msgstr ""
+"Language: fr\\n"
+
+msgid "Older posts"
+msgstr ""
+`
+
+	expect(translated(bare)).toBe(0)
+})
+
+test('counts the messages a catalogue answers', () => {
+	const held = `msgid ""
+msgstr ""
+"Language: es-ES\\n"
+
+msgid "Older posts"
+msgstr "Entradas anteriores"
+`
+
+	expect(translated(held)).toBe(1)
+})
+
+test('keeps the plural rule the committed catalogue declares', () => {
+	const ours = `msgid ""
+msgstr ""
+"Language: es-ES\\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\\n"
+`
+	const theirs = `msgid ""
+msgstr ""
+"Language: es-ES\\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n==2 ? 1 : 2);\\n"
+
+msgid "%d post"
+msgid_plural "%d posts"
+msgstr[0] "%d entrada"
+msgstr[1] "%d entradas"
+msgstr[2] ""
+`
+
+	const held = withPluralRuleOf(ours, theirs)
+
+	expect(held).toContain('nplurals=2')
+	expect(held).not.toContain('nplurals=3')
+	expect(held).not.toMatch(/msgstr\[2\]/)
+})
+
+test('refuses a source that declares no supported languages', () => {
+	const root = mkdtempSync(join(tmpdir(), 'gophenberg-locale-'))
+	mkdirSync(join(root, 'internal', 'content'), { recursive: true })
+	writeFileSync(join(root, 'internal', 'content', 'locale.go'), 'package content\n')
+
+	expect(() => supportedLocales(root)).toThrow(/no supported languages/)
+})
+
+test('takes the platform plural rule when the catalogue declares none', () => {
+	const ours = 'msgid ""\nmsgstr ""\n"Language: es-ES\\n"\n'
+	const theirs = 'msgid ""\nmsgstr ""\n"Plural-Forms: nplurals=2; plural=(n != 1);\\n"\n'
+
+	expect(withPluralRuleOf(ours, theirs)).toBe(theirs)
+})
+
+test('keeps one form when the committed rule names no count', () => {
+	const ours = 'msgid ""\nmsgstr ""\n"Plural-Forms: plural=(n != 1);\\n"\n'
+	const theirs = `msgid ""
+msgstr ""
+
+msgid "%d post"
+msgid_plural "%d posts"
+msgstr[0] "%d entrada"
+msgstr[1] "%d entradas"
+`
+
+	expect(withPluralRuleOf(ours, theirs)).not.toMatch(/msgstr\[1\]/)
 })


### PR DESCRIPTION
The first live sync run opened a pull request of six files the site cannot use. This makes the site's supported list the authority, maps a bare platform code onto the one region the site supports, skips untranslated and unsupported languages with a logged reason, and keeps the committed plural rule.

## Testing

    make db-up
    pnpm --filter @gophenberg/frontend cover
    pnpm lint
    pnpm exec eslint .
    pnpm exec knip

720 tests, coverage at 100 percent on all four metrics.

The sync itself cannot be exercised without platform credentials. After merging, run the translations workflow by hand. It should print no translation moved, skip French as untranslated, and skip Spanish Mexico as a language the site does not answer in.

Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved translation synchronization by matching language names, regional variants, and platform codes to supported site locales.
  - Added clearer reporting for skipped unsupported or untranslated languages.

- **Bug Fixes**
  - Prevented unsupported languages and untranslated catalogues from being imported.
  - Preserved existing pluralization rules when importing translation updates.
  - Improved handling of differing, missing, or singular plural-form metadata.
  - Added validation when supported locale information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->