### PR TITLE
Testing: reach the decisions hidden inside excluded runners

### DIFF
--- a/frontend/scripts/sync-translations.ts
+++ b/frontend/scripts/sync-translations.ts
@@ -3,15 +3,9 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
-import {
-	localeFor,
-	meaningfulChange,
-	poeditorAt,
-	supportedLocales,
-	translated,
-	withPluralRuleOf,
-} from './poeditor.ts'
+import { poeditorAt, supportedLocales } from './poeditor.ts'
 import { repositoryRoot } from './pot.ts'
+import { syncTranslations } from './sync.ts'
 
 const token = process.env.POEDITOR_API_TOKEN
 const project = process.env.POEDITOR_PROJECT_ID
@@ -21,35 +15,18 @@ if (token === undefined || project === undefined) {
 	process.exit(1)
 }
 
-const platform = poeditorAt(token, project)
 const root = repositoryRoot()
 const languages = join(root, 'languages')
-const supported = supportedLocales(root)
-const moved: string[] = []
-const skipped: string[] = []
 
-for (const named of await platform.languages()) {
-	const locale = localeFor(named, supported)
-	if (locale === undefined) {
-		skipped.push(`${named}, which the site does not answer in`)
-		continue
-	}
-	const target = join(languages, `${locale}.po`)
-	const current = existsSync(target) ? readFileSync(target, 'utf8') : undefined
-	const exported = await platform.exportPo(named)
-	if (translated(exported) === 0) {
-		skipped.push(`${named}, which nobody has translated yet`)
-		continue
-	}
-	const incoming = current === undefined ? exported : withPluralRuleOf(current, exported)
-	if (!meaningfulChange(current, incoming)) {
-		continue
-	}
-	writeFileSync(target, incoming)
-	moved.push(locale)
-}
+const done = await syncTranslations(poeditorAt(token, project), supportedLocales(root), {
+	read: (locale) => {
+		const target = join(languages, `${locale}.po`)
+		return existsSync(target) ? readFileSync(target, 'utf8') : undefined
+	},
+	write: (locale, source) => writeFileSync(join(languages, `${locale}.po`), source),
+})
 
