### PR TITLE
Never let a sync remove a translation the repository holds

### DIFF
--- a/frontend/scripts/poeditor.ts
+++ b/frontend/scripts/poeditor.ts
@@ -77,10 +77,10 @@ export function withPluralRuleOf(current: string, incoming: string): string {
 	const held = po.parse(incoming)
 	held.headers['Plural-Forms'] = rule
 	const counted = /nplurals\s*=\s*(\d+)/.exec(rule)
-	if (counted === null) {
-		throw new Error('the committed catalogue declares a plural rule naming no count')
+	const forms = counted === null ? 0 : Number(counted[1])
+	if (forms < 1) {
+		throw new Error('the committed catalogue declares a plural rule naming no usable count')
 	}
-	const forms = Number(counted[1])
 	for (const entries of Object.values(held.translations)) {
 		for (const entry of Object.values(entries)) {
 			if (entry.msgstr.length > forms) {

--- a/frontend/scripts/poeditor.ts
+++ b/frontend/scripts/poeditor.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { po } from 'gettext-parser'
+import type { GetTextTranslation, GetTextTranslations } from 'gettext-parser'
 
 /** Where the application declares the languages it answers in. */
 const LOCALE_SOURCE = ['internal', 'content', 'locale.go']
@@ -40,8 +41,8 @@ export function localeFor(code: string, supported: string[]): string | undefined
 	if (code.includes('-')) {
 		return undefined
 	}
-	const sharing = supported.filter((held) => held.split('-')[0] === code)
-	return sharing.length === 1 ? sharing[0] : undefined
+	const doubled = localeOf(`${code}-${code}`)
+	return supported.includes(doubled) ? doubled : undefined
 }
 
 /**
@@ -75,7 +76,11 @@ export function withPluralRuleOf(current: string, incoming: string): string {
 	}
 	const held = po.parse(incoming)
 	held.headers['Plural-Forms'] = rule
-	const forms = Number(/nplurals\s*=\s*(\d+)/.exec(rule)?.[1] ?? 1)
+	const counted = /nplurals\s*=\s*(\d+)/.exec(rule)
+	if (counted === null) {
+		throw new Error('the committed catalogue declares a plural rule naming no count')
+	}
+	const forms = Number(counted[1])
 	for (const entries of Object.values(held.translations)) {
 		for (const entry of Object.values(entries)) {
 			if (entry.msgstr.length > forms) {
@@ -84,6 +89,57 @@ export function withPluralRuleOf(current: string, incoming: string): string {
 		}
 	}
 	return po.compile(held, { foldLength: 0, eol: '\n' }).toString()
+}
+
+/**
+ * Returns an incoming catalogue restoring every committed answer it lost.
+ * @param current - The catalogue as committed.
+ * @param incoming - The catalogue the platform exported.
+ * @param template - The template naming every message the catalogue may carry.
+ * @returns The incoming catalogue, keeping each committed answer the export holds empty or lacks.
+ */
+export function keepingAnswers(current: string, incoming: string, template: string): string {
+	const named = po.parse(template).translations
+	const ours = po.parse(current).translations
+	const held = po.parse(incoming)
+	for (const [context, entries] of Object.entries(ours)) {
+		for (const [msgid, entry] of Object.entries(entries)) {
+			if (msgid === '' || named[context]?.[msgid] === undefined || !answered(entry)) {
+				continue
+			}
+			restoring(held, context, msgid, entry)
+		}
+	}
+	return po.compile(held, { foldLength: 0, eol: '\n' }).toString()
+}
+
+/**
+ * Reports whether a catalogue entry carries any translated form.
+ * @param entry - The entry to read, or nothing when the catalogue lacks it.
+ * @returns True when a form holds text.
+ */
+function answered(entry: GetTextTranslation | undefined): boolean {
+	return entry !== undefined && entry.msgstr.some((form) => form !== '')
+}
+
+/**
+ * Writes one committed answer into a catalogue that arrived without it.
+ * @param held - The catalogue the platform exported, as parsed.
+ * @param context - The context the answer sits under.
+ * @param msgid - The message the answer belongs to.
+ * @param entry - The committed answer.
+ */
+function restoring(
+	held: GetTextTranslations,
+	context: string,
+	msgid: string,
+	entry: GetTextTranslation,
+): void {
+	if (answered(held.translations[context]?.[msgid])) {
+		return
+	}
+	held.translations[context] ??= {}
+	held.translations[context][msgid] = entry
 }
 
 /**

--- a/frontend/scripts/sync-translations.ts
+++ b/frontend/scripts/sync-translations.ts
@@ -30,3 +30,6 @@ console.log(done.moved.length === 0 ? 'no translation moved' : `translations mov
 for (const held of done.skipped) {
 	console.log(`skipped ${held}`)
 }
+for (const held of done.kept) {
+	console.log(`kept ${held}`)
+}

--- a/frontend/scripts/sync.ts
+++ b/frontend/scripts/sync.ts
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { localeFor, meaningfulChange, namedByTemplate, translated, withPluralRuleOf } from './poeditor.ts'
+import {
+	keepingAnswers,
+	localeFor,
+	meaningfulChange,
+	namedByTemplate,
+	translated,
+	withPluralRuleOf,
+} from './poeditor.ts'
 import type { Poeditor } from './poeditor.ts'
 
 /** Where the catalogues a sync reads and writes live. */
@@ -13,6 +20,27 @@ export interface Catalogues {
 export interface Synced {
 	moved: string[]
 	skipped: string[]
+	kept: string[]
+}
+
+/**
+ * Returns the catalogue a sync writes and how many committed answers it restored.
+ * @param current - The catalogue as committed, or nothing when none is committed yet.
+ * @param exported - The catalogue the platform exported, trimmed to the template.
+ * @param template - The catalogue template naming every message the site shows.
+ * @returns The catalogue to write and the count of answers the export had lost.
+ */
+function merged(
+	current: string | undefined,
+	exported: string,
+	template: string,
+): { incoming: string, restored: number } {
+	if (current === undefined) {
+		return { incoming: exported, restored: 0 }
+	}
+	const clamped = withPluralRuleOf(current, exported)
+	const incoming = keepingAnswers(current, clamped, template)
+	return { incoming, restored: translated(incoming) - translated(clamped) }
 }
 
 /**
@@ -31,6 +59,7 @@ export async function syncTranslations(
 ): Promise<Synced> {
 	const moved: string[] = []
 	const skipped: string[] = []
+	const kept: string[] = []
 	await platform.uploadTerms(template)
 	for (const named of await platform.languages()) {
 		const locale = localeFor(named, supported)
@@ -44,12 +73,15 @@ export async function syncTranslations(
 			continue
 		}
 		const current = held.read(locale)
-		const incoming = current === undefined ? exported : withPluralRuleOf(current, exported)
+		const { incoming, restored } = merged(current, exported, template)
+		if (restored > 0) {
+			kept.push(`${locale}, keeping ${restored} answered where the platform holds nothing`)
+		}
 		if (!meaningfulChange(current, incoming)) {
 			continue
 		}
 		held.write(locale, incoming)
 		moved.push(locale)
 	}
-	return { moved, skipped }
+	return { moved, skipped, kept }
 }

--- a/frontend/src/test/poeditor.test.ts
+++ b/frontend/src/test/poeditor.test.ts
@@ -264,6 +264,18 @@ msgstr[1] "%d entradas"
 	expect(() => withPluralRuleOf(ours, theirs)).toThrow(/count/)
 })
 
+test('refuses a committed rule naming fewer than one form', () => {
+	const ours = 'msgid ""\nmsgstr ""\n"Plural-Forms: nplurals=0; plural=0;\\n"\n'
+	const theirs = `msgid ""
+msgstr ""
+
+msgid "Older posts"
+msgstr "Entradas anteriores"
+`
+
+	expect(() => withPluralRuleOf(ours, theirs)).toThrow(/count/)
+})
+
 test('keeps a current answer the incoming catalogue leaves empty', () => {
 	const naming = 'msgid "Older posts"\nmsgstr ""\n'
 	const ours = 'msgid ""\nmsgstr ""\n\nmsgid "Older posts"\nmsgstr "Entradas anteriores"\n'

--- a/frontend/src/test/poeditor.test.ts
+++ b/frontend/src/test/poeditor.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import { expect, test, vi } from 'vitest'
 
 import {
+	keepingAnswers,
 	localeFor,
 	localeOf,
 	meaningfulChange,
@@ -173,8 +174,12 @@ test('matches a bare language against the one region the application supports', 
 	expect(localeFor('es', ['en-US', 'es-ES'])).toBe('es-ES')
 })
 
-test('refuses a bare language when two regions of it are supported', () => {
-	expect(localeFor('es', ['es-ES', 'es-MX'])).toBeUndefined()
+test('matches a bare language to its doubled region beside another region of it', () => {
+	expect(localeFor('es', ['es-ES', 'es-MX'])).toBe('es-ES')
+})
+
+test('refuses a bare language whose doubled region the site does not answer in', () => {
+	expect(localeFor('pt', ['en-US', 'pt-BR'])).toBeUndefined()
 })
 
 test('refuses a language the application does not answer in', () => {
@@ -245,7 +250,7 @@ test('takes the platform plural rule when the catalogue declares none', () => {
 	expect(withPluralRuleOf(ours, theirs)).toBe(theirs)
 })
 
-test('keeps one form when the committed rule names no count', () => {
+test('refuses a committed rule naming no count', () => {
 	const ours = 'msgid ""\nmsgstr ""\n"Plural-Forms: plural=(n != 1);\\n"\n'
 	const theirs = `msgid ""
 msgstr ""
@@ -256,7 +261,50 @@ msgstr[0] "%d entrada"
 msgstr[1] "%d entradas"
 `
 
-	expect(withPluralRuleOf(ours, theirs)).not.toMatch(/msgstr\[1\]/)
+	expect(() => withPluralRuleOf(ours, theirs)).toThrow(/count/)
+})
+
+test('keeps a current answer the incoming catalogue leaves empty', () => {
+	const naming = 'msgid "Older posts"\nmsgstr ""\n'
+	const ours = 'msgid ""\nmsgstr ""\n\nmsgid "Older posts"\nmsgstr "Entradas anteriores"\n'
+	const theirs = 'msgid ""\nmsgstr ""\n\nmsgid "Older posts"\nmsgstr ""\n'
+
+	expect(keepingAnswers(ours, theirs, naming)).toContain('Entradas anteriores')
+})
+
+test('takes an incoming answer over the current one', () => {
+	const naming = 'msgid "Older posts"\nmsgstr ""\n'
+	const ours = 'msgid ""\nmsgstr ""\n\nmsgid "Older posts"\nmsgstr "Entradas anteriores"\n'
+	const theirs = 'msgid ""\nmsgstr ""\n\nmsgid "Older posts"\nmsgstr "Entradas antiguas"\n'
+
+	const held = keepingAnswers(ours, theirs, naming)
+
+	expect(held).toContain('Entradas antiguas')
+	expect(held).not.toContain('Entradas anteriores')
+})
+
+test('restores an answer the incoming catalogue does not carry', () => {
+	const naming = 'msgid "Older posts"\nmsgstr ""\n'
+	const ours = 'msgid ""\nmsgstr ""\n\nmsgid "Older posts"\nmsgstr "Entradas anteriores"\n'
+	const theirs = 'msgid ""\nmsgstr ""\n'
+
+	expect(keepingAnswers(ours, theirs, naming)).toContain('Entradas anteriores')
+})
+
+test('restores an answer under a context the incoming catalogue does not know', () => {
+	const naming = 'msgctxt "posts"\nmsgid "Older"\nmsgstr ""\n'
+	const ours = 'msgid ""\nmsgstr ""\n\nmsgctxt "posts"\nmsgid "Older"\nmsgstr "Antiguas"\n'
+	const theirs = 'msgid ""\nmsgstr ""\n'
+
+	expect(keepingAnswers(ours, theirs, naming)).toContain('Antiguas')
+})
+
+test('does not restore an answer the template no longer names', () => {
+	const naming = 'msgid "Older posts"\nmsgstr ""\n'
+	const ours = 'msgid ""\nmsgstr ""\n\nmsgid "Retired"\nmsgstr "Retirado"\n'
+	const theirs = 'msgid ""\nmsgstr ""\n\nmsgid "Older posts"\nmsgstr "Entradas anteriores"\n'
+
+	expect(keepingAnswers(ours, theirs, naming)).not.toContain('Retirado')
 })
 
 test('refuses a region the application does not answer in, rather than taking another', () => {

--- a/frontend/src/test/sync.test.ts
+++ b/frontend/src/test/sync.test.ts
@@ -157,6 +157,57 @@ msgstr "Retirado"
 	expect(done.skipped[0]).toContain('nobody has translated')
 })
 
+test('keeps an answer the platform holds empty', async () => {
+	const naming = 'msgid "Older posts"\nmsgstr ""\n\nmsgid "Newer posts"\nmsgstr ""\n'
+	const theirs = `${HEADER}
+msgid "Older posts"
+msgstr ""
+
+msgid "Newer posts"
+msgstr "Entradas nuevas"
+`
+	const platform = platformOf(['es'], { es: theirs })
+	const { held, written } = storeOf({ 'es-ES': catalogue('Entradas anteriores') })
+
+	await syncTranslations(platform, ['en-US', 'es-ES'], held, naming)
+
+	expect(written['es-ES']).toContain('Entradas nuevas')
+	expect(written['es-ES']).toContain('Entradas anteriores')
+})
+
+test('keeps an answer the export does not carry', async () => {
+	const naming = 'msgid "Older posts"\nmsgstr ""\n\nmsgid "Newer posts"\nmsgstr ""\n'
+	const theirs = `${HEADER}
+msgid "Newer posts"
+msgstr "Entradas nuevas"
+`
+	const platform = platformOf(['es'], { es: theirs })
+	const { held, written } = storeOf({ 'es-ES': catalogue('Entradas anteriores') })
+
+	await syncTranslations(platform, ['en-US', 'es-ES'], held, naming)
+
+	expect(written['es-ES']).toContain('Entradas nuevas')
+	expect(written['es-ES']).toContain('Entradas anteriores')
+})
+
+test('reports the answers it kept for a language', async () => {
+	const naming = 'msgid "Older posts"\nmsgstr ""\n\nmsgid "Newer posts"\nmsgstr ""\n'
+	const theirs = `${HEADER}
+msgid "Older posts"
+msgstr ""
+
+msgid "Newer posts"
+msgstr "Entradas nuevas"
+`
+	const platform = platformOf(['es'], { es: theirs })
+	const { held } = storeOf({ 'es-ES': catalogue('Entradas anteriores') })
+
+	const done = await syncTranslations(platform, ['en-US', 'es-ES'], held, naming)
+
+	expect(done.kept[0]).toContain('es-ES')
+	expect(done.kept[0]).toContain('1')
+})
+
 test('keeps the plural rule the committed catalogue declares', async () => {
 	const theirs = `msgid ""
 msgstr ""


### PR DESCRIPTION
The sync wrote the platform export straight over the committed catalogue, so any answer the platform held empty or did not carry was erased. This was not hypothetical: the repository holds 10 fully translated plural entries, 5 in Spanish and 5 in French, and the platform cannot receive plurals by file import, so it holds those exact terms incomplete. The next sync would have blanked all 10 and turned the batch pull request red on the completeness gate, which is what already happened once during the pipeline drill.

The rule is now that a translation, once set, is never removed by a sync. The only path that removes one is removing the English string from the software, which flows source to template to retirement. A new merge keeps every committed answer the export holds empty or lacks, scoped to the template so a retired term is never resurrected, and the platform still wins wherever it answers.

Two more fixes ride along, both found while working the first. Resolving a platform language stopped guessing: it filtered the supported list for one region sharing the language, which silently skips Spanish the day a second Spanish region is supported, and maps a bare pt onto pt-BR, the wrong dialect. It now uses the platform's own convention, where a locale whose region repeats its language is stored bare, so es means es-ES and a bare code resolves only to its doubled region. And a committed plural rule the code cannot read now refuses instead of falling back to one form and discarding every plural translation.

The sync summary gained a line naming how many answers it restored per language, printed by the driver so the batch pull request shows where the repository is ahead of the platform. That gap is normal, since the upload carries message names and never translations.

Closes #76

## Testing

1. On main, in frontend/src/test/sync.test.ts, add a test that seeds a committed es-ES catalogue holding a translation and serves a platform export whose entry for that message is empty.
2. Assert the written catalogue still contains the committed translation. On main it fails, the written file carries the empty answer. On this branch it passes.

The same shape covers an entry the export omits entirely rather than carries empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing translations when synchronization data contains missing or empty entries.
  * Removed obsolete translations during catalogue updates.
  * Improved locale matching for regional variants.
  * Reported errors when pluralization data is incomplete or invalid.

* **Improvements**
  * Added synchronization reporting for translations retained from existing catalogues.
  * Improved translation catalogue updates to restore valid committed translations when platform exports are incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->