### PR TITLE
fix(i18n): retire what the source no longer says

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: peers dev seed test test-race cover cover-html lint fmt generate outdated db-up db-down pot catalogs translations \
+	translations-retire \
 	e2e e2e-build e2e-theme e2e-serve e2e-db-reset e2e-seed e2e-reset bump \
 	brick-link brick-sync brick-pack brick-unlink
 
@@ -70,6 +71,9 @@ pot:
 
 translations:
 	node frontend/scripts/sync-translations.ts
+
+translations-retire:
+	node frontend/scripts/retire-translations.ts
 
 catalogs:
 	node frontend/scripts/write-catalogs.ts

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
 		"pot": "node scripts/write-pot.ts",
 		"preview": "vite preview",
 		"translations": "node scripts/sync-translations.ts",
+		"translations:retire": "node scripts/retire-translations.ts",
 		"typecheck": "tsc -b --force"
 	},
 	"dependencies": {

--- a/frontend/scripts/completeness.ts
+++ b/frontend/scripts/completeness.ts
@@ -35,6 +35,25 @@ function answered(source: string): Set<string> {
 	return held
 }
 
+/**
+ * Returns every message a catalogue carries that the template does not name.
+ * @param source - The catalogue as PO text.
+ * @param template - The template naming every message the catalogue may carry.
+ * @returns The keys carried without a place in the template, in the order the catalogue holds them.
+ */
+export function orphaned(source: string, template: string): string[] {
+	const named = po.parse(template).translations
+	const carried: string[] = []
+	for (const [context, entries] of Object.entries(po.parse(source).translations)) {
+		for (const msgid of Object.keys(entries)) {
+			if (msgid !== METADATA && named[context]?.[msgid] === undefined) {
+				carried.push(keyOf(context, msgid))
+			}
+		}
+	}
+	return carried
+}
+
 /** A placeholder naming what goes into it. */
 const NAMED = /%\(([A-Za-z_][A-Za-z0-9_]*)\)[bcdieEfgGosuxX]/g
 

--- a/frontend/scripts/poeditor.ts
+++ b/frontend/scripts/poeditor.ts
@@ -117,7 +117,7 @@ type Answers = Record<string, Record<string, string[]>>
 /** What the platform answers a request with. */
 interface Answer {
 	response: { status: string, message?: string }
-	result?: { languages?: { code: string }[], url?: string }
+	result?: { languages?: { code: string }[], url?: string, terms?: { deleted?: number } }
 }
 
 /** What this repository reads a translation platform through. */
@@ -125,6 +125,28 @@ export interface Poeditor {
 	languages: () => Promise<string[]>
 	exportPo: (locale: string) => Promise<string>
 	uploadTerms: (source: string) => Promise<void>
+}
+
+/** What this repository retires a platform's absent terms through. */
+export interface Retiring {
+	retireTerms: (source: string) => Promise<number>
+}
+
+/**
+ * Returns how many messages a template names.
+ * @param source - The template as POT text.
+ * @returns The count of named messages.
+ */
+function namedMessages(source: string): number {
+	let held = 0
+	for (const entries of Object.values(po.parse(source).translations)) {
+		for (const msgid of Object.keys(entries)) {
+			if (msgid !== '') {
+				held += 1
+			}
+		}
+	}
+	return held
 }
 
 /**
@@ -202,13 +224,48 @@ async function ask(
  * @param fetched - How a request is sent, the runtime's own by default.
  * @returns The reader.
  */
-export function poeditorAt(token: string, project: string, fetched: typeof fetch = fetch): Poeditor {
+export function poeditorAt(
+	token: string,
+	project: string,
+	fetched: typeof fetch = fetch,
+): Poeditor & Retiring {
 	/**
 	 * Returns the values every call carries.
 	 * @returns The credential and the project.
 	 */
 	function credentials(): URLSearchParams {
 		return new URLSearchParams({ api_token: token, id: project })
+	}
+	/**
+	 * Sends the template to the platform, saying whether absent terms retire.
+	 * @param source - The catalogue template as POT text.
+	 * @param retiring - Whether terms the template does not name are deleted.
+	 * @returns The result the platform answered with.
+	 */
+	async function sendTemplate(source: string, retiring: boolean): Promise<NonNullable<Answer['result']>> {
+		const form = new FormData()
+		form.set('api_token', token)
+		form.set('id', project)
+		form.set('updating', 'terms')
+		if (retiring) {
+			form.set('sync_terms', '1')
+		}
+		form.set('file', new Blob([source]), 'gophenberg.pot')
+		const response = await fetched(`${API}/projects/upload`, {
+			method: 'POST',
+			body: form,
+			signal: AbortSignal.timeout(REQUEST_TIMEOUT),
+		})
+		if (!response.ok) {
+			throw new Error(`the translation platform answered ${response.status}`)
+		}
+		const answered = (await response.json()) as Answer
+		if (answered.response.status !== 'success') {
+			throw new Error(
+				`the translation platform refused: ${answered.response.message ?? 'no reason given'}`,
+			)
+		}
+		return answered.result ?? {}
 	}
 	return {
 		/**
@@ -224,25 +281,18 @@ export function poeditorAt(token: string, project: string, fetched: typeof fetch
 		 * @param source - The catalogue template as POT text.
 		 */
 		uploadTerms: async (source: string) => {
-			const form = new FormData()
-			form.set('api_token', token)
-			form.set('id', project)
-			form.set('updating', 'terms')
-			form.set('file', new Blob([source]), 'gophenberg.pot')
-			const response = await fetched(`${API}/projects/upload`, {
-				method: 'POST',
-				body: form,
-				signal: AbortSignal.timeout(REQUEST_TIMEOUT),
-			})
-			if (!response.ok) {
-				throw new Error(`the translation platform answered ${response.status}`)
+			await sendTemplate(source, false)
+		},
+		/**
+		 * Deletes from the platform every term the template does not name.
+		 * @param source - The catalogue template as POT text.
+		 * @returns How many terms the platform deleted.
+		 */
+		retireTerms: async (source: string) => {
+			if (namedMessages(source) === 0) {
+				throw new Error('the template names no messages, so retiring would empty the project')
 			}
-			const answered = (await response.json()) as Answer
-			if (answered.response.status !== 'success') {
-				throw new Error(
-					`the translation platform refused: ${answered.response.message ?? 'no reason given'}`,
-				)
-			}
+			return (await sendTemplate(source, true)).terms?.deleted ?? 0
 		},
 		/**
 		 * Returns one language's catalogue as the platform exports it.

--- a/frontend/scripts/poeditor.ts
+++ b/frontend/scripts/poeditor.ts
@@ -86,6 +86,25 @@ export function withPluralRuleOf(current: string, incoming: string): string {
 	return po.compile(held, { foldLength: 0, eol: '\n' }).toString()
 }
 
+/**
+ * Returns an incoming catalogue without any message the template does not name.
+ * @param incoming - The catalogue the platform exported.
+ * @param template - The template naming every message the catalogue may carry.
+ * @returns The incoming catalogue, trimmed to the template.
+ */
+export function namedByTemplate(incoming: string, template: string): string {
+	const named = po.parse(template).translations
+	const held = po.parse(incoming)
+	for (const [context, entries] of Object.entries(held.translations)) {
+		for (const msgid of Object.keys(entries)) {
+			if (msgid !== '' && named[context]?.[msgid] === undefined) {
+				delete held.translations[context][msgid]
+			}
+		}
+	}
+	return po.compile(held, { foldLength: 0, eol: '\n' }).toString()
+}
+
 /** How long any one call to the platform may take. */
 const REQUEST_TIMEOUT = 30_000
 

--- a/frontend/scripts/poeditor.ts
+++ b/frontend/scripts/poeditor.ts
@@ -218,11 +218,11 @@ async function ask(
 }
 
 /**
- * Returns the reader of one translation platform project.
+ * Returns the reader and retirer of one translation platform project.
  * @param token - The credential the platform answers to.
  * @param project - The project the translations live in.
  * @param fetched - How a request is sent, the runtime's own by default.
- * @returns The reader.
+ * @returns The reader, carrying the retirement its own interface names.
  */
 export function poeditorAt(
 	token: string,

--- a/frontend/scripts/retire-translations.ts
+++ b/frontend/scripts/retire-translations.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { poeditorAt } from './poeditor.ts'
+import { DOMAIN, repositoryRoot } from './pot.ts'
+
+const token = process.env.POEDITOR_API_TOKEN
+const project = process.env.POEDITOR_PROJECT_ID
+
+if (token === undefined || project === undefined) {
+	console.error('set POEDITOR_API_TOKEN and POEDITOR_PROJECT_ID to retire terms')
+	process.exit(1)
+}
+
+const template = readFileSync(join(repositoryRoot(), 'languages', `${DOMAIN}.pot`), 'utf8')
+const deleted = await poeditorAt(token, project).retireTerms(template)
+
+console.log(deleted === 0 ? 'the platform held nothing to retire' : `terms retired: ${deleted}`)

--- a/frontend/scripts/sync.ts
+++ b/frontend/scripts/sync.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { localeFor, meaningfulChange, translated, withPluralRuleOf } from './poeditor.ts'
+import { localeFor, meaningfulChange, namedByTemplate, translated, withPluralRuleOf } from './poeditor.ts'
 import type { Poeditor } from './poeditor.ts'
 
 /** Where the catalogues a sync reads and writes live. */
@@ -38,7 +38,7 @@ export async function syncTranslations(
 			skipped.push(`${named}, which the site does not answer in`)
 			continue
 		}
-		const exported = await platform.exportPo(named)
+		const exported = namedByTemplate(await platform.exportPo(named), template)
 		if (translated(exported) === 0) {
 			skipped.push(`${named}, which nobody has translated yet`)
 			continue

--- a/frontend/src/test/poeditor.test.ts
+++ b/frontend/src/test/poeditor.test.ts
@@ -313,6 +313,77 @@ test('uploads terms only, so no translation can be overwritten', async () => {
 	expect(updating).toBe('terms')
 })
 
+test('retires with the template as the whole truth, deleting what it does not name', async () => {
+	let sent: string[] = []
+	let path = ''
+	let syncing = ''
+	const fetched = vi.fn(async (url: string, init?: { body?: FormData }) => {
+		path = url
+		const body = (init as { body: FormData }).body
+		sent = [...body.keys()].sort()
+		syncing = String(body.get('sync_terms'))
+		return { ok: true, json: async () => ({ response: { status: 'success' } }) }
+	})
+
+	await poeditorAt('t', '1', fetched as never).retireTerms('msgid ""\nmsgstr ""\n\nmsgid "Kept"\nmsgstr ""\n')
+
+	expect(path).toContain('projects/upload')
+	expect(sent).toEqual(['api_token', 'file', 'id', 'sync_terms', 'updating'])
+	expect(syncing).toBe('1')
+})
+
+test('reports how many terms the platform deleted', async () => {
+	const fetched = vi.fn(async () => ({
+		ok: true,
+		json: async () => ({ response: { status: 'success' }, result: { terms: { deleted: 49 } } }),
+	}))
+
+	const deleted = await poeditorAt('t', '1', fetched as never)
+		.retireTerms('msgid ""\nmsgstr ""\n\nmsgid "Kept"\nmsgstr ""\n')
+
+	expect(deleted).toBe(49)
+})
+
+test('reports no deletion when the platform names none', async () => {
+	const fetched = vi.fn(async () => ({
+		ok: true,
+		json: async () => ({ response: { status: 'success' } }),
+	}))
+
+	const deleted = await poeditorAt('t', '1', fetched as never)
+		.retireTerms('msgid ""\nmsgstr ""\n\nmsgid "Kept"\nmsgstr ""\n')
+
+	expect(deleted).toBe(0)
+})
+
+test('refuses to retire with a template naming no messages, before asking the platform', async () => {
+	const fetched = vi.fn()
+
+	await expect(poeditorAt('t', '1', fetched as never).retireTerms('msgid ""\nmsgstr ""\n')).rejects.toThrow(
+		/names no messages/,
+	)
+	expect(fetched).not.toHaveBeenCalled()
+})
+
+test('refuses a retirement the platform did not accept', async () => {
+	const fetched = vi.fn(async () => ({ ok: false, status: 502, json: async () => ({}) }))
+
+	await expect(
+		poeditorAt('t', '1', fetched as never).retireTerms('msgid ""\nmsgstr ""\n\nmsgid "Kept"\nmsgstr ""\n'),
+	).rejects.toThrow(/502/)
+})
+
+test('refuses a retirement the platform reported a failure for', async () => {
+	const fetched = vi.fn(async () => ({
+		ok: true,
+		json: async () => ({ response: { status: 'fail', message: 'terms locked' } }),
+	}))
+
+	await expect(
+		poeditorAt('t', '1', fetched as never).retireTerms('msgid ""\nmsgstr ""\n\nmsgid "Kept"\nmsgstr ""\n'),
+	).rejects.toThrow(/terms locked/)
+})
+
 test('refuses an upload the platform did not accept', async () => {
 	const fetched = vi.fn(async () => ({ ok: false, status: 502, json: async () => ({}) }))
 

--- a/frontend/src/test/proof-locale.test.ts
+++ b/frontend/src/test/proof-locale.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 import { expect, test } from 'vitest'
 
 import { repositoryRoot } from '../../scripts/pot.ts'
-import { untranslated } from '../../scripts/completeness.ts'
+import { orphaned, untranslated } from '../../scripts/completeness.ts'
 
 /**
  * Returns every language the repository ships a catalogue for.
@@ -27,6 +27,34 @@ test.each(catalogues())('leaves no more of the template unanswered in %s than is
 	expect(untranslated(source, template).length).toBeLessThanOrEqual(PENDING)
 })
 
+
+test.each(catalogues())('carries nothing in %s that the template does not name', (_locale, source) => {
+	const template = readFileSync(join(repositoryRoot(), 'languages', 'gophenberg.pot'), 'utf8')
+
+	expect(orphaned(source, template)).toEqual([])
+})
+
+test('names a message the template no longer holds', () => {
+	const template = `msgid ""\nmsgstr ""\n\nmsgid "Kept"\nmsgstr ""\n`
+	const held = `msgid ""\nmsgstr ""\n"Language: es-ES\\n"\n\nmsgid "Kept"\nmsgstr "Conservado"\n\n` +
+		`msgid "Retired"\nmsgstr "Retirado"\n`
+
+	expect(orphaned(held, template)).toEqual(['Retired'])
+})
+
+test('names an orphan under its context, apart from the same word without one', () => {
+	const template = `msgid ""\nmsgstr ""\n\nmsgid "Post"\nmsgstr ""\n`
+	const held = `msgid ""\nmsgstr ""\n"Language: es-ES\\n"\n\nmsgctxt "noun"\nmsgid "Post"\nmsgstr "Entrada"\n`
+
+	expect(orphaned(held, template)).toEqual([`noun${''}Post`])
+})
+
+test('names no orphan in a catalogue the template fully covers', () => {
+	const template = `msgid ""\nmsgstr ""\n\nmsgid "Kept"\nmsgstr ""\n`
+	const held = `msgid ""\nmsgstr ""\n"Language: es-ES\\n"\n\nmsgid "Kept"\nmsgstr "Conservado"\n`
+
+	expect(orphaned(held, template)).toEqual([])
+})
 
 test('counts a message the catalogue omits entirely as waiting', () => {
 	const template = `msgid ""

--- a/frontend/src/test/sync.test.ts
+++ b/frontend/src/test/sync.test.ts
@@ -123,6 +123,40 @@ test('writes nothing when the platform says what the catalogue already says', as
 	expect(done.moved).toEqual([])
 })
 
+test('drops what the template no longer names, rather than carrying it back in', async () => {
+	const theirs = `${HEADER}
+msgid "Older posts"
+msgstr "Entradas anteriores"
+
+msgid "Retired"
+msgstr "Retirado"
+`
+	const platform = platformOf(['es'], { es: theirs })
+	const { held, written } = storeOf()
+
+	await syncTranslations(platform, ['en-US', 'es-ES'], held, TEMPLATE)
+
+	expect(written['es-ES']).toContain('Entradas anteriores')
+	expect(written['es-ES']).not.toContain('Retired')
+})
+
+test('skips a language whose only translations answer retired messages', async () => {
+	const theirs = `${HEADER}
+msgid "Older posts"
+msgstr ""
+
+msgid "Retired"
+msgstr "Retirado"
+`
+	const platform = platformOf(['es'], { es: theirs })
+	const { held, written } = storeOf()
+
+	const done = await syncTranslations(platform, ['en-US', 'es-ES'], held, TEMPLATE)
+
+	expect(written).toEqual({})
+	expect(done.skipped[0]).toContain('nobody has translated')
+})
+
 test('keeps the plural rule the committed catalogue declares', async () => {
 	const theirs = `msgid ""
 msgstr ""
@@ -134,10 +168,11 @@ msgstr[0] "%d entrada"
 msgstr[1] "%d entradas"
 msgstr[2] ""
 `
+	const naming = 'msgid "%d post"\nmsgid_plural "%d posts"\nmsgstr[0] ""\nmsgstr[1] ""\n'
 	const platform = platformOf(['es'], { es: theirs })
 	const { held, written } = storeOf({ 'es-ES': HEADER })
 
-	await syncTranslations(platform, ['en-US', 'es-ES'], held, TEMPLATE)
+	await syncTranslations(platform, ['en-US', 'es-ES'], held, naming)
 
 	expect(written['es-ES']).toContain('nplurals=2')
 	expect(written['es-ES']).not.toMatch(/msgstr\[2\]/)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -62,6 +62,7 @@ export default defineConfig({
 				'scripts/write-pot.ts',
 				'scripts/write-catalogs.ts',
 				'scripts/sync-translations.ts',
+				'scripts/retire-translations.ts',
 				'../sdk/frontend/scripts/build-site-assets.ts',
 				'**/*.d.ts',
 				'**/test/**',


### PR DESCRIPTION

Closes #70

A message deleted from the source lived on forever. The platform kept its term, the next export carried it back, and the sync wrote it straight into the committed catalogue, which is how 49 dead terms needed a manual sweep through the platform interface. This closes the loop at all three points. The sync trims every export to the template before anything else, so a retired message cannot ride back in. A gate refuses a committed catalogue carrying anything the template does not name. And retirement on the platform becomes one deliberate command, make translations-retire, which sends the template with the sync_terms flag, refuses a template naming no messages before any request leaves the machine, and reports how many terms the platform deleted. The weekly sync cannot gain the destructive flag by accident, since it lives on a separate interface the sync never receives and the existing field whitelist test still pins the sync upload to exactly four fields.

## Testing instructions

1. From `frontend`, run `fnm exec --using=26 pnpm cover`. Expect 766 tests passing and 100 percent on statements, branches, functions and lines.

2. Confirm the orphan gate has teeth. From the repository root run `printf "\nmsgid \"A ghost\"\nmsgstr \"Un fantasma\"\n" >> languages/es-ES.po`, then from `frontend` run `fnm exec --using=26 pnpm exec vitest run src/test/proof-locale.test.ts`. Expect exactly one failure naming es-ES. Restore with `git checkout languages/es-ES.po`.

3. Confirm the empty template guard. Run `POEDITOR_API_TOKEN=x POEDITOR_PROJECT_ID=1 node frontend/scripts/retire-translations.ts` after emptying a copy of the template, or simply read the test named "refuses to retire with a template naming no messages, before asking the platform", which proves the platform is never called.

4. Confirm the runner refuses without credentials. Run `make translations-retire` with neither variable set. Expect "set POEDITOR_API_TOKEN and POEDITOR_PROJECT_ID to retire terms" and a failing exit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a translation-retirement workflow to remove obsolete messages from the translation platform.
  * Added commands for initiating translation retirement.
  * Retirement results now report how many obsolete messages were removed.

* **Bug Fixes**
  * Translation synchronization now filters out messages no longer present in the current template.
  * Prevented retired-only translations from being included in locale updates.
  * Added clearer handling for missing credentials and retirement failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->