-console.log(moved.length === 0 ? 'no translation moved' : `translations moved: ${moved.join(', ')}`)
-for (const held of skipped) {
+console.log(done.moved.length === 0 ? 'no translation moved' : `translations moved: ${done.moved.join(', ')}`)
+for (const held of done.skipped) {
 	console.log(`skipped ${held}`)
 }

--- a/frontend/scripts/sync.ts
+++ b/frontend/scripts/sync.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { localeFor, meaningfulChange, translated, withPluralRuleOf } from './poeditor.ts'
+import type { Poeditor } from './poeditor.ts'
+
+/** Where the catalogues a sync reads and writes live. */
+export interface Catalogues {
+	read: (locale: string) => string | undefined
+	write: (locale: string, source: string) => void
+}
+
+/** What one sync did, in words fit for a log. */
+export interface Synced {
+	moved: string[]
+	skipped: string[]
+}
+
+/**
+ * Carries every translation the platform holds for a language the site answers in.
+ * @param platform - The translation platform to read.
+ * @param supported - The languages the site answers in.
+ * @param held - Where the catalogues live.
+ * @returns The languages that moved and the ones passed over, each with its reason.
+ */
+export async function syncTranslations(
+	platform: Poeditor,
+	supported: string[],
+	held: Catalogues,
+): Promise<Synced> {
+	const moved: string[] = []
+	const skipped: string[] = []
+	for (const named of await platform.languages()) {
+		const locale = localeFor(named, supported)
+		if (locale === undefined) {
+			skipped.push(`${named}, which the site does not answer in`)
+			continue
+		}
+		const exported = await platform.exportPo(named)
+		if (translated(exported) === 0) {
+			skipped.push(`${named}, which nobody has translated yet`)
+			continue
+		}
+		const current = held.read(locale)
+		const incoming = current === undefined ? exported : withPluralRuleOf(current, exported)
+		if (!meaningfulChange(current, incoming)) {
+			continue
+		}
+		held.write(locale, incoming)
+		moved.push(locale)
+	}
+	return { moved, skipped }
+}

--- a/frontend/src/test/sync.test.ts
+++ b/frontend/src/test/sync.test.ts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, test } from 'vitest'
+
+import { syncTranslations } from '../../scripts/sync.ts'
+import type { Catalogues } from '../../scripts/sync.ts'
+import type { Poeditor } from '../../scripts/poeditor.ts'
+
+const HEADER = `msgid ""
+msgstr ""
+"Language: es-ES\\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\\n"
+`
+
+/**
+ * Returns a catalogue carrying one translation.
+ * @param msgstr - The translation the catalogue holds.
+ * @returns The catalogue as PO text.
+ */
+function catalogue(msgstr: string): string {
+	return `${HEADER}\nmsgid "Older posts"\nmsgstr "${msgstr}"\n`
+}
+
+/**
+ * Returns a platform answering with the given languages and exports.
+ * @param languages - The languages the platform lists.
+ * @param exports - The catalogue each language exports, keyed by platform name.
+ * @param asked - The names the platform was asked for, appended to.
+ * @returns The platform.
+ */
+function platformOf(
+	languages: string[],
+	exports: Record<string, string>,
+	asked: string[] = [],
+): Poeditor {
+	return {
+		languages: async () => languages,
+		exportPo: async (named: string) => {
+			asked.push(named)
+			return exports[named] ?? ''
+		},
+	}
+}
+
+/**
+ * Returns a catalogue store over the given committed sources.
+ * @param committed - The catalogues already committed, keyed by locale.
+ * @returns The store and the writes it received.
+ */
+function storeOf(committed: Record<string, string> = {}): {
+	held: Catalogues
+	written: Record<string, string>
+} {
+	const written: Record<string, string> = {}
+	return {
+		held: {
+			read: (locale: string) => committed[locale],
+			write: (locale: string, source: string) => {
+				written[locale] = source
+			},
+		},
+		written,
+	}
+}
+
+test('asks the platform under its own name and writes under the site locale', async () => {
+	const asked: string[] = []
+	const platform = platformOf(['es'], { es: catalogue('Entradas anteriores') }, asked)
+	const { held, written } = storeOf()
+
+	const done = await syncTranslations(platform, ['en-US', 'es-ES'], held)
+
+	expect(asked).toEqual(['es'])
+	expect(Object.keys(written)).toEqual(['es-ES'])
+	expect(done.moved).toEqual(['es-ES'])
+})
+
+test('skips a language the site does not answer in', async () => {
+	const asked: string[] = []
+	const platform = platformOf(['fr'], { fr: catalogue('Articles plus anciens') }, asked)
+	const { held, written } = storeOf()
+
+	const done = await syncTranslations(platform, ['en-US', 'es-ES'], held)
+
+	expect(asked).toEqual([])
+	expect(written).toEqual({})
+	expect(done.skipped[0]).toContain('fr')
+})
+
+test('skips a region the site does not answer in, rather than writing over another', async () => {
+	const platform = platformOf(['es-MX'], { 'es-MX': catalogue('Entradas antiguas') })
+	const { held, written } = storeOf({ 'es-ES': catalogue('Entradas anteriores') })
+
+	await syncTranslations(platform, ['en-US', 'es-ES'], held)
+
+	expect(written).toEqual({})
+})
+
+test('skips a language nobody has translated yet', async () => {
+	const bare = `${HEADER}\nmsgid "Older posts"\nmsgstr ""\n`
+	const platform = platformOf(['es'], { es: bare })
+	const { held, written } = storeOf()
+
+	const done = await syncTranslations(platform, ['en-US', 'es-ES'], held)
+
+	expect(written).toEqual({})
+	expect(done.skipped[0]).toContain('nobody has translated')
+})
+
+test('writes nothing when the platform says what the catalogue already says', async () => {
+	const same = catalogue('Entradas anteriores')
+	const platform = platformOf(['es'], { es: same })
+	const { held, written } = storeOf({ 'es-ES': same })
+
+	const done = await syncTranslations(platform, ['en-US', 'es-ES'], held)
+
+	expect(written).toEqual({})
+	expect(done.moved).toEqual([])
+})
+
+test('keeps the plural rule the committed catalogue declares', async () => {
+	const theirs = `msgid ""
+msgstr ""
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n==2 ? 1 : 2);\\n"
+
+msgid "%d post"
+msgid_plural "%d posts"
+msgstr[0] "%d entrada"
+msgstr[1] "%d entradas"
+msgstr[2] ""
+`
+	const platform = platformOf(['es'], { es: theirs })
+	const { held, written } = storeOf({ 'es-ES': HEADER })
+
+	await syncTranslations(platform, ['en-US', 'es-ES'], held)
+
+	expect(written['es-ES']).toContain('nplurals=2')
+	expect(written['es-ES']).not.toMatch(/msgstr\[2\]/)
+})


### PR DESCRIPTION
Closes #57

The sync loop lived in a coverage-excluded runner, so a defect that confused the platform's language code with the site's locale passed every test. The loop is now a function the tests drive with a fake platform and a fake catalogue store, and the runner holds only wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved translation synchronization across supported site locales.
  * Preserves existing pluralization rules and avoids unnecessary catalog updates.
  * Reports languages that were synchronized or skipped.

* **Bug Fixes**
  * Prevents unsupported languages, regions, and untranslated catalogs from being imported.

* **Tests**
  * Added coverage for locale mapping, skipped translations, unchanged catalogs, and plural-rule preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->