### PR TITLE
Push the held catalogues to the translation platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: peers dev seed test test-race cover cover-html lint fmt generate outdated db-up db-down pot catalogs translations \
-	translations-retire \
+	translations-push translations-retire \
 	e2e e2e-build e2e-theme e2e-serve e2e-db-reset e2e-seed e2e-reset bump bump-kit \
 	brick-link brick-sync brick-pack brick-unlink
 
@@ -74,6 +74,9 @@ pot:
 
 translations:
 	node --env-file-if-exists=.env frontend/scripts/sync-translations.ts
+
+translations-push:
+	node --env-file-if-exists=.env frontend/scripts/push-translations.ts
 
 translations-retire:
 	node --env-file-if-exists=.env frontend/scripts/retire-translations.ts

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,13 +13,14 @@
 		"pot": "node scripts/write-pot.ts",
 		"preview": "vite preview",
 		"translations": "node scripts/sync-translations.ts",
+		"translations:push": "node scripts/push-translations.ts",
 		"translations:retire": "node scripts/retire-translations.ts",
 		"typecheck": "tsc -b --force"
 	},
 	"dependencies": {
 		"@gophenberg/frontend-sdk": "workspace:*",
 		"@gopherium/godmin": "0.7.0",
-		"@gopherium/gottext": "0.1.1",
+		"@gopherium/gottext": "0.3.0",
 		"@gopherium/react-auth": "0.6.0",
 		"@tanstack/react-query": "^5.101.2",
 		"@tanstack/react-router": "^1.170.24",

--- a/frontend/scripts/push-translations.ts
+++ b/frontend/scripts/push-translations.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { poeditorAt, pushTranslations } from '@gopherium/gottext/sync'
+
+import { DOMAIN, repositoryRoot } from './config.ts'
+import { supportedLocales } from './locales.ts'
+
+const token = process.env.POEDITOR_API_TOKEN
+const project = process.env.POEDITOR_PROJECT_ID
+
+if (token === undefined || project === undefined) {
+	console.error('set POEDITOR_API_TOKEN and POEDITOR_PROJECT_ID to push translations')
+	process.exit(1)
+}
+
+const root = repositoryRoot()
+const languages = join(root, 'languages')
+
+const done = await pushTranslations(
+	poeditorAt({ token, project, domain: DOMAIN }),
+	supportedLocales(root),
+	{
+		read: (locale) => {
+			const target = join(languages, `${locale}.po`)
+			return existsSync(target) ? readFileSync(target, 'utf8') : undefined
+		},
+		write: (locale, source) => writeFileSync(join(languages, `${locale}.po`), source),
+	},
+	readFileSync(join(languages, `${DOMAIN}.pot`), 'utf8'),
+)
+
+console.log(done.pushed.length === 0 ? 'no catalogue pushed' : `catalogues pushed: ${done.pushed.join(', ')}`)
+for (const held of done.added) {
+	console.log(`added ${held}`)
+}
+for (const held of done.skipped) {
+	console.log(`skipped ${held}`)
+}

--- a/frontend/src/test/proof-locale.test.ts
+++ b/frontend/src/test/proof-locale.test.ts
@@ -4,7 +4,7 @@ import { readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { expect, test } from 'vitest'
 
-import { orphaned, untranslated } from '@gopherium/gottext/build'
+import { orphaned, unreviewed, untranslated } from '@gopherium/gottext/build'
 
 import { repositoryRoot } from '../../scripts/config.ts'
 
@@ -28,6 +28,25 @@ test.each(catalogues())('leaves no more of the template unanswered in %s than is
 	expect(untranslated(source, template).length).toBeLessThanOrEqual(PENDING)
 })
 
+
+test.each(catalogues())('says how much of %s still waits for review', (locale, source) => {
+	const waiting = unreviewed(source)
+
+	console.log(`${locale}: ${waiting.length} answers awaiting review`)
+	expect(Array.isArray(waiting)).toBe(true)
+})
+
+test('names an answer still carrying the fuzzy flag', () => {
+	const held = `msgid ""\nmsgstr ""\n"Language: es-ES\\n"\n\n#, fuzzy\nmsgid "Machine"\nmsgstr "Maquina"\n`
+
+	expect(unreviewed(held)).toEqual(['Machine'])
+})
+
+test('names no answer waiting for review in a settled catalogue', () => {
+	const held = `msgid ""\nmsgstr ""\n"Language: es-ES\\n"\n\nmsgid "Settled"\nmsgstr "Asentado"\n`
+
+	expect(unreviewed(held)).toEqual([])
+})
 
 test.each(catalogues())('carries nothing in %s that the template does not name', (_locale, source) => {
 	const template = readFileSync(join(repositoryRoot(), 'languages', 'gophenberg.pot'), 'utf8')

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -87,6 +87,7 @@ export default defineConfig({
 				'scripts/write-pot.ts',
 				'scripts/write-catalogs.ts',
 				'scripts/sync-translations.ts',
+				'scripts/push-translations.ts',
 				'scripts/retire-translations.ts',
 				'../sdk/frontend/scripts/build-site-assets.ts',
 				'**/*.d.ts',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: 0.7.0
         version: 0.7.0(@tanstack/react-router@1.170.24(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@wordpress/style-runtime@0.8.0)(@wordpress/theme@1.1.0(@types/react@19.2.18)(esbuild@0.28.1)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(stylelint@17.14.1(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(@wordpress/ui@0.19.0(@date-fns/tz@1.5.0)(@types/react@19.2.18)(date-fns@4.4.0)(esbuild@0.28.1)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(stylelint@17.14.1(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(react@19.2.8)(stylelint@17.14.1(typescript@6.0.3))(vitest@4.1.10)
       '@gopherium/gottext':
-        specifier: 0.1.1
-        version: 0.1.1(@wordpress/i18n@6.26.0)(gettext-extractor@4.0.6)
+        specifier: 0.3.0
+        version: 0.3.0(@wordpress/i18n@6.26.0)(gettext-extractor@4.0.6)
       '@gopherium/react-auth':
         specifier: 0.6.0
         version: 0.6.0(@tanstack/react-query@5.101.4(react@19.2.8))(@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1))(@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@wordpress/i18n@6.26.0)(@wordpress/theme@1.1.0(@types/react@19.2.18)(esbuild@0.28.1)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(stylelint@17.14.1(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(@wordpress/ui@0.19.0(@date-fns/tz@1.5.0)(@types/react@19.2.18)(date-fns@4.4.0)(esbuild@0.28.1)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(stylelint@17.14.1(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(react@19.2.8)(vitest@4.1.10)
@@ -975,8 +975,8 @@ packages:
       vitest:
         optional: true
 
-  '@gopherium/gottext@0.1.1':
-    resolution: {integrity: sha512-f/uL1A0uF14D44lLVRwPqSIc1a1TKFUIWUdu8PWYTkaxhC8hTZyc4l4ZFGIaxa4j71K2YJPb3tcjlkvFA0OCsg==}
+  '@gopherium/gottext@0.3.0':
+    resolution: {integrity: sha512-zxJlUgUwkZa6gl7ZpYOtR8Q8we4QJB0f8u79vRmbdDipTQqPWqtye0hwfmdLWpAHQ9N1nkB7ynXpMRtdaXqVrw==}
     engines: {node: '>=22'}
     peerDependencies:
       '@wordpress/i18n': '>=6.26.0 <7.0.0'
@@ -6005,7 +6005,7 @@ snapshots:
       stylelint: 17.14.1(typescript@6.0.3)
       vitest: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
-  '@gopherium/gottext@0.1.1(@wordpress/i18n@6.26.0)(gettext-extractor@4.0.6)':
+  '@gopherium/gottext@0.3.0(@wordpress/i18n@6.26.0)(gettext-extractor@4.0.6)':
     dependencies:
       '@wordpress/i18n': 6.26.0
       gettext-parser: 9.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ peerDependencyRules:
 
 minimumReleaseAgeExclude:
   - '@gopherium/godmin@0.7.0'
-  - '@gopherium/gottext@0.1.1'
+  - '@gopherium/gottext@0.3.0'
   - '@wordpress/dataviews@17.3.0'
   - '@gopherium/react-auth@0.6.0'
   - '@wordpress/i18n@6.26.0'


### PR DESCRIPTION
Closes #111

## What

- The translation brick moves from 0.1.1 to 0.3.0, which adds the push half of the sync.
- A push entry point beside the existing sync one, wired as make translations-push and pnpm translations:push, sending held catalogues up with their fuzzy flags.
- The catalogue gate now reports how many answers of each language still wait for review, without failing on them.

## Why

Catalogues only ever travelled down from the platform, so translations written here never reached it. Reviewers met empty boxes for strings both catalogues already answered, and had no way to see that Spanish was settled and French was machine written.

## Testing

1. Run pnpm install at the root, then pnpm --filter @gophenberg/frontend cover. All four coverage thresholds hold at 100 percent, and the run prints the review debt per language.
2. Set POEDITOR_API_TOKEN and POEDITOR_PROJECT_ID, then run make translations-push. It reports the catalogues pushed and skips en-US, which has no catalogue of its own.
3. Open the project on the platform and filter by fuzzy. French shows its machine answers awaiting review and Spanish shows none, because its answers are already settled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streamlined workflow for synchronizing translation catalogues with the translation management service.
  * Added reporting for pushed, newly added, and skipped catalogues.
* **Bug Fixes**
  * Improved localization review-status reporting, including detection of fuzzy and fully settled translations.
* **Chores**
  * Updated localization tooling to support the enhanced translation synchronization workflow.
  * Added safeguards for missing translation-service credentials and supported locale files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->