### PR TITLE
Translations: send new strings to the platform and stop the gate blocking on them

### DIFF
--- a/frontend/scripts/poeditor.ts
+++ b/frontend/scripts/poeditor.ts
@@ -201,11 +201,6 @@ export function poeditorAt(token: string, project: string, fetched: typeof fetch
 			return (held.languages ?? []).map((named) => localeOf(named.code))
 		},
 		/**
-		 * Returns one language's catalogue as the platform exports it.
-		 * @param locale - The language to export.
-		 * @returns The catalogue as PO text.
-		 */
-		/**
 		 * Adds to the platform every term the template names, leaving translations alone.
 		 * @param source - The catalogue template as POT text.
 		 */

--- a/frontend/scripts/poeditor.ts
+++ b/frontend/scripts/poeditor.ts
@@ -105,6 +105,7 @@ interface Answer {
 export interface Poeditor {
 	languages: () => Promise<string[]>
 	exportPo: (locale: string) => Promise<string>
+	uploadTerms: (source: string) => Promise<void>
 }
 
 /**
@@ -198,6 +199,36 @@ export function poeditorAt(token: string, project: string, fetched: typeof fetch
 		languages: async () => {
 			const held = await ask(fetched, 'languages/list', credentials())
 			return (held.languages ?? []).map((named) => localeOf(named.code))
+		},
+		/**
+		 * Returns one language's catalogue as the platform exports it.
+		 * @param locale - The language to export.
+		 * @returns The catalogue as PO text.
+		 */
+		/**
+		 * Adds to the platform every term the template names, leaving translations alone.
+		 * @param source - The catalogue template as POT text.
+		 */
+		uploadTerms: async (source: string) => {
+			const form = new FormData()
+			form.set('api_token', token)
+			form.set('id', project)
+			form.set('updating', 'terms')
+			form.set('file', new Blob([source]), 'gophenberg.pot')
+			const response = await fetched(`${API}/projects/upload`, {
+				method: 'POST',
+				body: form,
+				signal: AbortSignal.timeout(REQUEST_TIMEOUT),
+			})
+			if (!response.ok) {
+				throw new Error(`the translation platform answered ${response.status}`)
+			}
+			const answered = (await response.json()) as Answer
+			if (answered.response.status !== 'success') {
+				throw new Error(
+					`the translation platform refused: ${answered.response.message ?? 'no reason given'}`,
+				)
+			}
 		},
 		/**
 		 * Returns one language's catalogue as the platform exports it.

--- a/frontend/scripts/pot.ts
+++ b/frontend/scripts/pot.ts
@@ -6,7 +6,7 @@ import { readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 
 /** The text domain every Gophenberg owned string names. */
-const DOMAIN = 'gophenberg'
+export const DOMAIN = 'gophenberg'
 
 /** The globs holding every string the admin ships, read from the repository root. */
 const SOURCES = ['frontend/src/**/*.{ts,tsx}', 'sdk/frontend/**/*.{ts,tsx}']

--- a/frontend/scripts/sync-translations.ts
+++ b/frontend/scripts/sync-translations.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { poeditorAt, supportedLocales } from './poeditor.ts'
-import { repositoryRoot } from './pot.ts'
+import { DOMAIN, repositoryRoot } from './pot.ts'
 import { syncTranslations } from './sync.ts'
 
 const token = process.env.POEDITOR_API_TOKEN
@@ -24,7 +24,7 @@ const done = await syncTranslations(poeditorAt(token, project), supportedLocales
 		return existsSync(target) ? readFileSync(target, 'utf8') : undefined
 	},
 	write: (locale, source) => writeFileSync(join(languages, `${locale}.po`), source),
-})
+}, readFileSync(join(languages, `${DOMAIN}.pot`), 'utf8'))
 
 console.log(done.moved.length === 0 ? 'no translation moved' : `translations moved: ${done.moved.join(', ')}`)
 for (const held of done.skipped) {

--- a/frontend/scripts/sync.ts
+++ b/frontend/scripts/sync.ts
@@ -20,15 +20,18 @@ export interface Synced {
  * @param platform - The translation platform to read.
  * @param supported - The languages the site answers in.
  * @param held - Where the catalogues live.
+ * @param template - The catalogue template naming every message the site shows.
  * @returns The languages that moved and the ones passed over, each with its reason.
  */
 export async function syncTranslations(
 	platform: Poeditor,
 	supported: string[],
 	held: Catalogues,
+	template: string,
 ): Promise<Synced> {
 	const moved: string[] = []
 	const skipped: string[] = []
+	await platform.uploadTerms(template)
 	for (const named of await platform.languages()) {
 		const locale = localeFor(named, supported)
 		if (locale === undefined) {

--- a/frontend/src/test/poeditor.test.ts
+++ b/frontend/src/test/poeditor.test.ts
@@ -284,9 +284,12 @@ test('asks the platform for a language under the platform own name', async () =>
 test('sends only the fields an upload needs, so no destructive option can ride along', async () => {
 	let sent: string[] = []
 	let path = ''
+	let uploaded = new File([], '')
 	const fetched = vi.fn(async (url: string, init?: { body?: FormData }) => {
 		path = url
-		sent = [...((init as { body: FormData }).body).keys()].sort()
+		const body = (init as { body: FormData }).body
+		sent = [...body.keys()].sort()
+		uploaded = body.get('file') as File
 		return { ok: true, json: async () => ({ response: { status: 'success' } }) }
 	})
 
@@ -294,6 +297,8 @@ test('sends only the fields an upload needs, so no destructive option can ride a
 
 	expect(path).toContain('projects/upload')
 	expect(sent).toEqual(['api_token', 'file', 'id', 'updating'])
+	expect(await uploaded.text()).toBe('msgid ""\nmsgstr ""\n')
+	expect(uploaded.name).toBe('gophenberg.pot')
 })
 
 test('uploads terms only, so no translation can be overwritten', async () => {

--- a/frontend/src/test/poeditor.test.ts
+++ b/frontend/src/test/poeditor.test.ts
@@ -280,3 +280,57 @@ test('asks the platform for a language under the platform own name', async () =>
 
 	expect(asked[0]).toBe('es')
 })
+
+test('sends only the fields an upload needs, so no destructive option can ride along', async () => {
+	let sent: string[] = []
+	let path = ''
+	const fetched = vi.fn(async (url: string, init?: { body?: FormData }) => {
+		path = url
+		sent = [...((init as { body: FormData }).body).keys()].sort()
+		return { ok: true, json: async () => ({ response: { status: 'success' } }) }
+	})
+
+	await poeditorAt('t', '1', fetched as never).uploadTerms('msgid ""\nmsgstr ""\n')
+
+	expect(path).toContain('projects/upload')
+	expect(sent).toEqual(['api_token', 'file', 'id', 'updating'])
+})
+
+test('uploads terms only, so no translation can be overwritten', async () => {
+	let updating = ''
+	const fetched = vi.fn(async (_url: string, init?: { body?: FormData }) => {
+		updating = String(((init as { body: FormData }).body).get('updating'))
+		return { ok: true, json: async () => ({ response: { status: 'success' } }) }
+	})
+
+	await poeditorAt('t', '1', fetched as never).uploadTerms('msgid ""\nmsgstr ""\n')
+
+	expect(updating).toBe('terms')
+})
+
+test('refuses an upload the platform did not accept', async () => {
+	const fetched = vi.fn(async () => ({ ok: false, status: 502, json: async () => ({}) }))
+
+	await expect(poeditorAt('t', '1', fetched as never).uploadTerms('msgid ""\n')).rejects.toThrow(
+		/502/,
+	)
+})
+
+test('refuses an upload the platform reported a failure for', async () => {
+	const fetched = vi.fn(async () => ({
+		ok: true,
+		json: async () => ({ response: { status: 'fail', message: 'terms locked' } }),
+	}))
+
+	await expect(poeditorAt('t', '1', fetched as never).uploadTerms('msgid ""\n')).rejects.toThrow(
+		/terms locked/,
+	)
+})
+
+test('names no reason when the platform refused an upload without one', async () => {
+	const fetched = vi.fn(async () => ({ ok: true, json: async () => ({ response: { status: 'fail' } }) }))
+
+	await expect(poeditorAt('t', '1', fetched as never).uploadTerms('msgid ""\n')).rejects.toThrow(
+		/no reason given/,
+	)
+})

--- a/frontend/src/test/proof-locale.test.ts
+++ b/frontend/src/test/proof-locale.test.ts
@@ -28,11 +28,6 @@ test('leaves no more of the template unanswered than the proof locale admits', (
 	expect(untranslated(catalogOf(PROOF_LOCALE), template).length).toBeLessThanOrEqual(PENDING)
 })
 
-test('holds the proof locale to what it has already reached', () => {
-	const template = readFileSync(join(repositoryRoot(), 'languages', 'gophenberg.pot'), 'utf8')
-
-	expect(untranslated(catalogOf(PROOF_LOCALE), template).length).toBe(PENDING)
-})
 
 test('counts a message the catalogue omits entirely as waiting', () => {
 	const template = `msgid ""

--- a/frontend/src/test/proof-locale.test.ts
+++ b/frontend/src/test/proof-locale.test.ts
@@ -19,10 +19,19 @@ function catalogOf(locale: string): string {
 	return readFileSync(join(repositoryRoot(), 'languages', `${locale}.po`), 'utf8')
 }
 
-test('leaves no message of the template untranslated in the proof locale', () => {
+/** How many messages of the template the proof locale has yet to answer. */
+const PENDING = 0
+
+test('leaves no more of the template unanswered than the proof locale admits', () => {
 	const template = readFileSync(join(repositoryRoot(), 'languages', 'gophenberg.pot'), 'utf8')
 
-	expect(untranslated(catalogOf(PROOF_LOCALE), template)).toEqual([])
+	expect(untranslated(catalogOf(PROOF_LOCALE), template).length).toBeLessThanOrEqual(PENDING)
+})
+
+test('holds the proof locale to what it has already reached', () => {
+	const template = readFileSync(join(repositoryRoot(), 'languages', 'gophenberg.pot'), 'utf8')
+
+	expect(untranslated(catalogOf(PROOF_LOCALE), template).length).toBe(PENDING)
 })
 
 test('counts a message the catalogue omits entirely as waiting', () => {

--- a/frontend/src/test/sync.test.ts
+++ b/frontend/src/test/sync.test.ts
@@ -27,7 +27,7 @@ function catalogue(msgstr: string): string {
  * Returns a platform answering with the given languages and exports.
  * @param languages - The languages the platform lists.
  * @param exports - The catalogue each language exports, keyed by platform name.
- * @param asked - The names the platform was asked for, appended to.
+ * @param asked - What the platform was asked to do, in order, appended to.
  * @returns The platform.
  */
 function platformOf(
@@ -38,10 +38,12 @@ function platformOf(
 	return {
 		languages: async () => languages,
 		exportPo: async (named: string) => {
-			asked.push(named)
+			asked.push(`export:${named}`)
 			return exports[named] ?? ''
 		},
-		uploadTerms: async () => undefined,
+		uploadTerms: async (source: string) => {
+			asked.push(`upload:${source}`)
+		},
 	}
 }
 
@@ -73,7 +75,7 @@ test('asks the platform under its own name and writes under the site locale', as
 
 	const done = await syncTranslations(platform, ['en-US', 'es-ES'], held, TEMPLATE)
 
-	expect(asked).toEqual(['es'])
+	expect(asked).toEqual([`upload:${TEMPLATE}`, 'export:es'])
 	expect(Object.keys(written)).toEqual(['es-ES'])
 	expect(done.moved).toEqual(['es-ES'])
 })
@@ -85,7 +87,7 @@ test('skips a language the site does not answer in', async () => {
 
 	const done = await syncTranslations(platform, ['en-US', 'es-ES'], held, TEMPLATE)
 
-	expect(asked).toEqual([])
+	expect(asked).toEqual([`upload:${TEMPLATE}`])
 	expect(written).toEqual({})
 	expect(done.skipped[0]).toContain('fr')
 })

--- a/frontend/src/test/sync.test.ts
+++ b/frontend/src/test/sync.test.ts
@@ -39,6 +39,7 @@ function platformOf(
 			asked.push(named)
 			return exports[named] ?? ''
 		},
+		uploadTerms: async () => undefined,
 	}
 }
 

--- a/frontend/src/test/sync.test.ts
+++ b/frontend/src/test/sync.test.ts
@@ -6,6 +6,8 @@ import { syncTranslations } from '../../scripts/sync.ts'
 import type { Catalogues } from '../../scripts/sync.ts'
 import type { Poeditor } from '../../scripts/poeditor.ts'
 
+const TEMPLATE = 'msgid "Older posts"\nmsgstr ""\n'
+
 const HEADER = `msgid ""
 msgstr ""
 "Language: es-ES\\n"
@@ -69,7 +71,7 @@ test('asks the platform under its own name and writes under the site locale', as
 	const platform = platformOf(['es'], { es: catalogue('Entradas anteriores') }, asked)
 	const { held, written } = storeOf()
 
-	const done = await syncTranslations(platform, ['en-US', 'es-ES'], held)
+	const done = await syncTranslations(platform, ['en-US', 'es-ES'], held, TEMPLATE)
 
 	expect(asked).toEqual(['es'])
 	expect(Object.keys(written)).toEqual(['es-ES'])
@@ -81,7 +83,7 @@ test('skips a language the site does not answer in', async () => {
 	const platform = platformOf(['fr'], { fr: catalogue('Articles plus anciens') }, asked)
 	const { held, written } = storeOf()
 
-	const done = await syncTranslations(platform, ['en-US', 'es-ES'], held)
+	const done = await syncTranslations(platform, ['en-US', 'es-ES'], held, TEMPLATE)
 
 	expect(asked).toEqual([])
 	expect(written).toEqual({})
@@ -92,7 +94,7 @@ test('skips a region the site does not answer in, rather than writing over anoth
 	const platform = platformOf(['es-MX'], { 'es-MX': catalogue('Entradas antiguas') })
 	const { held, written } = storeOf({ 'es-ES': catalogue('Entradas anteriores') })
 
-	await syncTranslations(platform, ['en-US', 'es-ES'], held)
+	await syncTranslations(platform, ['en-US', 'es-ES'], held, TEMPLATE)
 
 	expect(written).toEqual({})
 })
@@ -102,7 +104,7 @@ test('skips a language nobody has translated yet', async () => {
 	const platform = platformOf(['es'], { es: bare })
 	const { held, written } = storeOf()
 
-	const done = await syncTranslations(platform, ['en-US', 'es-ES'], held)
+	const done = await syncTranslations(platform, ['en-US', 'es-ES'], held, TEMPLATE)
 
 	expect(written).toEqual({})
 	expect(done.skipped[0]).toContain('nobody has translated')
@@ -113,7 +115,7 @@ test('writes nothing when the platform says what the catalogue already says', as
 	const platform = platformOf(['es'], { es: same })
 	const { held, written } = storeOf({ 'es-ES': same })
 
-	const done = await syncTranslations(platform, ['en-US', 'es-ES'], held)
+	const done = await syncTranslations(platform, ['en-US', 'es-ES'], held, TEMPLATE)
 
 	expect(written).toEqual({})
 	expect(done.moved).toEqual([])
@@ -133,8 +135,27 @@ msgstr[2] ""
 	const platform = platformOf(['es'], { es: theirs })
 	const { held, written } = storeOf({ 'es-ES': HEADER })
 
-	await syncTranslations(platform, ['en-US', 'es-ES'], held)
+	await syncTranslations(platform, ['en-US', 'es-ES'], held, TEMPLATE)
 
 	expect(written['es-ES']).toContain('nplurals=2')
 	expect(written['es-ES']).not.toMatch(/msgstr\[2\]/)
+})
+
+test('sends the template before asking what the platform holds', async () => {
+	const order: string[] = []
+	const platform: Poeditor = {
+		languages: async () => {
+			order.push('languages')
+			return []
+		},
+		exportPo: async () => '',
+		uploadTerms: async (source: string) => {
+			order.push(`upload:${source.trim()}`)
+		},
+	}
+	const { held } = storeOf()
+
+	await syncTranslations(platform, ['en-US'], held, 'msgid "Older posts"')
+
+	expect(order).toEqual(['upload:msgid "Older posts"', 'languages'])
 })


### PR DESCRIPTION
Closes #60

A new English string never reached translators and turned the suite red for whoever added it. The sync now uploads the committed template before pulling, adding terms only, and completeness is a ratchet at zero rather than a demand.

## Testing

    pnpm --filter @gophenberg/frontend cover
    pnpm --filter @gophenberg/frontend typecheck
    pnpm lint
    pnpm exec eslint .
    pnpm exec knip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for uploading translation terms in POT format before synchronizing translations.
  * Uploads use terms-only updates and provide clear error handling for failed requests or platform operations.

* **Tests**
  * Added coverage for successful uploads, required upload fields, HTTP errors, and platform-reported failures.
  * Strengthened checks for untranslated messages against the allowed pending threshold.
  * Verified that the translation template uploads before language synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->