### PR TITLE
Serve a media field as the file it names

### DIFF
--- a/docs/src/content/docs/reference/content-api.md
+++ b/docs/src/content/docs/reference/content-api.md
@@ -159,14 +159,40 @@ identify each block.
 The `fields` object carries the item's values, keyed by field key.
 A text, number, date or yes-no field holds its value as it was
 typed. A choice field holds the stored value, and the label sits in
-that field's `choices`. A media field holds the library identity of
-the file, which no public route turns into an address. A field
-holding many, whether choice, media or relation, holds a list, and
-relation entries name and address the item they point at, so a
-theme links to it without another request. Only published targets
-of active types appear, so a draft category never leaks through a
-published post. A field nobody filled is absent, though a Many
-values choice emptied in the editor comes back as an empty list.
+that field's `choices`. A field holding many, whether choice, media
+or relation, holds a list, and relation entries name and address
+the item they point at, so a theme links to it without another
+request. Only published targets of active types appear, so a draft
+category never leaks through a published post. A field nobody
+filled is absent, though a Many values choice emptied in the editor
+comes back as an empty list.
+
+A media field serves the file itself, one object for a Media field
+and a list for a Gallery, ready to render:
+
+```json
+"cover": {
+  "id": 12,
+  "src": "/media/2026/08/sunrise.jpg",
+  "title": "Sunrise",
+  "alt_text": "Sunrise over the bay",
+  "caption": "Golden hour at the marina",
+  "mime_type": "image/jpeg",
+  "width": 3200,
+  "height": 1800,
+  "sizes": {
+    "large": {"src": "/media/2026/08/sunrise-1024x576.jpg", "width": 1024, "height": 576, "mime_type": "image/jpeg"}
+  }
+}
+```
+
+`src` is the one address every file carries. `sizes` maps the stored
+renditions for building responsive images, and it can be empty, for
+an animated GIF or a plain file, so never rely on a particular slug.
+A file that was deleted from the library drops out of a list, and a
+field whose only file is gone is absent, so a theme checks presence
+rather than trusting the editor. The library's description stays
+private.
 
 Archive addresses answer with a page instead. The root of a type is
 its `route_word`, the front page is the default type, and both
@@ -214,11 +240,13 @@ An item filed under the term through two different fields is listed
 once. Term pages paginate behind `/page/{n}` like archives, and a
 page suffix on an ordinary single item stays `404`.
 
-Item answers carry an `ETag`. Send it back as `If-None-Match` and an
-unchanged answer comes back as `304` with no body, worth doing if you
-poll. The tag covers the whole answer, so it also moves when the type
-or its fields change.
+Item answers carry an `ETag` computed over the whole served answer.
+Send it back as `If-None-Match` and an unchanged answer comes back
+as `304` with no body, worth doing if you poll. Because the tag
+covers everything served, it also moves when the type, a relation
+target, or the words on an inlined media file change, not only when
+the item itself is edited. Revalidation saves bandwidth, not server
+work, since the answer is rebuilt to compare.
 Cross-origin browser scripts cannot read the `ETag` header, so this is
-for servers and command lines. Term answers carry no `ETag`, because
-a term page changes when other items publish, which the term's own
-timestamp cannot witness.
+for servers and command lines. Term answers carry no `ETag` and rely
+on the shared cache windows alone.

--- a/docs/src/content/docs/themes/writing-a-theme.md
+++ b/docs/src/content/docs/themes/writing-a-theme.md
@@ -150,11 +150,44 @@ const related = relatedFields(post)
 }
 ```
 
-`relatedFields` returns relations only. A choice value comes back
-as the stored value, and a media value as an object carrying `src`,
-`alt_text` and its `sizes`, so an image renders straight from the
-page answer. The shapes are covered in the
+`relatedFields` returns relations only, and a choice value comes
+back as the stored value. The shapes are covered in the
 [content API](/reference/content-api/).
+
+Media fields work the same way through `mediaFields`, which reads a
+Media field and a Gallery alike, so one loop renders either:
+
+```astro
+---
+import { mediaFields, mediaUrl } from '@gophenberg/astro'
+
+const pictured = mediaFields(post)
+---
+
+{
+	pictured.map((field) => (
+		<ul>
+			{field.items.map((item) => (
+				<li>
+					<img
+						src={mediaUrl(item.src)}
+						alt={item.alt_text}
+						width={item.width}
+						height={item.height}
+						loading="lazy"
+					/>
+				</li>
+			))}
+		</ul>
+	))
+}
+```
+
+Always pass `mediaUrl`, which is what lets a theme running on its
+own address during development still load files from the instance.
+Giving `width` and `height` stops the page jumping as images
+arrive. `item.sizes` holds the other renditions when you want a
+`srcset`, and it can be empty, so check before reaching into it.
 
 ## Trying it
 

--- a/docs/src/content/docs/themes/writing-a-theme.md
+++ b/docs/src/content/docs/themes/writing-a-theme.md
@@ -151,8 +151,10 @@ const related = relatedFields(post)
 ```
 
 `relatedFields` returns relations only. A choice value comes back
-as the stored value and a media value as a library identity, both
-covered in the [content API](/reference/content-api/).
+as the stored value, and a media value as an object carrying `src`,
+`alt_text` and its `sizes`, so an image renders straight from the
+page answer. The shapes are covered in the
+[content API](/reference/content-api/).
 
 ## Trying it
 

--- a/internal/content/values.go
+++ b/internal/content/values.go
@@ -268,8 +268,25 @@ func isNumber(value any) bool {
 
 // isMediaID reports whether the value is a whole number the library can store as an identity.
 func isMediaID(value any) bool {
-	held, ok := settingNumber(value)
-	return ok && held >= 1 && held < math.MaxInt64 && held == math.Trunc(held)
+	switch held := value.(type) {
+	case int:
+		return held >= 1
+	case int32:
+		return held >= 1
+	case int64:
+		return held >= 1
+	case float32:
+		return storableIdentity(float64(held))
+	case float64:
+		return storableIdentity(held)
+	default:
+		return false
+	}
+}
+
+// storableIdentity reports whether the number is a whole identity the library can store.
+func storableIdentity(held float64) bool {
+	return held >= 1 && held < math.MaxInt64 && held == math.Trunc(held)
 }
 
 // isDay reports whether the value is a day written as a date.

--- a/internal/content/values.go
+++ b/internal/content/values.go
@@ -266,10 +266,10 @@ func isNumber(value any) bool {
 	return held
 }
 
-// isMediaID reports whether the value is a whole number naming one library file.
+// isMediaID reports whether the value is a whole number the library can store as an identity.
 func isMediaID(value any) bool {
 	held, ok := settingNumber(value)
-	return ok && held >= 1 && held == math.Trunc(held) && !math.IsInf(held, 0)
+	return ok && held >= 1 && held < math.MaxInt64 && held == math.Trunc(held)
 }
 
 // isDay reports whether the value is a day written as a date.

--- a/internal/content/values.go
+++ b/internal/content/values.go
@@ -103,8 +103,8 @@ func namedOnce(f Field, member any) any {
 	if f.Kind != FieldKindMedia {
 		return member
 	}
-	held, _ := settingNumber(member)
-	return int64(held)
+	id, _ := mediaIdentity(member)
+	return id
 }
 
 // withinBounds reports whether the value sits inside the bounds its field's settings name.
@@ -278,25 +278,34 @@ func isNumber(value any) bool {
 
 // isMediaID reports whether the value is a whole number the library can store as an identity.
 func isMediaID(value any) bool {
+	_, ok := mediaIdentity(value)
+	return ok
+}
+
+// mediaIdentity returns the identity the value names, and whether the library can store it.
+func mediaIdentity(value any) (int64, bool) {
 	switch held := value.(type) {
 	case int:
-		return held >= 1
+		return int64(held), held >= 1
 	case int32:
-		return held >= 1
+		return int64(held), held >= 1
 	case int64:
-		return held >= 1
+		return held, held >= 1
 	case float32:
 		return storableIdentity(float64(held))
 	case float64:
 		return storableIdentity(held)
 	default:
-		return false
+		return 0, false
 	}
 }
 
-// storableIdentity reports whether the number is a whole identity the library can store.
-func storableIdentity(held float64) bool {
-	return held >= 1 && held < math.MaxInt64 && held == math.Trunc(held)
+// storableIdentity returns the number as an identity, and whether the library can store it.
+func storableIdentity(held float64) (int64, bool) {
+	if held < 1 || held >= math.MaxInt64 || held != math.Trunc(held) {
+		return 0, false
+	}
+	return int64(held), true
 }
 
 // isDay reports whether the value is a day written as a date.

--- a/internal/content/values.go
+++ b/internal/content/values.go
@@ -5,6 +5,7 @@ package content
 import (
 	"errors"
 	"fmt"
+	"math"
 	"net/url"
 	"regexp"
 	"time"
@@ -207,7 +208,7 @@ func holdsShape(f Field, value any) bool {
 	case f.Kind == FieldKindChoice:
 		return isWord(value)
 	case f.Kind == FieldKindMedia && f.Many:
-		return holdsEvery(value, isNumber)
+		return holdsEvery(value, isMediaID)
 	default:
 		return holdsKind(value, f.Kind)
 	}
@@ -245,8 +246,10 @@ func holdsKind(value any, kind FieldKind) bool {
 	case FieldKindText:
 		_, ok := value.(string)
 		return ok
-	case FieldKindNumber, FieldKindMedia:
+	case FieldKindNumber:
 		return isNumber(value)
+	case FieldKindMedia:
+		return isMediaID(value)
 	case FieldKindBoolean:
 		_, ok := value.(bool)
 		return ok
@@ -261,6 +264,12 @@ func holdsKind(value any, kind FieldKind) bool {
 func isNumber(value any) bool {
 	_, held := settingNumber(value)
 	return held
+}
+
+// isMediaID reports whether the value is a whole number naming one library file.
+func isMediaID(value any) bool {
+	held, ok := settingNumber(value)
+	return ok && held >= 1 && held == math.Trunc(held) && !math.IsInf(held, 0)
 }
 
 // isDay reports whether the value is a day written as a date.

--- a/internal/content/values.go
+++ b/internal/content/values.go
@@ -87,14 +87,24 @@ func holdsEachOnce(f Field, value any) error {
 	}
 	seen := make(map[any]bool, len(members))
 	for _, member := range members {
-		if seen[member] {
+		named := namedOnce(f, member)
+		if seen[named] {
 			return Refuse(ErrFieldShape, "field_repeated",
 				fmt.Sprintf("%s: %s names the same one twice", ErrFieldShape, f.Key),
 				Details{"field": f.Key})
 		}
-		seen[member] = true
+		seen[named] = true
 	}
 	return nil
+}
+
+// namedOnce returns the member as the one thing it names, however a caller wrote it.
+func namedOnce(f Field, member any) any {
+	if f.Kind != FieldKindMedia {
+		return member
+	}
+	held, _ := settingNumber(member)
+	return int64(held)
 }
 
 // withinBounds reports whether the value sits inside the bounds its field's settings name.

--- a/internal/content/values_test.go
+++ b/internal/content/values_test.go
@@ -4,6 +4,7 @@ package content_test
 
 import (
 	"errors"
+	"math"
 	"strings"
 	"testing"
 
@@ -128,6 +129,27 @@ func TestValuesShapeTheChoiceKindAndAManyMedia(t *testing.T) {
 		},
 		"a media holds the largest item that stores": {
 			shaped(t, content.FieldKindMedia, false, nil), float64(9223372036854774784), true,
+		},
+		"a media holds the last identity a caller writes whole": {
+			shaped(t, content.FieldKindMedia, false, nil), int64(math.MaxInt64), true,
+		},
+		"a media refuses a whole identity before the first": {
+			shaped(t, content.FieldKindMedia, false, nil), int64(0), false,
+		},
+		"a media holds an identity a caller wrote plainly": {
+			shaped(t, content.FieldKindMedia, false, nil), 7, true,
+		},
+		"a media holds an identity a caller wrote narrowly": {
+			shaped(t, content.FieldKindMedia, false, nil), int32(7), true,
+		},
+		"a media holds an identity that arrived narrow": {
+			shaped(t, content.FieldKindMedia, false, nil), float32(7), true,
+		},
+		"a media refuses a plain identity before the first": {
+			shaped(t, content.FieldKindMedia, false, nil), -1, false,
+		},
+		"a media refuses a narrow identity before the first": {
+			shaped(t, content.FieldKindMedia, false, nil), int32(0), false,
 		},
 		"a many media refuses a part of an item": {
 			shaped(t, content.FieldKindMedia, true, nil), []any{float64(1), float64(2.5)}, false,

--- a/internal/content/values_test.go
+++ b/internal/content/values_test.go
@@ -123,6 +123,12 @@ func TestValuesShapeTheChoiceKindAndAManyMedia(t *testing.T) {
 		"a media refuses an item before the first": {
 			shaped(t, content.FieldKindMedia, false, nil), float64(-3), false,
 		},
+		"a media refuses an item past the last one storable": {
+			shaped(t, content.FieldKindMedia, false, nil), float64(9223372036854775808), false,
+		},
+		"a media holds the largest item that stores": {
+			shaped(t, content.FieldKindMedia, false, nil), float64(9223372036854774784), true,
+		},
 		"a many media refuses a part of an item": {
 			shaped(t, content.FieldKindMedia, true, nil), []any{float64(1), float64(2.5)}, false,
 		},

--- a/internal/content/values_test.go
+++ b/internal/content/values_test.go
@@ -114,6 +114,21 @@ func TestValuesShapeTheChoiceKindAndAManyMedia(t *testing.T) {
 		"a many media refuses the same item twice": {
 			shaped(t, content.FieldKindMedia, true, nil), []any{float64(1), float64(1)}, false,
 		},
+		"a media refuses a part of an item": {
+			shaped(t, content.FieldKindMedia, false, nil), float64(1.5), false,
+		},
+		"a media refuses an item below one": {
+			shaped(t, content.FieldKindMedia, false, nil), float64(0), false,
+		},
+		"a media refuses an item before the first": {
+			shaped(t, content.FieldKindMedia, false, nil), float64(-3), false,
+		},
+		"a many media refuses a part of an item": {
+			shaped(t, content.FieldKindMedia, true, nil), []any{float64(1), float64(2.5)}, false,
+		},
+		"a number still holds a part of one": {
+			shaped(t, content.FieldKindNumber, false, nil), float64(1.5), true,
+		},
 		"a multiple choice refuses the same answer twice": {
 			shaped(t, content.FieldKindChoice, false, map[string]any{"multiple": true}),
 			[]any{"ipa", "ipa"}, false,

--- a/internal/content/values_test.go
+++ b/internal/content/values_test.go
@@ -118,6 +118,10 @@ func TestValuesShapeTheChoiceKindAndAManyMedia(t *testing.T) {
 		"a many media refuses the same item written two ways": {
 			shaped(t, content.FieldKindMedia, true, nil), []any{float64(7), int64(7)}, false,
 		},
+		"a many media holds two neighbouring identities a caller wrote whole": {
+			shaped(t, content.FieldKindMedia, true, nil),
+			[]any{int64(math.MaxInt64), int64(math.MaxInt64 - 1)}, true,
+		},
 		"a media refuses a part of an item": {
 			shaped(t, content.FieldKindMedia, false, nil), float64(1.5), false,
 		},

--- a/internal/content/values_test.go
+++ b/internal/content/values_test.go
@@ -115,6 +115,9 @@ func TestValuesShapeTheChoiceKindAndAManyMedia(t *testing.T) {
 		"a many media refuses the same item twice": {
 			shaped(t, content.FieldKindMedia, true, nil), []any{float64(1), float64(1)}, false,
 		},
+		"a many media refuses the same item written two ways": {
+			shaped(t, content.FieldKindMedia, true, nil), []any{float64(7), int64(7)}, false,
+		},
 		"a media refuses a part of an item": {
 			shaped(t, content.FieldKindMedia, false, nil), float64(1.5), false,
 		},

--- a/internal/media/store.go
+++ b/internal/media/store.go
@@ -24,6 +24,7 @@ type Filter struct {
 type Store interface {
 	Create(ctx context.Context, m Media) (Media, error)
 	ByID(ctx context.Context, id int64) (Media, error)
+	ByIDs(ctx context.Context, ids []int64) ([]Media, error)
 	List(ctx context.Context, f Filter) ([]Media, int, error)
 	Update(ctx context.Context, m Media, expectedUpdatedAt time.Time) (Media, error)
 	Delete(ctx context.Context, id int64) (Media, error)

--- a/internal/postgres/db/queries.sql.go
+++ b/internal/postgres/db/queries.sql.go
@@ -1215,6 +1215,49 @@ func (q *Queries) ListMedia(ctx context.Context, arg ListMediaParams) ([]CoreMed
 	return items, nil
 }
 
+const listMediaByIDs = `-- name: ListMediaByIDs :many
+SELECT m.id, m.media_type, m.file, m.title, m.alt_text, m.caption, m.description,
+    m.mime_type, m.width, m.height, m.filesize, m.sizes, m.author_id, m.created_at, m.updated_at
+FROM core.media m
+WHERE m.id = ANY($1::bigint [])
+`
+
+func (q *Queries) ListMediaByIDs(ctx context.Context, ids []int64) ([]CoreMedia, error) {
+	rows, err := q.db.Query(ctx, listMediaByIDs, ids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []CoreMedia
+	for rows.Next() {
+		var i CoreMedia
+		if err := rows.Scan(
+			&i.ID,
+			&i.MediaType,
+			&i.File,
+			&i.Title,
+			&i.AltText,
+			&i.Caption,
+			&i.Description,
+			&i.MimeType,
+			&i.Width,
+			&i.Height,
+			&i.Filesize,
+			&i.Sizes,
+			&i.AuthorID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRelatedContent = `-- name: ListRelatedContent :many
 SELECT c.id, c.type, c.status, c.slug, c.title, c.excerpt,
     c.author_id, c.published_at, c.created_at, c.updated_at, c.parent_id, c.path, c.fields

--- a/internal/postgres/groups_internal_test.go
+++ b/internal/postgres/groups_internal_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"testing"
+
+	"github.com/gopherium/gophenberg/internal/content"
+)
+
+func TestHoldsKeyAnswersForTheKeysAGroupDeclares(t *testing.T) {
+	t.Parallel()
+
+	held := content.Group{Fields: []content.Field{{Key: "subtitle"}, {Key: "rating"}}}
+
+	if !holdsKey(held, "rating") {
+		t.Error("holdsKey(rating) = false, want the declared key found")
+	}
+	if holdsKey(held, "colour") {
+		t.Error("holdsKey(colour) = true, want a key the group never declared")
+	}
+	if holdsKey(content.Group{}, "subtitle") {
+		t.Error("holdsKey() on a group declaring nothing = true, want false")
+	}
+}

--- a/internal/postgres/kinds_test.go
+++ b/internal/postgres/kinds_test.go
@@ -3,6 +3,7 @@
 package postgres_test
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -49,6 +50,24 @@ func TestTheStoreHoldsAChoiceField(t *testing.T) {
 	}
 	if !reflect.DeepEqual(held.Fields[0].Settings, declared.Settings) {
 		t.Errorf("listed settings = %v, want %v read back", held.Fields[0].Settings, declared.Settings)
+	}
+}
+
+func TestTheStoreNamesTheTargetAFieldPointsAtInVain(t *testing.T) {
+	t.Parallel()
+
+	store, _, _ := typedStore(t)
+	storeType(t, store, "car")
+	group, err := store.CreateGroup(t.Context(), content.Group{Title: "Extras", Location: locationOf("car")})
+	if err != nil {
+		t.Fatalf("CreateGroup() error = %v, want nil", err)
+	}
+	declared := fieldOn(t, "", "engine", content.FieldKindRelation, "nosuchtype")
+
+	_, err = store.CreateFieldInGroup(t.Context(), group.ID, declared)
+
+	if !errors.Is(err, content.ErrTargetUnknown) {
+		t.Errorf("CreateFieldInGroup() error = %v, want %v", err, content.ErrTargetUnknown)
 	}
 }
 

--- a/internal/postgres/media.go
+++ b/internal/postgres/media.go
@@ -63,6 +63,22 @@ func (s *MediaStore) ByID(ctx context.Context, id int64) (media.Media, error) {
 	return toMedia(row), nil
 }
 
+// ByIDs returns the media items stored under the identities, leaving out any that are gone.
+func (s *MediaStore) ByIDs(ctx context.Context, ids []int64) ([]media.Media, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	rows, err := s.queries.ListMediaByIDs(ctx, ids)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: list media by ids: %w", err)
+	}
+	listed := make([]media.Media, len(rows))
+	for i, row := range rows {
+		listed[i] = toMedia(row)
+	}
+	return listed, nil
+}
+
 // List returns the media items matching the filter, newest first, and the
 // total number matching it.
 func (s *MediaStore) List(ctx context.Context, f media.Filter) ([]media.Media, int, error) {

--- a/internal/postgres/media_test.go
+++ b/internal/postgres/media_test.go
@@ -473,4 +473,65 @@ func TestMediaStoreReportsDatabaseFailures(t *testing.T) {
 	if _, err := store.Delete(t.Context(), created.ID); err == nil {
 		t.Error("Delete() on a closed pool error = nil, want a failure")
 	}
+	if _, err := store.ByIDs(t.Context(), []int64{created.ID}); err == nil {
+		t.Error("ByIDs() on a closed pool error = nil, want a failure")
+	}
+}
+
+func TestMediaStoreReadsSeveralByTheirIdentities(t *testing.T) {
+	t.Parallel()
+
+	store, author := newMediaStore(t)
+	first := mustCreateMedia(t, store, mustImage(t, "2026/08/first.jpg", "first", author))
+	second := mustCreateMedia(t, store, mustImage(t, "2026/08/second.jpg", "second", author))
+
+	listed, err := store.ByIDs(t.Context(), []int64{first.ID, second.ID})
+
+	if err != nil {
+		t.Fatalf("ByIDs() error = %v, want nil", err)
+	}
+	byID := make(map[int64]media.Media, len(listed))
+	for _, held := range listed {
+		byID[held.ID] = held
+	}
+	if len(byID) != 2 {
+		t.Fatalf("ByIDs() = %d items, want both", len(byID))
+	}
+	if byID[first.ID].File != "2026/08/first.jpg" || byID[first.ID].Title != "first" {
+		t.Errorf("first = %+v, want the stored file and title read back", byID[first.ID])
+	}
+	if len(byID[second.ID].Sizes) != 2 {
+		t.Errorf("second sizes = %v, want the renditions read back", byID[second.ID].Sizes)
+	}
+}
+
+func TestMediaStoreReadsFewerWhenAnIdentityIsGone(t *testing.T) {
+	t.Parallel()
+
+	store, author := newMediaStore(t)
+	kept := mustCreateMedia(t, store, mustImage(t, "2026/08/kept.jpg", "kept", author))
+
+	listed, err := store.ByIDs(t.Context(), []int64{kept.ID, kept.ID + 1000})
+
+	if err != nil {
+		t.Fatalf("ByIDs() error = %v, want nil", err)
+	}
+	if len(listed) != 1 || listed[0].ID != kept.ID {
+		t.Errorf("ByIDs() = %+v, want only the stored item", listed)
+	}
+}
+
+func TestMediaStoreReadsNothingFromNoIdentities(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newMediaStore(t)
+
+	listed, err := store.ByIDs(t.Context(), nil)
+
+	if err != nil {
+		t.Fatalf("ByIDs() error = %v, want nil", err)
+	}
+	if len(listed) != 0 {
+		t.Errorf("ByIDs() = %+v, want nothing", listed)
+	}
 }

--- a/internal/postgres/queries.sql
+++ b/internal/postgres/queries.sql
@@ -202,6 +202,12 @@ SELECT m.id, m.media_type, m.file, m.title, m.alt_text, m.caption, m.description
 FROM core.media m
 WHERE m.id = @id;
 
+-- name: ListMediaByIDs :many
+SELECT m.id, m.media_type, m.file, m.title, m.alt_text, m.caption, m.description,
+    m.mime_type, m.width, m.height, m.filesize, m.sizes, m.author_id, m.created_at, m.updated_at
+FROM core.media m
+WHERE m.id = ANY(@ids::bigint []);
+
 -- name: ListMedia :many
 SELECT m.id, m.media_type, m.file, m.title, m.alt_text, m.caption, m.description,
     m.mime_type, m.width, m.height, m.filesize, m.sizes, m.author_id, m.created_at, m.updated_at

--- a/internal/postgres/types_internal_test.go
+++ b/internal/postgres/types_internal_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/gopherium/gophenberg/internal/content"
+)
+
+func TestFieldWriteFailureNamesWhatTheConstraintRefused(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		code       string
+		constraint string
+		want       error
+	}{
+		"a key another field holds": {
+			uniqueViolationCode, fieldKeyConstraint, content.ErrFieldTaken,
+		},
+		"a target no type answers to": {
+			foreignKeyViolationCode, fieldTargetConstraint, content.ErrTargetUnknown,
+		},
+		"a group that is gone": {
+			foreignKeyViolationCode, fieldGroupConstraint, content.ErrGroupNotFound,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			held := fieldWriteFailure(&pgconn.PgError{Code: test.code, ConstraintName: test.constraint})
+
+			if !errors.Is(held, test.want) {
+				t.Errorf("fieldWriteFailure() = %v, want %v", held, test.want)
+			}
+		})
+	}
+}
+
+func TestFieldWriteFailureWrapsWhatItDoesNotName(t *testing.T) {
+	t.Parallel()
+
+	stray := errors.New("the connection is gone")
+
+	held := fieldWriteFailure(stray)
+
+	if !errors.Is(held, stray) {
+		t.Errorf("fieldWriteFailure() = %v, want the error it was given carried", held)
+	}
+}

--- a/internal/seed/media_test.go
+++ b/internal/seed/media_test.go
@@ -67,7 +67,7 @@ func (s *countingMediaStore) ByID(context.Context, int64) (media.Media, error) {
 	return media.Media{}, media.ErrNotFound
 }
 
-// ByIDs answers no items, the seeder never reads by identity.
+// ByIDs answers no items.
 func (s *countingMediaStore) ByIDs(context.Context, []int64) ([]media.Media, error) {
 	return nil, nil
 }

--- a/internal/seed/media_test.go
+++ b/internal/seed/media_test.go
@@ -67,6 +67,11 @@ func (s *countingMediaStore) ByID(context.Context, int64) (media.Media, error) {
 	return media.Media{}, media.ErrNotFound
 }
 
+// ByIDs answers no items, the seeder never reads by identity.
+func (s *countingMediaStore) ByIDs(context.Context, []int64) ([]media.Media, error) {
+	return nil, nil
+}
+
 // List returns what the store holds matching the search, one page at a time.
 func (s *countingMediaStore) List(_ context.Context, f media.Filter) ([]media.Media, int, error) {
 	if s.listErr != nil {

--- a/internal/server/content.go
+++ b/internal/server/content.go
@@ -380,7 +380,8 @@ func mediaIDsHeld(t content.Type, values content.Values) []int64 {
 		if f.Kind != content.FieldKindMedia {
 			continue
 		}
-		if listed, many := values[f.Key].([]any); many {
+		if f.Many {
+			listed, _ := values[f.Key].([]any)
 			for _, member := range listed {
 				if id, ok := heldMediaID(member); ok {
 					ids = append(ids, id)
@@ -410,30 +411,23 @@ func (s *server) inlineMediaValues(r *http.Request, t content.Type, values conte
 	}
 	for _, f := range t.Fields {
 		if f.Kind == content.FieldKindMedia {
-			inlineMediaKey(f.Key, values, byID)
+			inlineMediaKey(f, values, byID)
 		}
 	}
 	return nil
 }
 
-// inlineMediaKey rewrites one field's value, deleting the key when nothing resolves.
-func inlineMediaKey(key string, values content.Values, byID map[int64]media.Media) {
-	if listed, many := values[key].([]any); many {
-		served := make([]servedMedia, 0, len(listed))
-		for _, member := range listed {
-			if id, ok := heldMediaID(member); ok {
-				if m, found := byID[id]; found {
-					served = append(served, servedMediaOf(m))
-				}
-			}
-		}
-		if len(served) == 0 {
-			delete(values, key)
-			return
-		}
-		values[key] = served
+// inlineMediaKey rewrites one field's value into the shape it declares, deleting what will not serve.
+func inlineMediaKey(f content.Field, values content.Values, byID map[int64]media.Media) {
+	if f.Many {
+		inlineMediaList(f.Key, values, byID)
 		return
 	}
+	inlineMediaOne(f.Key, values, byID)
+}
+
+// inlineMediaOne rewrites a field holding one file, deleting the key when it will not serve.
+func inlineMediaOne(key string, values content.Values, byID map[int64]media.Media) {
 	id, ok := heldMediaID(values[key])
 	m, found := byID[id]
 	if !ok || !found {
@@ -441,6 +435,28 @@ func inlineMediaKey(key string, values content.Values, byID map[int64]media.Medi
 		return
 	}
 	values[key] = servedMediaOf(m)
+}
+
+// inlineMediaList rewrites a field holding many files, deleting the key when none serve.
+func inlineMediaList(key string, values content.Values, byID map[int64]media.Media) {
+	listed, many := values[key].([]any)
+	if !many {
+		delete(values, key)
+		return
+	}
+	served := make([]servedMedia, 0, len(listed))
+	for _, member := range listed {
+		if id, ok := heldMediaID(member); ok {
+			if m, found := byID[id]; found {
+				served = append(served, servedMediaOf(m))
+			}
+		}
+	}
+	if len(served) == 0 {
+		delete(values, key)
+		return
+	}
+	values[key] = served
 }
 
 // respondTerm answers with the addressed item and the published content pointing at it.

--- a/internal/server/content.go
+++ b/internal/server/content.go
@@ -397,12 +397,9 @@ func mediaIDsHeld(t content.Type, values content.Values) []int64 {
 
 // inlineMediaValues rewrites every media key into the files it names, dropping what is gone.
 func (s *server) inlineMediaValues(r *http.Request, t content.Type, values content.Values) error {
-	ids := mediaIDsHeld(t, values)
-	if len(ids) == 0 {
-		return nil
-	}
 	byID := map[int64]media.Media{}
-	if s.mediaStore != nil {
+	ids := mediaIDsHeld(t, values)
+	if len(ids) > 0 && s.mediaStore != nil {
 		listed, err := s.mediaStore.ByIDs(r.Context(), ids)
 		if err != nil {
 			return err
@@ -438,11 +435,8 @@ func inlineMediaKey(key string, values content.Values, byID map[int64]media.Medi
 		return
 	}
 	id, ok := heldMediaID(values[key])
-	if !ok {
-		return
-	}
 	m, found := byID[id]
-	if !found {
+	if !ok || !found {
 		delete(values, key)
 		return
 	}

--- a/internal/server/content.go
+++ b/internal/server/content.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -346,22 +347,30 @@ func servedMediaOf(m media.Media) servedMedia {
 	}
 }
 
-// heldMediaID returns the value as a library identity, and whether it is one.
+// heldMediaID returns the value as a library identity, and whether it names one.
 func heldMediaID(value any) (int64, bool) {
 	switch held := value.(type) {
 	case float64:
-		return int64(held), true
+		return wholeMediaID(held)
 	case float32:
-		return int64(held), true
+		return wholeMediaID(float64(held))
 	case int64:
-		return held, true
+		return held, held >= 1
 	case int32:
-		return int64(held), true
+		return int64(held), held >= 1
 	case int:
-		return int64(held), true
+		return int64(held), held >= 1
 	default:
 		return 0, false
 	}
+}
+
+// wholeMediaID returns the number as a library identity, and whether it names one whole file.
+func wholeMediaID(held float64) (int64, bool) {
+	if math.IsNaN(held) || math.IsInf(held, 0) || held < 1 || held != math.Trunc(held) {
+		return 0, false
+	}
+	return int64(held), true
 }
 
 // mediaIDsHeld returns every identity the values hold under the type's media fields.
@@ -388,20 +397,19 @@ func mediaIDsHeld(t content.Type, values content.Values) []int64 {
 
 // inlineMediaValues rewrites every media key into the files it names, dropping what is gone.
 func (s *server) inlineMediaValues(r *http.Request, t content.Type, values content.Values) error {
-	if s.mediaStore == nil {
-		return nil
-	}
 	ids := mediaIDsHeld(t, values)
 	if len(ids) == 0 {
 		return nil
 	}
-	listed, err := s.mediaStore.ByIDs(r.Context(), ids)
-	if err != nil {
-		return err
-	}
-	byID := make(map[int64]media.Media, len(listed))
-	for _, m := range listed {
-		byID[m.ID] = m
+	byID := map[int64]media.Media{}
+	if s.mediaStore != nil {
+		listed, err := s.mediaStore.ByIDs(r.Context(), ids)
+		if err != nil {
+			return err
+		}
+		for _, m := range listed {
+			byID[m.ID] = m
+		}
 	}
 	for _, f := range t.Fields {
 		if f.Kind == content.FieldKindMedia {

--- a/internal/server/content.go
+++ b/internal/server/content.go
@@ -367,7 +367,7 @@ func heldMediaID(value any) (int64, bool) {
 
 // wholeMediaID returns the number as a library identity, and whether it names one whole file.
 func wholeMediaID(held float64) (int64, bool) {
-	if math.IsNaN(held) || math.IsInf(held, 0) || held < 1 || held != math.Trunc(held) {
+	if math.IsNaN(held) || held < 1 || held >= math.MaxInt64 || held != math.Trunc(held) {
 		return 0, false
 	}
 	return int64(held), true

--- a/internal/server/content.go
+++ b/internal/server/content.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gopherium/gouncer/authkit"
 
 	"github.com/gopherium/gophenberg/internal/content"
+	"github.com/gopherium/gophenberg/internal/media"
 	"github.com/gopherium/gophenberg/internal/publichtml"
 	"github.com/gopherium/gophenberg/internal/themehost"
 )
@@ -237,7 +238,7 @@ func (s *server) handleContentResolve() http.HandlerFunc {
 
 // respondResolvedItem answers with the addressed item, or reports it unchanged.
 func (s *server) respondResolvedItem(w http.ResponseWriter, r *http.Request, held content.Address) {
-	detail, err := s.publishedDetailOf(r, held.Item)
+	detail, err := s.publishedDetailOf(r, held.Type, held.Item)
 	if err != nil {
 		respondDomainError(w, err)
 		return
@@ -276,8 +277,8 @@ func namedTargets(held []content.Target) []relatedTarget {
 	return named
 }
 
-// publishedDetailOf returns the public view of an item with its targets named and addressed.
-func (s *server) publishedDetailOf(r *http.Request, c content.Content) (publishedDetail, error) {
+// publishedDetailOf returns the public view of an item with its targets and media resolved.
+func (s *server) publishedDetailOf(r *http.Request, t content.Type, c content.Content) (publishedDetail, error) {
 	targets, err := s.content.TargetsOf(r.Context(), c.ID)
 	if err != nil {
 		return publishedDetail{}, err
@@ -290,11 +291,154 @@ func (s *server) publishedDetailOf(r *http.Request, c content.Content) (publishe
 	for key, listed := range targets {
 		values[key] = namedTargets(listed)
 	}
+	if err := s.inlineMediaValues(r, t, values); err != nil {
+		return publishedDetail{}, err
+	}
 	return publishedDetail{
 		publishedSummary: newPublishedSummary(c),
 		Content:          publichtml.Sanitize(c.Content),
 		Fields:           values,
 	}, nil
+}
+
+// servedRendition is one stored rendition as a public reader sees it.
+type servedRendition struct {
+	Src      string `json:"src"`
+	Width    int    `json:"width"`
+	Height   int    `json:"height"`
+	MimeType string `json:"mime_type"`
+}
+
+// servedMedia is one library file as a public reader sees it.
+type servedMedia struct {
+	ID       int64                      `json:"id"`
+	Src      string                     `json:"src"`
+	Title    string                     `json:"title"`
+	AltText  string                     `json:"alt_text"`
+	Caption  string                     `json:"caption"`
+	MimeType string                     `json:"mime_type"`
+	Width    int                        `json:"width"`
+	Height   int                        `json:"height"`
+	Sizes    map[string]servedRendition `json:"sizes"`
+}
+
+// servedMediaOf returns the public view of one stored file.
+func servedMediaOf(m media.Media) servedMedia {
+	sizes := make(map[string]servedRendition, len(m.Sizes))
+	for slug, held := range m.Sizes {
+		sizes[slug] = servedRendition{
+			Src:      mediaPrefix + "/" + held.File,
+			Width:    held.Width,
+			Height:   held.Height,
+			MimeType: held.MimeType,
+		}
+	}
+	return servedMedia{
+		ID:       m.ID,
+		Src:      mediaPrefix + "/" + m.File,
+		Title:    m.Title,
+		AltText:  m.AltText,
+		Caption:  m.Caption,
+		MimeType: m.MimeType,
+		Width:    m.Width,
+		Height:   m.Height,
+		Sizes:    sizes,
+	}
+}
+
+// heldMediaID returns the value as a library identity, and whether it is one.
+func heldMediaID(value any) (int64, bool) {
+	switch held := value.(type) {
+	case float64:
+		return int64(held), true
+	case float32:
+		return int64(held), true
+	case int64:
+		return held, true
+	case int32:
+		return int64(held), true
+	case int:
+		return int64(held), true
+	default:
+		return 0, false
+	}
+}
+
+// mediaIDsHeld returns every identity the values hold under the type's media fields.
+func mediaIDsHeld(t content.Type, values content.Values) []int64 {
+	var ids []int64
+	for _, f := range t.Fields {
+		if f.Kind != content.FieldKindMedia {
+			continue
+		}
+		if listed, many := values[f.Key].([]any); many {
+			for _, member := range listed {
+				if id, ok := heldMediaID(member); ok {
+					ids = append(ids, id)
+				}
+			}
+			continue
+		}
+		if id, ok := heldMediaID(values[f.Key]); ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// inlineMediaValues rewrites every media key into the files it names, dropping what is gone.
+func (s *server) inlineMediaValues(r *http.Request, t content.Type, values content.Values) error {
+	if s.mediaStore == nil {
+		return nil
+	}
+	ids := mediaIDsHeld(t, values)
+	if len(ids) == 0 {
+		return nil
+	}
+	listed, err := s.mediaStore.ByIDs(r.Context(), ids)
+	if err != nil {
+		return err
+	}
+	byID := make(map[int64]media.Media, len(listed))
+	for _, m := range listed {
+		byID[m.ID] = m
+	}
+	for _, f := range t.Fields {
+		if f.Kind == content.FieldKindMedia {
+			inlineMediaKey(f.Key, values, byID)
+		}
+	}
+	return nil
+}
+
+// inlineMediaKey rewrites one field's value, deleting the key when nothing resolves.
+func inlineMediaKey(key string, values content.Values, byID map[int64]media.Media) {
+	if listed, many := values[key].([]any); many {
+		served := make([]servedMedia, 0, len(listed))
+		for _, member := range listed {
+			if id, ok := heldMediaID(member); ok {
+				if m, found := byID[id]; found {
+					served = append(served, servedMediaOf(m))
+				}
+			}
+		}
+		if len(served) == 0 {
+			delete(values, key)
+			return
+		}
+		values[key] = served
+		return
+	}
+	id, ok := heldMediaID(values[key])
+	if !ok {
+		return
+	}
+	m, found := byID[id]
+	if !found {
+		delete(values, key)
+		return
+	}
+	values[key] = servedMediaOf(m)
 }
 
 // respondTerm answers with the addressed item and the published content pointing at it.
@@ -315,7 +459,7 @@ func (s *server) respondTerm(w http.ResponseWriter, r *http.Request, held conten
 	for i, c := range rows {
 		items[i] = newPublishedSummary(c)
 	}
-	detail, err := s.publishedDetailOf(r, held.Item)
+	detail, err := s.publishedDetailOf(r, held.Type, held.Item)
 	if err != nil {
 		respondDomainError(w, err)
 		return

--- a/internal/server/content_media_internal_test.go
+++ b/internal/server/content_media_internal_test.go
@@ -35,6 +35,16 @@ func TestHeldMediaIDReadsEveryNumberShapeAWriteAccepts(t *testing.T) {
 	}
 }
 
+func TestHeldMediaIDNamesTheLastIdentityACallerWritesWhole(t *testing.T) {
+	t.Parallel()
+
+	id, ok := heldMediaID(int64(math.MaxInt64))
+
+	if !ok || id != math.MaxInt64 {
+		t.Errorf("heldMediaID(max) = %d, %v, want the identity read whole", id, ok)
+	}
+}
+
 func TestHeldMediaIDNamesNoFileFromAPartOfANumber(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/content_media_internal_test.go
+++ b/internal/server/content_media_internal_test.go
@@ -3,6 +3,7 @@
 package server
 
 import (
+	"math"
 	"testing"
 
 	"github.com/gopherium/gophenberg/internal/content"
@@ -31,6 +32,27 @@ func TestHeldMediaIDReadsEveryNumberShapeAWriteAccepts(t *testing.T) {
 	}
 	if _, ok := heldMediaID("seven"); ok {
 		t.Error("heldMediaID(word) = true, want no identity in a word")
+	}
+}
+
+func TestHeldMediaIDNamesNoFileFromAPartOfANumber(t *testing.T) {
+	t.Parallel()
+
+	for name, value := range map[string]any{
+		"a part of a number":   float64(1.5),
+		"a narrow part":        float32(1.5),
+		"nothing at all":       math.NaN(),
+		"a number without end": math.Inf(1),
+		"a number below one":   float64(0),
+		"a number before it":   float64(-3),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if id, ok := heldMediaID(value); ok {
+				t.Errorf("heldMediaID(%v) = %d, want no file named by it", value, id)
+			}
+		})
 	}
 }
 

--- a/internal/server/content_media_internal_test.go
+++ b/internal/server/content_media_internal_test.go
@@ -105,12 +105,57 @@ func TestInlineMediaKeyDeletesWhatNamesNoFile(t *testing.T) {
 
 			values := content.Values{"cover": held}
 
-			inlineMediaKey("cover", values, map[int64]media.Media{})
+			inlineMediaKey(galleryField("cover", false), values, map[int64]media.Media{})
 
 			if raw, found := values["cover"]; found {
 				t.Errorf("values hold %v, want the key deleted rather than served", raw)
 			}
 		})
+	}
+}
+
+func TestInlineMediaKeyServesTheShapeTheFieldDeclares(t *testing.T) {
+	t.Parallel()
+
+	stored := map[int64]media.Media{7: {ID: 7, File: "2026/08/one.jpg", MimeType: "image/jpeg"}}
+
+	for name, test := range map[string]struct {
+		field content.Field
+		held  any
+	}{
+		"a cover holding a list":     {galleryField("cover", false), []any{float64(7)}},
+		"a gallery holding one item": {galleryField("gallery", true), float64(7)},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			values := content.Values{test.field.Key: test.held}
+
+			inlineMediaKey(test.field, values, stored)
+
+			if raw, found := values[test.field.Key]; found {
+				t.Errorf("%s serves %v, want the key left out rather than the wrong shape",
+					test.field.Key, raw)
+			}
+		})
+	}
+}
+
+func TestInlineMediaKeyServesEachDeclaredShape(t *testing.T) {
+	t.Parallel()
+
+	stored := map[int64]media.Media{7: {ID: 7, File: "2026/08/one.jpg", MimeType: "image/jpeg"}}
+	cover := content.Values{"cover": float64(7)}
+	gallery := content.Values{"gallery": []any{float64(7)}}
+
+	inlineMediaKey(galleryField("cover", false), cover, stored)
+	inlineMediaKey(galleryField("gallery", true), gallery, stored)
+
+	if _, one := cover["cover"].(servedMedia); !one {
+		t.Errorf("cover serves %T, want one object", cover["cover"])
+	}
+	if listed, many := gallery["gallery"].([]servedMedia); !many || len(listed) != 1 {
+		t.Errorf("gallery serves %T, want a list of one", gallery["gallery"])
 	}
 }
 
@@ -137,7 +182,7 @@ func TestInlineMediaKeyDeletesAnEmptiedList(t *testing.T) {
 
 	values := content.Values{"gallery": []any{float64(9)}}
 
-	inlineMediaKey("gallery", values, map[int64]media.Media{})
+	inlineMediaKey(galleryField("gallery", true), values, map[int64]media.Media{})
 
 	if _, found := values["gallery"]; found {
 		t.Errorf("values = %v, want the emptied key deleted", values)

--- a/internal/server/content_media_internal_test.go
+++ b/internal/server/content_media_internal_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"testing"
+
+	"github.com/gopherium/gophenberg/internal/content"
+	"github.com/gopherium/gophenberg/internal/media"
+)
+
+func TestHeldMediaIDReadsEveryNumberShapeAWriteAccepts(t *testing.T) {
+	t.Parallel()
+
+	for name, value := range map[string]any{
+		"a decoded number":       float64(7),
+		"a narrow decoded one":   float32(7),
+		"a written whole number": int(7),
+		"a narrow whole number":  int32(7),
+		"a wide whole number":    int64(7),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			id, ok := heldMediaID(value)
+
+			if !ok || id != 7 {
+				t.Errorf("heldMediaID(%v) = %d, %v, want the identity read", value, id, ok)
+			}
+		})
+	}
+	if _, ok := heldMediaID("seven"); ok {
+		t.Error("heldMediaID(word) = true, want no identity in a word")
+	}
+}
+
+// galleryField returns one media field of the key, holding many when asked.
+func galleryField(key string, many bool) content.Field {
+	return content.Field{Key: key, Kind: content.FieldKindMedia, Many: many}
+}
+
+func TestMediaIDsHeldSkipsWhatIsNotAnIdentity(t *testing.T) {
+	t.Parallel()
+
+	held := content.Type{Fields: []content.Field{
+		galleryField("cover", false),
+		galleryField("gallery", true),
+		{Key: "subtitle", Kind: content.FieldKindText},
+	}}
+	values := content.Values{
+		"gallery":  []any{float64(3), "stray", float64(4)},
+		"subtitle": "words",
+	}
+
+	ids := mediaIDsHeld(held, values)
+
+	if len(ids) != 2 || ids[0] != 3 || ids[1] != 4 {
+		t.Errorf("mediaIDsHeld() = %v, want only the identities the values hold", ids)
+	}
+}
+
+func TestInlineMediaKeyLeavesWhatIsNotAnIdentityAlone(t *testing.T) {
+	t.Parallel()
+
+	values := content.Values{"cover": "not-an-identity"}
+
+	inlineMediaKey("cover", values, map[int64]media.Media{})
+
+	if values["cover"] != "not-an-identity" {
+		t.Errorf("values = %v, want the stray value left alone", values)
+	}
+}
+
+func TestInlineMediaKeyDeletesAnEmptiedList(t *testing.T) {
+	t.Parallel()
+
+	values := content.Values{"gallery": []any{float64(9)}}
+
+	inlineMediaKey("gallery", values, map[int64]media.Media{})
+
+	if _, found := values["gallery"]; found {
+		t.Errorf("values = %v, want the emptied key deleted", values)
+	}
+}

--- a/internal/server/content_media_internal_test.go
+++ b/internal/server/content_media_internal_test.go
@@ -39,12 +39,13 @@ func TestHeldMediaIDNamesNoFileFromAPartOfANumber(t *testing.T) {
 	t.Parallel()
 
 	for name, value := range map[string]any{
-		"a part of a number":   float64(1.5),
-		"a narrow part":        float32(1.5),
-		"nothing at all":       math.NaN(),
-		"a number without end": math.Inf(1),
-		"a number below one":   float64(0),
-		"a number before it":   float64(-3),
+		"a part of a number":                  float64(1.5),
+		"a narrow part":                       float32(1.5),
+		"nothing at all":                      math.NaN(),
+		"a number without end":                math.Inf(1),
+		"a number below one":                  float64(0),
+		"a number before it":                  float64(-3),
+		"a number past the last one storable": float64(9223372036854775808),
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/server/content_media_internal_test.go
+++ b/internal/server/content_media_internal_test.go
@@ -92,15 +92,43 @@ func TestMediaIDsHeldSkipsWhatIsNotAnIdentity(t *testing.T) {
 	}
 }
 
-func TestInlineMediaKeyLeavesWhatIsNotAnIdentityAlone(t *testing.T) {
+func TestInlineMediaKeyDeletesWhatNamesNoFile(t *testing.T) {
 	t.Parallel()
 
-	values := content.Values{"cover": "not-an-identity"}
+	for name, held := range map[string]any{
+		"a word":            "not-an-identity",
+		"a part of an item": float64(1.5),
+		"nothing at all":    nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	inlineMediaKey("cover", values, map[int64]media.Media{})
+			values := content.Values{"cover": held}
 
-	if values["cover"] != "not-an-identity" {
-		t.Errorf("values = %v, want the stray value left alone", values)
+			inlineMediaKey("cover", values, map[int64]media.Media{})
+
+			if raw, found := values["cover"]; found {
+				t.Errorf("values hold %v, want the key deleted rather than served", raw)
+			}
+		})
+	}
+}
+
+func TestInlineMediaValuesClearsAFieldEvenWhenNothingResolves(t *testing.T) {
+	t.Parallel()
+
+	held := content.Type{Fields: []content.Field{
+		galleryField("cover", false),
+		galleryField("gallery", true),
+	}}
+	values := content.Values{"cover": "not-an-identity", "gallery": []any{"stray"}}
+
+	if err := (&server{}).inlineMediaValues(nil, held, values); err != nil {
+		t.Fatalf("inlineMediaValues() error = %v, want nil", err)
+	}
+
+	if len(values) != 0 {
+		t.Errorf("values = %v, want every media key the library cannot name deleted", values)
 	}
 }
 

--- a/internal/server/content_media_test.go
+++ b/internal/server/content_media_test.go
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/gopherium/gophenberg/internal/media"
+	"github.com/gopherium/gophenberg/internal/server"
+)
+
+// mediaTypedServer returns a signed in server holding a type registry and a media library.
+func mediaTypedServer(t *testing.T) (http.Handler, *fakeMediaStore) {
+	t.Helper()
+	users := newFakeUserStore()
+	addAda(t, users)
+	store := newFakeMediaStore()
+	handler := authedServerWithStores(t, server.Config{
+		Users: users, Content: newFakePostStore(), Types: newFakeTypeStore(), MediaStore: store,
+	})
+	return handler, store
+}
+
+// storedImage stores one described image and returns it with its identity.
+func storedImage(t *testing.T, store *fakeMediaStore, file, title string) media.Media {
+	t.Helper()
+	m, err := media.New(file, title, "image/jpeg", uuid.New())
+	if err != nil {
+		t.Fatalf("New(%q) error = %v, want nil", file, err)
+	}
+	m.AltText = "Boats at " + title
+	m.Caption = "Before the market opens"
+	m.Description = "Taken from the eastern pier"
+	m.Width = 640
+	m.Height = 480
+	m.Sizes = media.RenditionMap{
+		"large": {File: title + "-1024x768.jpg", Width: 1024, Height: 768, MimeType: "image/jpeg"},
+	}
+	created, err := store.Create(t.Context(), m)
+	if err != nil {
+		t.Fatalf("Create(%q) error = %v, want nil", file, err)
+	}
+	return created
+}
+
+// publishedWith publishes a fresh post holding the field values and returns its slug.
+func publishedWith(t *testing.T, handler http.Handler, fields string) string {
+	t.Helper()
+	held := draftedPost(t, handler)
+	saved := patchValues(t, handler, held, fields)
+	body := fmt.Sprintf(`{"updated_at":%q,"status":"published"}`, saved.UpdatedAt)
+	recorder := doRequest(t, handler, http.MethodPatch, "/api/content/"+held.ID, body)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("publishing: %d: %s", recorder.Code, recorder.Body.String())
+	}
+	return decodeBody[struct {
+		Slug string `json:"slug"`
+	}](t, recorder).Slug
+}
+
+// resolvedFields returns the fields object the public resolve answer carries for the slug.
+func resolvedFields(t *testing.T, handler http.Handler, slug string) map[string]json.RawMessage {
+	t.Helper()
+	recorder := doRequest(t, handler, http.MethodGet, "/api/content/v1/resolve?path="+slug, "")
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("resolving %q: %d: %s", slug, recorder.Code, recorder.Body.String())
+	}
+	var answered struct {
+		Item struct {
+			Fields map[string]json.RawMessage `json:"fields"`
+		} `json:"item"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &answered); err != nil {
+		t.Fatalf("reading the answer: %v", err)
+	}
+	return answered.Item.Fields
+}
+
+// servedMediaBody is one served media object as the tests read it.
+type servedMediaBody struct {
+	ID       int64                      `json:"id"`
+	Src      string                     `json:"src"`
+	Title    string                     `json:"title"`
+	AltText  string                     `json:"alt_text"`
+	Caption  string                     `json:"caption"`
+	MimeType string                     `json:"mime_type"`
+	Width    int                        `json:"width"`
+	Height   int                        `json:"height"`
+	Sizes    map[string]json.RawMessage `json:"sizes"`
+}
+
+func TestResolveServesTheCoverAsItsFile(t *testing.T) {
+	t.Parallel()
+
+	handler, store := mediaTypedServer(t)
+	sunrise := storedImage(t, store, "2026/08/sunrise.jpg", "Sunrise")
+	declaredOn(t, handler, `{"key":"cover","label":"Cover","kind":"media"}`)
+	slug := publishedWith(t, handler, fmt.Sprintf(`{"cover": %d}`, sunrise.ID))
+
+	fields := resolvedFields(t, handler, slug)
+
+	raw, found := fields["cover"]
+	if !found {
+		t.Fatalf("fields = %v, want the cover served", fields)
+	}
+	var served servedMediaBody
+	if err := json.Unmarshal(raw, &served); err != nil {
+		t.Fatalf("cover = %s, want one object rather than a list: %v", raw, err)
+	}
+	if served.Src != "/media/2026/08/sunrise.jpg" {
+		t.Errorf("src = %q, want the public address with its prefix", served.Src)
+	}
+	if served.ID != sunrise.ID || served.Width != 640 || served.Height != 480 {
+		t.Errorf("served = %+v, want the identity and the size", served)
+	}
+	if served.Title != "Sunrise" || served.AltText != "Boats at Sunrise" || served.Caption == "" {
+		t.Errorf("served = %+v, want the title, alt text and caption", served)
+	}
+	if _, leaked := served.Sizes["large"]; !leaked {
+		t.Errorf("sizes = %v, want the stored renditions", served.Sizes)
+	}
+	var loose map[string]any
+	if err := json.Unmarshal(raw, &loose); err != nil {
+		t.Fatalf("rereading the cover: %v", err)
+	}
+	if _, leaked := loose["description"]; leaked {
+		t.Errorf("served = %v, want the description kept private", loose)
+	}
+}
+
+func TestResolveServesTheRenditionAddress(t *testing.T) {
+	t.Parallel()
+
+	handler, store := mediaTypedServer(t)
+	sunrise := storedImage(t, store, "2026/08/sunrise.jpg", "Sunrise")
+	declaredOn(t, handler, `{"key":"cover","label":"Cover","kind":"media"}`)
+	slug := publishedWith(t, handler, fmt.Sprintf(`{"cover": %d}`, sunrise.ID))
+
+	fields := resolvedFields(t, handler, slug)
+
+	var served struct {
+		Sizes map[string]struct {
+			Src   string `json:"src"`
+			Width int    `json:"width"`
+		} `json:"sizes"`
+	}
+	if err := json.Unmarshal(fields["cover"], &served); err != nil {
+		t.Fatalf("reading the cover: %v", err)
+	}
+	large := served.Sizes["large"]
+	if large.Src != "/media/Sunrise-1024x768.jpg" || large.Width != 1024 {
+		t.Errorf("large = %+v, want the rendition addressed under the prefix", large)
+	}
+}
+
+func TestResolveServesTheGalleryInStoredOrder(t *testing.T) {
+	t.Parallel()
+
+	handler, store := mediaTypedServer(t)
+	beach := storedImage(t, store, "2026/08/beach.jpg", "Beach")
+	cliff := storedImage(t, store, "2026/08/cliff.jpg", "Cliff")
+	declaredOn(t, handler, `{"key":"gallery","label":"Gallery","kind":"media","many":true}`)
+	slug := publishedWith(t, handler, fmt.Sprintf(`{"gallery": [%d, %d]}`, cliff.ID, beach.ID))
+
+	fields := resolvedFields(t, handler, slug)
+
+	var served []servedMediaBody
+	if err := json.Unmarshal(fields["gallery"], &served); err != nil {
+		t.Fatalf("gallery = %s, want a list: %v", fields["gallery"], err)
+	}
+	if len(served) != 2 || served[0].ID != cliff.ID || served[1].ID != beach.ID {
+		t.Errorf("gallery = %+v, want the stored order kept", served)
+	}
+}
+
+func TestResolveDropsTheMediaThatIsGone(t *testing.T) {
+	t.Parallel()
+
+	handler, store := mediaTypedServer(t)
+	beach := storedImage(t, store, "2026/08/beach.jpg", "Beach")
+	cliff := storedImage(t, store, "2026/08/cliff.jpg", "Cliff")
+	declaredOn(t, handler, `{"key":"gallery","label":"Gallery","kind":"media","many":true}`)
+	slug := publishedWith(t, handler, fmt.Sprintf(`{"gallery": [%d, %d]}`, cliff.ID, beach.ID))
+	if _, err := store.Delete(t.Context(), cliff.ID); err != nil {
+		t.Fatalf("Delete() error = %v, want nil", err)
+	}
+
+	fields := resolvedFields(t, handler, slug)
+
+	var served []servedMediaBody
+	if err := json.Unmarshal(fields["gallery"], &served); err != nil {
+		t.Fatalf("gallery = %s, want a list: %v", fields["gallery"], err)
+	}
+	if len(served) != 1 || served[0].ID != beach.ID {
+		t.Errorf("gallery = %+v, want only the file that remains", served)
+	}
+}
+
+func TestResolveLeavesOutTheFieldWhoseMediaIsGone(t *testing.T) {
+	t.Parallel()
+
+	handler, store := mediaTypedServer(t)
+	sunrise := storedImage(t, store, "2026/08/sunrise.jpg", "Sunrise")
+	declaredOn(t, handler, `{"key":"cover","label":"Cover","kind":"media"}`)
+	slug := publishedWith(t, handler, fmt.Sprintf(`{"cover": %d}`, sunrise.ID))
+	if _, err := store.Delete(t.Context(), sunrise.ID); err != nil {
+		t.Fatalf("Delete() error = %v, want nil", err)
+	}
+
+	fields := resolvedFields(t, handler, slug)
+
+	if raw, found := fields["cover"]; found {
+		t.Errorf("cover = %s, want the field absent once its file is gone", raw)
+	}
+}
+
+func TestResolveServesEmptySizesWhenAFileHasNoRenditions(t *testing.T) {
+	t.Parallel()
+
+	handler, store := mediaTypedServer(t)
+	wave, err := media.New("2026/08/wave.gif", "Wave", "image/gif", uuid.New())
+	if err != nil {
+		t.Fatalf("New() error = %v, want nil", err)
+	}
+	created, err := store.Create(t.Context(), wave)
+	if err != nil {
+		t.Fatalf("Create() error = %v, want nil", err)
+	}
+	declaredOn(t, handler, `{"key":"cover","label":"Cover","kind":"media"}`)
+	slug := publishedWith(t, handler, fmt.Sprintf(`{"cover": %d}`, created.ID))
+
+	fields := resolvedFields(t, handler, slug)
+
+	var served servedMediaBody
+	if err := json.Unmarshal(fields["cover"], &served); err != nil {
+		t.Fatalf("reading the cover: %v", err)
+	}
+	if served.Sizes == nil || len(served.Sizes) != 0 {
+		t.Errorf("sizes = %v, want an empty map rather than null", served.Sizes)
+	}
+}
+
+func TestResolveMovesTheValidatorWhenAFileIsRedescribed(t *testing.T) {
+	t.Parallel()
+
+	handler, store := mediaTypedServer(t)
+	sunrise := storedImage(t, store, "2026/08/sunrise.jpg", "Sunrise")
+	declaredOn(t, handler, `{"key":"cover","label":"Cover","kind":"media"}`)
+	slug := publishedWith(t, handler, fmt.Sprintf(`{"cover": %d}`, sunrise.ID))
+
+	first := doRequest(t, handler, http.MethodGet, "/api/content/v1/resolve?path="+slug, "")
+	sunrise.AltText = "A brand new dawn"
+	if _, err := store.Update(t.Context(), sunrise, sunrise.UpdatedAt); err != nil {
+		t.Fatalf("Update() error = %v, want nil", err)
+	}
+	second := doRequest(t, handler, http.MethodGet, "/api/content/v1/resolve?path="+slug, "")
+
+	before, after := first.Header().Get("ETag"), second.Header().Get("ETag")
+	if before == "" || before == after {
+		t.Errorf("ETag = %q then %q, want the validator moved by the new words", before, after)
+	}
+}
+
+func TestResolveServesAnItemHoldingNoMedia(t *testing.T) {
+	t.Parallel()
+
+	handler, _ := mediaTypedServer(t)
+	declaredOn(t, handler, `{"key":"cover","label":"Cover","kind":"media"}`)
+	slug := publishedWith(t, handler, `{}`)
+
+	fields := resolvedFields(t, handler, slug)
+
+	if raw, found := fields["cover"]; found {
+		t.Errorf("cover = %s, want nothing served for a field nobody filled", raw)
+	}
+}
+
+func TestResolveReportsAFailingMediaLibrary(t *testing.T) {
+	t.Parallel()
+
+	users := newFakeUserStore()
+	addAda(t, users)
+	handler := authedServerWithStores(t, server.Config{
+		Users: users, Content: newFakePostStore(), Types: newFakeTypeStore(),
+		MediaStore: undeletableMediaStore{err: errors.New("the library is down")},
+	})
+	declaredOn(t, handler, `{"key":"cover","label":"Cover","kind":"media"}`)
+	slug := publishedWith(t, handler, `{"cover": 7}`)
+
+	recorder := doRequest(t, handler, http.MethodGet, "/api/content/v1/resolve?path="+slug, "")
+
+	if recorder.Code == http.StatusOK {
+		t.Errorf("status = %d, want the library failure reported", recorder.Code)
+	}
+}
+
+func TestResolveServesBareIdentitiesWithoutAMediaLibrary(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	declaredOn(t, handler, `{"key":"cover","label":"Cover","kind":"media"}`)
+	slug := publishedWith(t, handler, `{"cover": 7}`)
+
+	fields := resolvedFields(t, handler, slug)
+
+	var held float64
+	if err := json.Unmarshal(fields["cover"], &held); err != nil || held != 7 {
+		t.Errorf("cover = %s, want the stored identity untouched", fields["cover"])
+	}
+}

--- a/internal/server/content_media_test.go
+++ b/internal/server/content_media_test.go
@@ -300,7 +300,7 @@ func TestResolveReportsAFailingMediaLibrary(t *testing.T) {
 	}
 }
 
-func TestResolveServesBareIdentitiesWithoutAMediaLibrary(t *testing.T) {
+func TestResolveLeavesOutMediaWithoutALibraryToResolveIt(t *testing.T) {
 	t.Parallel()
 
 	handler := authedTypeServer(t)
@@ -309,8 +309,7 @@ func TestResolveServesBareIdentitiesWithoutAMediaLibrary(t *testing.T) {
 
 	fields := resolvedFields(t, handler, slug)
 
-	var held float64
-	if err := json.Unmarshal(fields["cover"], &held); err != nil || held != 7 {
-		t.Errorf("cover = %s, want the stored identity untouched", fields["cover"])
+	if raw, found := fields["cover"]; found {
+		t.Errorf("cover = %s, want the field absent rather than a bare identity", raw)
 	}
 }

--- a/internal/server/content_test.go
+++ b/internal/server/content_test.go
@@ -72,7 +72,7 @@ func TestContentAPIAnswersTheHandshakeWithoutASession(t *testing.T) {
 	if !strings.Contains(body, `"api":0`) {
 		t.Errorf("body = %q, want the api generation", body)
 	}
-	if !strings.Contains(body, `"kit":["0.9.0"]`) {
+	if !strings.Contains(body, `"kit":["0.9.0","0.10.0"]`) {
 		t.Errorf("body = %q, want the kit versions served", body)
 	}
 	if !strings.Contains(body, `"gophenberg"`) {
@@ -341,7 +341,7 @@ func TestContentAPIAdvertisesTheTypesItServes(t *testing.T) {
 	if handshake.API != 0 {
 		t.Errorf("api = %d, want 0", handshake.API)
 	}
-	if !slices.Equal(handshake.Kit, []string{"0.9.0"}) {
+	if !slices.Equal(handshake.Kit, []string{"0.9.0", "0.10.0"}) {
 		t.Errorf("kit = %v, want the kit versions this release serves", handshake.Kit)
 	}
 	if len(handshake.Types) != 1 {

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -384,6 +384,23 @@ func TestGroupFieldPatchRefusesSettingsTheDefinitionForbids(t *testing.T) {
 	}
 }
 
+func TestGroupWriteRefusesASecondBodyAfterTheFirst(t *testing.T) {
+	t.Parallel()
+
+	handler, _, _, _ := typedPostServer(t)
+	id := createGroup(t, handler, "Article details")
+
+	recorder := doRequest(t, handler, http.MethodPost, groupPath(id)+"/fields",
+		`{"key":"subtitle","label":"Subtitle","kind":"text"}{"key":"second","label":"Second","kind":"text"}`)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d, body %s", recorder.Code, http.StatusBadRequest, recorder.Body.String())
+	}
+	if code := errorCode(t, recorder); code != "body_malformed" {
+		t.Errorf("code = %q, want body_malformed", code)
+	}
+}
+
 func TestGroupFieldDeleteTakesTheFieldAway(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/media_failure_test.go
+++ b/internal/server/media_failure_test.go
@@ -60,6 +60,11 @@ func (s undeletableMediaStore) ByID(context.Context, int64) (media.Media, error)
 	return s.item, nil
 }
 
+// ByIDs reports the failure.
+func (s undeletableMediaStore) ByIDs(context.Context, []int64) ([]media.Media, error) {
+	return nil, s.err
+}
+
 // List answers nothing stored.
 func (s undeletableMediaStore) List(context.Context, media.Filter) ([]media.Media, int, error) {
 	return nil, 0, nil

--- a/internal/server/media_test.go
+++ b/internal/server/media_test.go
@@ -69,6 +69,19 @@ func (s *fakeMediaStore) ByID(_ context.Context, id int64) (media.Media, error) 
 	return m, nil
 }
 
+// ByIDs returns the stored items among the identities, leaving out any that are gone.
+func (s *fakeMediaStore) ByIDs(_ context.Context, ids []int64) ([]media.Media, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	listed := make([]media.Media, 0, len(ids))
+	for _, id := range ids {
+		if m, found := s.items[id]; found {
+			listed = append(listed, m)
+		}
+	}
+	return listed, nil
+}
+
 // List returns every stored item newest first with their count, or fails as told.
 func (s *fakeMediaStore) List(_ context.Context, f media.Filter) ([]media.Media, int, error) {
 	s.mu.Lock()

--- a/internal/themehost/kit.go
+++ b/internal/themehost/kit.go
@@ -9,7 +9,7 @@ import (
 )
 
 // servedKits names the theme kit versions this release serves, oldest first.
-var servedKits = []string{"0.9.0"}
+var servedKits = []string{"0.9.0", "0.10.0"}
 
 // ServedKits returns the theme kit versions this release serves.
 func ServedKits() []string {

--- a/internal/themehost/kit_test.go
+++ b/internal/themehost/kit_test.go
@@ -17,11 +17,26 @@ func TestServedKitsNamesWhatThisReleaseServes(t *testing.T) {
 
 	served := themehost.ServedKits()
 
-	if !slices.Equal(served, []string{"0.9.0"}) {
+	if !slices.Equal(served, []string{"0.9.0", "0.10.0"}) {
 		t.Errorf("ServedKits() = %v, want the kit versions this release serves", served)
 	}
-	if themehost.NewestKit() != "0.9.0" {
+	if themehost.NewestKit() != "0.10.0" {
 		t.Errorf("NewestKit() = %q, want the newest of them", themehost.NewestKit())
+	}
+}
+
+func TestAThemeOnEitherServedKitIsAccepted(t *testing.T) {
+	t.Parallel()
+
+	for _, declared := range []string{"0.9.0", "0.10.0"} {
+		if !themehost.ServesKit(declared) {
+			t.Errorf("ServesKit(%q) = false, want a theme on a served kit accepted", declared)
+		}
+	}
+	for _, declared := range []string{"0.8.0", "0.10.3"} {
+		if themehost.ServesKit(declared) {
+			t.Errorf("ServesKit(%q) = true, want a kit this release cannot serve turned away", declared)
+		}
 	}
 }
 
@@ -30,7 +45,7 @@ func TestServedKitsCannotBeChangedByACaller(t *testing.T) {
 
 	themehost.ServedKits()[0] = "9.9.9"
 
-	if themehost.NewestKit() != "0.9.0" {
+	if themehost.NewestKit() != "0.10.0" {
 		t.Errorf("NewestKit() = %q after a caller wrote to the returned slice", themehost.NewestKit())
 	}
 }

--- a/sdk/astro/CHANGELOG.md
+++ b/sdk/astro/CHANGELOG.md
@@ -16,6 +16,9 @@ through 0.8.0 shipped in step with Gophenberg under its `vX.Y.Z` tags.
 ### Added
 
 - A content type's fields carry the settings the operator set on them.
+- `mediaFields` and `mediaItems` read the library files a media field names.
+- `mediaUrl` addresses a library file from a theme serving its own origin.
+- `MediaValue` and `MediaRendition` type what a media field serves.
 
 ### Changed
 

--- a/sdk/astro/content.ts
+++ b/sdk/astro/content.ts
@@ -25,6 +25,27 @@ export interface RelatedItem {
 	path: string
 }
 
+/** One stored rendition of a library file, as a reader sees it. */
+export interface MediaRendition {
+	src: string
+	width: number
+	height: number
+	mime_type: string
+}
+
+/** One library file a media field names, as a reader sees it. */
+export interface MediaValue {
+	id: number
+	src: string
+	title: string
+	alt_text: string
+	caption: string
+	mime_type: string
+	width: number
+	height: number
+	sizes: Record<string, MediaRendition>
+}
+
 /** One typed field a content type declares. */
 export interface ContentTypeField {
 	key: string

--- a/sdk/astro/index.ts
+++ b/sdk/astro/index.ts
@@ -14,6 +14,7 @@ export {
 export { defineTheme } from './theme.ts'
 export { gophenbergLoader } from './loader.ts'
 export { relatedFields, relatedItems } from './related.ts'
+export { mediaFields, mediaItems, mediaUrl } from './media.ts'
 
 export type { BlockComponentMap, BlockNode, BlockProps, BlockSegment, ParsedBlock } from './blocks.ts'
 export type { ClientOptions, ListQuery, ResolveOptions } from './client.ts'
@@ -21,6 +22,8 @@ export type {
 	ContentType,
 	ContentTypeField,
 	Handshake,
+	MediaRendition,
+	MediaValue,
 	Page,
 	Post,
 	PostSummary,
@@ -30,4 +33,5 @@ export type {
 export type { SiteAssetUrls } from './assets.ts'
 export type { LivePost, LoaderOptions, PostCollectionFilter, PostEntryFilter } from './loader.ts'
 export type { RelatedField } from './related.ts'
+export type { MediaField } from './media.ts'
 export type { GophenbergTheme, ThemeLayouts, ThemeSeo } from './theme.ts'

--- a/sdk/astro/media.ts
+++ b/sdk/astro/media.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { env } from 'node:process'
+
+import type { MediaValue, Post } from './content.ts'
+
+/** One media field of an item and the files it names. */
+export interface MediaField {
+	key: string
+	items: MediaValue[]
+}
+
+/**
+ * Returns the files a value names, or nothing when it names no file.
+ * @param value - The value an item holds under a field key.
+ * @returns The files named, or nothing.
+ */
+export function mediaItems(value: unknown): MediaValue[] | undefined {
+	if (isMediaValue(value)) {
+		return [value]
+	}
+	if (!Array.isArray(value) || value.length === 0) {
+		return undefined
+	}
+	if (value.every(isMediaValue)) {
+		return value
+	}
+	return undefined
+}
+
+/**
+ * Reports whether a value names one library file.
+ * @param held - A field value or one entry of it.
+ * @returns True when the value names a file.
+ */
+function isMediaValue(held: unknown): held is MediaValue {
+	if (typeof held !== 'object' || held === null) {
+		return false
+	}
+	const named = held as Record<string, unknown>
+	return (
+		typeof named.id === 'number' &&
+		typeof named.src === 'string' &&
+		typeof named.sizes === 'object' &&
+		named.sizes !== null
+	)
+}
+
+/**
+ * Returns the media fields an item carries, keyed in the order their keys read.
+ * @param post - The item to read.
+ * @returns Each media field and the files it names.
+ */
+export function mediaFields(post: Post): MediaField[] {
+	const held: MediaField[] = []
+	for (const key of Object.keys(post.fields).sort()) {
+		const items = mediaItems(post.fields[key])
+		if (items !== undefined) {
+			held.push({ key, items })
+		}
+	}
+	return held
+}
+
+/**
+ * Returns the address a themed page loads a library file from.
+ * @param src - The address the content API served.
+ * @returns The address to put in the markup.
+ */
+export function mediaUrl(src: string): string {
+	if (/^[a-z]+:\/\//i.test(src)) {
+		return src
+	}
+	const origin = (env.GOPHENBERG_ASSET_ORIGIN ?? '').replace(/\/+$/, '')
+	return `${origin}${src}`
+}

--- a/sdk/astro/package.json
+++ b/sdk/astro/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gophenberg/astro",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "Build a Gophenberg theme in Astro: routes, block rendering, and the theme contract.",

--- a/sdk/astro/test/media.test.ts
+++ b/sdk/astro/test/media.test.ts
@@ -2,7 +2,7 @@
 
 import { env } from 'node:process'
 
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 
 import { mediaFields, mediaItems, mediaUrl, relatedFields, relatedItems } from '../index.ts'
 import type { MediaValue, Post } from '../index.ts'
@@ -101,8 +101,18 @@ describe('the media fields an item carries', () => {
 })
 
 describe('the address a theme loads a file from', () => {
-	afterEach(() => {
+	const held = env.GOPHENBERG_ASSET_ORIGIN
+
+	beforeEach(() => {
 		delete env.GOPHENBERG_ASSET_ORIGIN
+	})
+
+	afterEach(() => {
+		if (held === undefined) {
+			delete env.GOPHENBERG_ASSET_ORIGIN
+			return
+		}
+		env.GOPHENBERG_ASSET_ORIGIN = held
 	})
 
 	test('loads from the theme origin when it shares one', () => {

--- a/sdk/astro/test/media.test.ts
+++ b/sdk/astro/test/media.test.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { env } from 'node:process'
+
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { mediaFields, mediaItems, mediaUrl, relatedFields, relatedItems } from '../index.ts'
+import type { MediaValue, Post } from '../index.ts'
+
+/**
+ * Returns a published post carrying the given values.
+ * @param fields - The values the post holds.
+ * @returns The post.
+ */
+function posting(fields: Record<string, unknown>): Post {
+	return {
+		id: '1',
+		type: 'post',
+		path: 'hello-world',
+		slug: 'hello-world',
+		title: 'Hello world',
+		excerpt: '',
+		content: '',
+		fields,
+		published_at: '2026-08-04T12:00:00Z',
+		updated_at: '2026-08-04T12:00:00Z',
+	}
+}
+
+const SUNRISE: MediaValue = {
+	id: 12,
+	src: '/media/2026/08/sunrise.jpg',
+	title: 'Sunrise',
+	alt_text: 'Sunrise over the bay',
+	caption: 'Golden hour at the marina',
+	mime_type: 'image/jpeg',
+	width: 3200,
+	height: 1800,
+	sizes: {
+		large: { src: '/media/2026/08/sunrise-1024x576.jpg', width: 1024, height: 576, mime_type: 'image/jpeg' },
+	},
+}
+
+const HARBOR: MediaValue = { ...SUNRISE, id: 15, src: '/media/2026/08/harbor.gif', sizes: {} }
+
+const NEWS = { id: 'a1', title: 'News', path: 'categories/news' }
+
+describe('the files a value names', () => {
+	test('reads the one file a media value holds', () => {
+		expect(mediaItems(SUNRISE)).toEqual([SUNRISE])
+	})
+
+	test('reads every file a gallery holds, in order', () => {
+		expect(mediaItems([SUNRISE, HARBOR])).toEqual([SUNRISE, HARBOR])
+	})
+
+	test('reads nothing from a value naming no file', () => {
+		expect(mediaItems(undefined)).toBeUndefined()
+		expect(mediaItems('a word')).toBeUndefined()
+		expect(mediaItems(12)).toBeUndefined()
+		expect(mediaItems([])).toBeUndefined()
+		expect(mediaItems({ id: 12 })).toBeUndefined()
+	})
+
+	test('reads nothing from a list holding anything but files', () => {
+		expect(mediaItems([SUNRISE, 'a word'])).toBeUndefined()
+	})
+})
+
+describe('the guards stay apart', () => {
+	test('a file is never read as an item a relation points at', () => {
+		expect(relatedItems([SUNRISE])).toBeUndefined()
+		expect(relatedFields(posting({ cover: SUNRISE, gallery: [SUNRISE, HARBOR] }))).toEqual([])
+	})
+
+	test('an item a relation points at is never read as a file', () => {
+		expect(mediaItems([NEWS])).toBeUndefined()
+		expect(mediaFields(posting({ categories: [NEWS] }))).toEqual([])
+	})
+})
+
+describe('the media fields an item carries', () => {
+	test('names each field and the files it holds', () => {
+		const post = posting({ cover: SUNRISE, gallery: [HARBOR], subtitle: 'words' })
+
+		expect(mediaFields(post)).toEqual([
+			{ key: 'cover', items: [SUNRISE] },
+			{ key: 'gallery', items: [HARBOR] },
+		])
+	})
+
+	test('reads the fields in the order their keys read', () => {
+		const post = posting({ zebra: SUNRISE, apple: HARBOR })
+
+		expect(mediaFields(post).map((field) => field.key)).toEqual(['apple', 'zebra'])
+	})
+
+	test('carries nothing for an item holding no files', () => {
+		expect(mediaFields(posting({ subtitle: 'words' }))).toEqual([])
+	})
+})
+
+describe('the address a theme loads a file from', () => {
+	afterEach(() => {
+		delete env.GOPHENBERG_ASSET_ORIGIN
+	})
+
+	test('loads from the theme origin when it shares one', () => {
+		expect(mediaUrl(SUNRISE.src)).toBe('/media/2026/08/sunrise.jpg')
+	})
+
+	test('loads from the instance when the theme runs apart', () => {
+		env.GOPHENBERG_ASSET_ORIGIN = 'https://example.com/'
+
+		expect(mediaUrl(SUNRISE.src)).toBe('https://example.com/media/2026/08/sunrise.jpg')
+	})
+
+	test('leaves an address that already names its origin alone', () => {
+		env.GOPHENBERG_ASSET_ORIGIN = 'https://example.com'
+
+		expect(mediaUrl('https://cdn.example.com/a.jpg')).toBe('https://cdn.example.com/a.jpg')
+	})
+})

--- a/test/features/features/media-values.feature
+++ b/test/features/features/media-values.feature
@@ -8,7 +8,6 @@ Feature: Serving media field values
     And a signed in administrator
     And the group "Extras" placed on "post"
 
-  @wip
   Scenario: A cover serves the file it points at
     Given the media field "cover" in "Extras"
     And the administrator uploads a 640 by 480 pixel JPEG named "sunrise.jpg"
@@ -18,18 +17,16 @@ Feature: Serving media field values
     Then the served field "cover" is one object addressing "sunrise.jpg"
     And the served field "cover" carries the size 640 by 480
 
-  @wip
   Scenario: The words on a file go public without the librarian's note
     Given the media field "cover" in "Extras"
     And the administrator uploads a 640 by 480 pixel JPEG named "sunrise.jpg"
-    And the administrator describes the image "sunrise"
     And the published post "Hello world"
     And the administrator saves the image named "sunrise" into "cover" of "Hello world"
+    And the administrator describes the image "sunrise"
     When a visitor resolves "/hello-world"
     Then the served field "cover" carries the saved title, alt text and caption
     And the served field "cover" carries no description
 
-  @wip
   Scenario: A gallery keeps its stored order
     Given the many media field "gallery" in "Extras"
     And the administrator uploads a 640 by 480 pixel JPEG named "beach.jpg"
@@ -39,7 +36,6 @@ Feature: Serving media field values
     When a visitor resolves "/hello-world"
     Then the served field "gallery" lists the addresses "cliff.jpg, beach.jpg" in that order
 
-  @wip
   Scenario: A file that is gone drops out of a gallery
     Given the many media field "gallery" in "Extras"
     And the administrator uploads a 640 by 480 pixel JPEG named "beach.jpg"
@@ -50,7 +46,6 @@ Feature: Serving media field values
     When a visitor resolves "/hello-world"
     Then the served field "gallery" lists the addresses "beach.jpg" in that order
 
-  @wip
   Scenario: A cover whose file is gone leaves the field out
     Given the media field "cover" in "Extras"
     And the administrator uploads a 640 by 480 pixel JPEG named "sunrise.jpg"
@@ -60,7 +55,6 @@ Feature: Serving media field values
     When a visitor resolves "/hello-world"
     Then the served fields carry no "cover"
 
-  @wip
   Scenario: A term's own item serves its media
     Given the type "category" labeled "Category" and "Categories" under "categories" serving term pages
     And the group "Category art" placed on "category"
@@ -71,7 +65,6 @@ Feature: Serving media field values
     When a visitor resolves "/categories/news"
     Then the served field "portrait" is one object addressing "banner.jpg"
 
-  @wip
   Scenario: Editing the words on a file changes the item's validator
     Given the media field "cover" in "Extras"
     And the administrator uploads a 640 by 480 pixel JPEG named "sunrise.jpg"
@@ -81,7 +74,6 @@ Feature: Serving media field values
     When the administrator describes the image "sunrise"
     Then resolving "/hello-world" answers a changed validator
 
-  @wip
   Scenario: An animated GIF serves its address and no renditions
     Given the media field "cover" in "Extras"
     And the administrator uploads an animated GIF named "wave.gif"

--- a/test/features/features/media-values.feature
+++ b/test/features/features/media-values.feature
@@ -1,0 +1,92 @@
+Feature: Serving media field values
+  A published item's media fields serve the file itself, its address, its
+  words and its renditions, so a theme renders an image without a login.
+  A file that is gone drops out rather than breaking the page.
+
+  Background:
+    Given a running Gophenberg with the default content types
+    And a signed in administrator
+    And the group "Extras" placed on "post"
+
+  @wip
+  Scenario: A cover serves the file it points at
+    Given the media field "cover" in "Extras"
+    And the administrator uploads a 640 by 480 pixel JPEG named "sunrise.jpg"
+    And the published post "Hello world"
+    And the administrator saves the image named "sunrise" into "cover" of "Hello world"
+    When a visitor resolves "/hello-world"
+    Then the served field "cover" is one object addressing "sunrise.jpg"
+    And the served field "cover" carries the size 640 by 480
+
+  @wip
+  Scenario: The words on a file go public without the librarian's note
+    Given the media field "cover" in "Extras"
+    And the administrator uploads a 640 by 480 pixel JPEG named "sunrise.jpg"
+    And the administrator describes the image "sunrise"
+    And the published post "Hello world"
+    And the administrator saves the image named "sunrise" into "cover" of "Hello world"
+    When a visitor resolves "/hello-world"
+    Then the served field "cover" carries the saved title, alt text and caption
+    And the served field "cover" carries no description
+
+  @wip
+  Scenario: A gallery keeps its stored order
+    Given the many media field "gallery" in "Extras"
+    And the administrator uploads a 640 by 480 pixel JPEG named "beach.jpg"
+    And the administrator uploads a 640 by 480 pixel JPEG named "cliff.jpg"
+    And the published post "Hello world"
+    And the administrator saves the images named "cliff, beach" into "gallery" of "Hello world"
+    When a visitor resolves "/hello-world"
+    Then the served field "gallery" lists the addresses "cliff.jpg, beach.jpg" in that order
+
+  @wip
+  Scenario: A file that is gone drops out of a gallery
+    Given the many media field "gallery" in "Extras"
+    And the administrator uploads a 640 by 480 pixel JPEG named "beach.jpg"
+    And the administrator uploads a 640 by 480 pixel JPEG named "cliff.jpg"
+    And the published post "Hello world"
+    And the administrator saves the images named "cliff, beach" into "gallery" of "Hello world"
+    And the administrator deletes the image named "cliff"
+    When a visitor resolves "/hello-world"
+    Then the served field "gallery" lists the addresses "beach.jpg" in that order
+
+  @wip
+  Scenario: A cover whose file is gone leaves the field out
+    Given the media field "cover" in "Extras"
+    And the administrator uploads a 640 by 480 pixel JPEG named "sunrise.jpg"
+    And the published post "Hello world"
+    And the administrator saves the image named "sunrise" into "cover" of "Hello world"
+    And the administrator deletes the image named "sunrise"
+    When a visitor resolves "/hello-world"
+    Then the served fields carry no "cover"
+
+  @wip
+  Scenario: A term's own item serves its media
+    Given the type "category" labeled "Category" and "Categories" under "categories" serving term pages
+    And the group "Category art" placed on "category"
+    And the media field "portrait" in "Category art"
+    And the administrator uploads a 640 by 480 pixel JPEG named "banner.jpg"
+    And the published category "News"
+    And the administrator saves the image named "banner" into "portrait" of "News"
+    When a visitor resolves "/categories/news"
+    Then the served field "portrait" is one object addressing "banner.jpg"
+
+  @wip
+  Scenario: Editing the words on a file changes the item's validator
+    Given the media field "cover" in "Extras"
+    And the administrator uploads a 640 by 480 pixel JPEG named "sunrise.jpg"
+    And the published post "Hello world"
+    And the administrator saves the image named "sunrise" into "cover" of "Hello world"
+    And a visitor remembers the validator of "/hello-world"
+    When the administrator describes the image "sunrise"
+    Then resolving "/hello-world" answers a changed validator
+
+  @wip
+  Scenario: An animated GIF serves its address and no renditions
+    Given the media field "cover" in "Extras"
+    And the administrator uploads an animated GIF named "wave.gif"
+    And the published post "Hello world"
+    And the administrator saves the image named "wave" into "cover" of "Hello world"
+    When a visitor resolves "/hello-world"
+    Then the served field "cover" is one object addressing "wave.gif"
+    And the served field "cover" carries no renditions

--- a/test/features/features_test.go
+++ b/test/features/features_test.go
@@ -54,6 +54,10 @@ func TestFieldKinds(t *testing.T) {
 	runFeature(t, "features/field-kinds.feature", initializeFieldKinds)
 }
 
+func TestMediaValues(t *testing.T) {
+	runFeature(t, "features/media-values.feature", initializeMediaValues)
+}
+
 func TestRouteGate(t *testing.T) {
 	runFeature(t, "features/roles-route-gate.feature", initializeRouteGate)
 }

--- a/test/features/memorymedia_test.go
+++ b/test/features/memorymedia_test.go
@@ -45,6 +45,19 @@ func (s *memoryMedia) ByID(_ context.Context, id int64) (media.Media, error) {
 	return m, nil
 }
 
+// ByIDs returns the media items stored under the identities, leaving out any that are gone.
+func (s *memoryMedia) ByIDs(_ context.Context, ids []int64) ([]media.Media, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	listed := make([]media.Media, 0, len(ids))
+	for _, id := range ids {
+		if m, found := s.items[id]; found {
+			listed = append(listed, m)
+		}
+	}
+	return listed, nil
+}
+
 // List returns the media items matching the filter, newest first, and the
 // total number matching it.
 func (s *memoryMedia) List(_ context.Context, f media.Filter) ([]media.Media, int, error) {

--- a/test/features/steps_media_values_test.go
+++ b/test/features/steps_media_values_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package features_test
+
+import (
+	"github.com/cucumber/godog"
+)
+
+// initializeMediaValues registers the steps of the media values feature.
+func initializeMediaValues(sc *godog.ScenarioContext) {
+	sc.Before(provisionWorld)
+	sc.After(retireWorld)
+	sc.Given(`^a running Gophenberg with the default content types$`, aRunningGophenbergWithTheDefaultContentTypes)
+	sc.Given(`^a signed in administrator$`, aSignedInAdministrator)
+	sc.Given(`^the group "([^"]*)" placed on "([^"]*)"$`, theGroupExists)
+	sc.Given(`^the published post "([^"]*)"$`, thePublishedPost)
+	sc.Given(`^the published category "([^"]*)"$`, thePublishedCategory)
+	sc.Given(
+		`^the type "([^"]*)" labeled "([^"]*)" and "([^"]*)" under "([^"]*)" serving term pages$`,
+		theTermTypeExists,
+	)
+	sc.Given(`^the many media field "([^"]*)" in "([^"]*)"$`, theManyMediaFieldExists)
+	sc.Given(`^the administrator uploads a (\d+) by (\d+) pixel JPEG named "([^"]*)"$`, uploadsAPixelJPEG)
+	sc.Given(`^the administrator uploads an animated GIF named "([^"]*)"$`, uploadsAnAnimatedGIF)
+	sc.Given(`^the administrator describes the image "([^"]*)"$`, describesTheImage)
+	sc.When(`^the administrator describes the image "([^"]*)"$`, describesTheImage)
+	sc.When(`^a visitor resolves "([^"]*)"$`, aVisitorResolves)
+}

--- a/test/features/steps_media_values_test.go
+++ b/test/features/steps_media_values_test.go
@@ -3,8 +3,304 @@
 package features_test
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
 	"github.com/cucumber/godog"
 )
+
+// theMediaFieldExists declares a media field holding one item inside the named group.
+func theMediaFieldExists(ctx context.Context, key, title string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	held, err := groupNamed(w, title)
+	if err != nil {
+		return err
+	}
+	body := fmt.Sprintf(`{"key":%q,"label":%q,"kind":"media"}`, key, key)
+	if err := w.postJSON(groupsPath+"/"+strconv.Itoa(held.ID)+"/fields", body); err != nil {
+		return err
+	}
+	if err := w.expect(http.StatusCreated); err != nil {
+		return fmt.Errorf("declaring the media field %q: %w", key, err)
+	}
+	return nil
+}
+
+// imageIDsNamed returns the library identities of the named images, in the given order.
+func imageIDsNamed(w *world, names string) ([]int64, error) {
+	var ids []int64
+	for _, name := range strings.Split(names, ", ") {
+		item, err := libraryItemNamed(w, name)
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, item.ID)
+	}
+	return ids, nil
+}
+
+// savesTheImageNamed writes one image's identity into a field of the remembered item.
+func savesTheImageNamed(ctx context.Context, name, key, title string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	ids, err := imageIDsNamed(w, name)
+	if err != nil {
+		return err
+	}
+	return saveFieldValues(w, title, fmt.Sprintf(`{%q:%d}`, key, ids[0]))
+}
+
+// savesTheImagesNamed writes the images' identities as a list into a field of the remembered item.
+func savesTheImagesNamed(ctx context.Context, names, key, title string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	ids, err := imageIDsNamed(w, names)
+	if err != nil {
+		return err
+	}
+	written := make([]string, len(ids))
+	for i, id := range ids {
+		written[i] = strconv.FormatInt(id, 10)
+	}
+	return saveFieldValues(w, title, fmt.Sprintf(`{%q:[%s]}`, key, strings.Join(written, ",")))
+}
+
+// deletesTheImageNamed removes the named image from the library.
+func deletesTheImageNamed(ctx context.Context, name string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	item, err := libraryItemNamed(w, name)
+	if err != nil {
+		return err
+	}
+	if err := w.deleteAt("/api/media/" + strconv.FormatInt(item.ID, 10)); err != nil {
+		return err
+	}
+	return w.expect(http.StatusNoContent)
+}
+
+// servedMediaValue is one media object as the resolve answer serves it.
+type servedMediaValue struct {
+	Src      string                     `json:"src"`
+	Title    string                     `json:"title"`
+	AltText  string                     `json:"alt_text"`
+	Caption  string                     `json:"caption"`
+	Width    int                        `json:"width"`
+	Height   int                        `json:"height"`
+	Sizes    map[string]json.RawMessage `json:"sizes"`
+	MimeType string                     `json:"mime_type"`
+}
+
+// resolvedFieldRaw returns the raw value the last resolve answer serves under the field key.
+func resolvedFieldRaw(w *world, key string) (json.RawMessage, bool, error) {
+	if w.answer == nil {
+		return nil, false, fmt.Errorf("no address was resolved yet")
+	}
+	var answered struct {
+		Item struct {
+			Fields map[string]json.RawMessage `json:"fields"`
+		} `json:"item"`
+	}
+	if err := json.Unmarshal(w.answer.body, &answered); err != nil {
+		return nil, false, fmt.Errorf("reading the resolve answer: %w", err)
+	}
+	raw, found := answered.Item.Fields[key]
+	return raw, found, nil
+}
+
+// resolvedMediaObject returns the one media object the last answer serves under the key.
+func resolvedMediaObject(w *world, key string) (servedMediaValue, error) {
+	raw, found, err := resolvedFieldRaw(w, key)
+	if err != nil {
+		return servedMediaValue{}, err
+	}
+	if !found {
+		return servedMediaValue{}, fmt.Errorf("the answer serves no field %q", key)
+	}
+	var served servedMediaValue
+	if err := json.Unmarshal(raw, &served); err != nil {
+		return servedMediaValue{}, fmt.Errorf("the field %q serves %s, want one object: %w", key, raw, err)
+	}
+	return served, nil
+}
+
+// theServedFieldAddresses asserts the field serves one object addressing the named file.
+func theServedFieldAddresses(ctx context.Context, key, file string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	served, err := resolvedMediaObject(w, key)
+	if err != nil {
+		return err
+	}
+	if !strings.HasPrefix(served.Src, "/media/") || !strings.HasSuffix(served.Src, file) {
+		return fmt.Errorf("the field %q addresses %q, want %q under the public prefix", key, served.Src, file)
+	}
+	return nil
+}
+
+// theServedFieldCarriesTheSize asserts the served object carries the pixel size.
+func theServedFieldCarriesTheSize(ctx context.Context, key string, width, height int) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	served, err := resolvedMediaObject(w, key)
+	if err != nil {
+		return err
+	}
+	if served.Width != width || served.Height != height {
+		return fmt.Errorf("the field %q is %d by %d, want %d by %d", key, served.Width, served.Height, width, height)
+	}
+	return nil
+}
+
+// theServedFieldCarriesTheSavedWords asserts the described title, alt text and caption are served.
+func theServedFieldCarriesTheSavedWords(ctx context.Context, key string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	served, err := resolvedMediaObject(w, key)
+	if err != nil {
+		return err
+	}
+	if served.Title != savedTitle || served.AltText != savedAltText || served.Caption != savedCaption {
+		return fmt.Errorf("the field %q serves %+v, want the saved words", key, served)
+	}
+	return nil
+}
+
+// theServedFieldCarriesNoDescription asserts the librarian's note stays private.
+func theServedFieldCarriesNoDescription(ctx context.Context, key string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	raw, found, err := resolvedFieldRaw(w, key)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("the answer serves no field %q", key)
+	}
+	var loose map[string]any
+	if err := json.Unmarshal(raw, &loose); err != nil {
+		return fmt.Errorf("reading the field %q: %w", key, err)
+	}
+	if _, leaked := loose["description"]; leaked {
+		return fmt.Errorf("the field %q serves %v, want the description kept private", key, loose)
+	}
+	return nil
+}
+
+// theServedFieldListsTheAddresses asserts the field serves the named files in the given order.
+func theServedFieldListsTheAddresses(ctx context.Context, key, files string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	raw, found, err := resolvedFieldRaw(w, key)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("the answer serves no field %q", key)
+	}
+	var served []servedMediaValue
+	if err := json.Unmarshal(raw, &served); err != nil {
+		return fmt.Errorf("the field %q serves %s, want a list: %w", key, raw, err)
+	}
+	wanted := strings.Split(files, ", ")
+	if len(served) != len(wanted) {
+		return fmt.Errorf("the field %q lists %d files, want %d", key, len(served), len(wanted))
+	}
+	for i, file := range wanted {
+		if !strings.HasSuffix(served[i].Src, file) {
+			return fmt.Errorf("the field %q lists %q at %d, want %q", key, served[i].Src, i, file)
+		}
+	}
+	return nil
+}
+
+// theServedFieldsCarryNo asserts the resolve answer serves nothing under the key.
+func theServedFieldsCarryNo(ctx context.Context, key string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	raw, found, err := resolvedFieldRaw(w, key)
+	if err != nil {
+		return err
+	}
+	if found {
+		return fmt.Errorf("the answer serves %s under %q, want the field absent", raw, key)
+	}
+	return nil
+}
+
+// theServedFieldCarriesNoRenditions asserts the served object holds an empty sizes map.
+func theServedFieldCarriesNoRenditions(ctx context.Context, key string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	served, err := resolvedMediaObject(w, key)
+	if err != nil {
+		return err
+	}
+	if served.Sizes == nil || len(served.Sizes) != 0 {
+		return fmt.Errorf("the field %q serves sizes %v, want an empty map", key, served.Sizes)
+	}
+	return nil
+}
+
+// aVisitorRemembersTheValidator resolves the path and keeps the validator it answers.
+func aVisitorRemembersTheValidator(ctx context.Context, path string) error {
+	if err := aVisitorResolves(ctx, path); err != nil {
+		return err
+	}
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	held := w.answer.header.Get("ETag")
+	if held == "" {
+		return fmt.Errorf("resolving %q answered no validator", path)
+	}
+	w.rememberedETag = held
+	return nil
+}
+
+// resolvingAnswersAChangedValidator resolves the path again and compares the validators.
+func resolvingAnswersAChangedValidator(ctx context.Context, path string) error {
+	if err := aVisitorResolves(ctx, path); err != nil {
+		return err
+	}
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	held := w.answer.header.Get("ETag")
+	if held == "" || held == w.rememberedETag {
+		return fmt.Errorf("the validator answered %q twice, want it moved by the change", held)
+	}
+	return nil
+}
 
 // initializeMediaValues registers the steps of the media values feature.
 func initializeMediaValues(sc *godog.ScenarioContext) {
@@ -19,10 +315,38 @@ func initializeMediaValues(sc *godog.ScenarioContext) {
 		`^the type "([^"]*)" labeled "([^"]*)" and "([^"]*)" under "([^"]*)" serving term pages$`,
 		theTermTypeExists,
 	)
+	sc.Given(`^the media field "([^"]*)" in "([^"]*)"$`, theMediaFieldExists)
 	sc.Given(`^the many media field "([^"]*)" in "([^"]*)"$`, theManyMediaFieldExists)
 	sc.Given(`^the administrator uploads a (\d+) by (\d+) pixel JPEG named "([^"]*)"$`, uploadsAPixelJPEG)
 	sc.Given(`^the administrator uploads an animated GIF named "([^"]*)"$`, uploadsAnAnimatedGIF)
 	sc.Given(`^the administrator describes the image "([^"]*)"$`, describesTheImage)
+	sc.Given(
+		`^the administrator saves the image named "([^"]*)" into "([^"]*)" of "([^"]*)"$`,
+		savesTheImageNamed,
+	)
+	sc.Given(
+		`^the administrator saves the images named "([^"]*)" into "([^"]*)" of "([^"]*)"$`,
+		savesTheImagesNamed,
+	)
+	sc.Given(`^the administrator deletes the image named "([^"]*)"$`, deletesTheImageNamed)
+	sc.Given(`^a visitor remembers the validator of "([^"]*)"$`, aVisitorRemembersTheValidator)
 	sc.When(`^the administrator describes the image "([^"]*)"$`, describesTheImage)
 	sc.When(`^a visitor resolves "([^"]*)"$`, aVisitorResolves)
+	sc.Then(`^the served field "([^"]*)" is one object addressing "([^"]*)"$`, theServedFieldAddresses)
+	sc.Then(
+		`^the served field "([^"]*)" carries the size (\d+) by (\d+)$`,
+		theServedFieldCarriesTheSize,
+	)
+	sc.Then(
+		`^the served field "([^"]*)" carries the saved title, alt text and caption$`,
+		theServedFieldCarriesTheSavedWords,
+	)
+	sc.Then(`^the served field "([^"]*)" carries no description$`, theServedFieldCarriesNoDescription)
+	sc.Then(
+		`^the served field "([^"]*)" lists the addresses "([^"]*)" in that order$`,
+		theServedFieldListsTheAddresses,
+	)
+	sc.Then(`^the served fields carry no "([^"]*)"$`, theServedFieldsCarryNo)
+	sc.Then(`^the served field "([^"]*)" carries no renditions$`, theServedFieldCarriesNoRenditions)
+	sc.Then(`^resolving "([^"]*)" answers a changed validator$`, resolvingAnswersAChangedValidator)
 }

--- a/test/features/world_test.go
+++ b/test/features/world_test.go
@@ -123,6 +123,7 @@ type world struct {
 	client         *http.Client
 	answer         *answer
 	pending        *activation
+	rememberedETag string
 }
 
 // provisionWorld gives a scenario its own themes directory.

--- a/test/theme/src/layouts/Post.astro
+++ b/test/theme/src/layouts/Post.astro
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Blocks } from '@gophenberg/astro/components'
-import { relatedFields } from '@gophenberg/astro'
+import { mediaFields, mediaUrl, relatedFields } from '@gophenberg/astro'
 
 import type { BlockComponentMap, Post } from '@gophenberg/astro'
 
@@ -16,6 +16,7 @@ interface Props {
 
 const { post, blocks, seo } = Astro.props
 const related = relatedFields(post)
+const pictured = mediaFields(post)
 ---
 
 <Base seo={seo} title={post.title}>
@@ -23,6 +24,24 @@ const related = relatedFields(post)
 		<h1>{post.title}</h1>
 		<time datetime={post.published_at}>{post.published_at.slice(0, 10)}</time>
 		<Blocks html={post.content} components={blocks} post={post} />
+		{
+			pictured.map((field) => (
+				<ul class="gophenberg-media">
+					{field.items.map((item) => (
+						<li>
+							<img
+								src={mediaUrl(item.src)}
+								alt={item.alt_text}
+								width={item.width}
+								height={item.height}
+								loading="lazy"
+							/>
+							{item.caption && <figcaption>{item.caption}</figcaption>}
+						</li>
+					))}
+				</ul>
+			))
+		}
 		{
 			related.map((field) => (
 				<ul class="gophenberg-related">

--- a/test/theme/src/layouts/Post.astro
+++ b/test/theme/src/layouts/Post.astro
@@ -29,13 +29,17 @@ const pictured = mediaFields(post)
 				<ul class="gophenberg-media">
 					{field.items.map((item) => (
 						<li>
-							<img
-								src={mediaUrl(item.src)}
-								alt={item.alt_text}
-								width={item.width}
-								height={item.height}
-								loading="lazy"
-							/>
+							{item.mime_type.startsWith('image/') ? (
+								<img
+									src={mediaUrl(item.src)}
+									alt={item.alt_text}
+									width={item.width}
+									height={item.height}
+									loading="lazy"
+								/>
+							) : (
+								<a href={mediaUrl(item.src)}>{item.title || item.src}</a>
+							)}
 							{item.caption && <figcaption>{item.caption}</figcaption>}
 						</li>
 					))}

--- a/test/theme/src/layouts/Post.astro
+++ b/test/theme/src/layouts/Post.astro
@@ -29,18 +29,20 @@ const pictured = mediaFields(post)
 				<ul class="gophenberg-media">
 					{field.items.map((item) => (
 						<li>
-							{item.mime_type.startsWith('image/') ? (
-								<img
-									src={mediaUrl(item.src)}
-									alt={item.alt_text}
-									width={item.width}
-									height={item.height}
-									loading="lazy"
-								/>
-							) : (
-								<a href={mediaUrl(item.src)}>{item.title || item.src}</a>
-							)}
-							{item.caption && <figcaption>{item.caption}</figcaption>}
+							<figure>
+								{item.mime_type.startsWith('image/') ? (
+									<img
+										src={mediaUrl(item.src)}
+										alt={item.alt_text}
+										width={item.width}
+										height={item.height}
+										loading="lazy"
+									/>
+								) : (
+									<a href={mediaUrl(item.src)}>{item.title || item.src}</a>
+								)}
+								{item.caption && <figcaption>{item.caption}</figcaption>}
+							</figure>
 						</li>
 					))}
 				</ul>

--- a/test/theme/test/contract.test.ts
+++ b/test/theme/test/contract.test.ts
@@ -50,4 +50,9 @@ describe('what the starter shows of an item', () => {
 		expect(layout).toContain('width={item.width}')
 		expect(layout).toContain('height={item.height}')
 	})
+
+	test('links a file that is not an image rather than showing a broken picture', () => {
+		expect(layout).toContain("item.mime_type.startsWith('image/')")
+		expect(layout).toContain('<a href={mediaUrl(item.src)}')
+	})
 })

--- a/test/theme/test/contract.test.ts
+++ b/test/theme/test/contract.test.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { readFileSync } from 'node:fs'
+
 import { describe, expect, expectTypeOf, test } from 'vitest'
 
 import type { GophenbergTheme } from '@gophenberg/astro'
@@ -28,5 +30,24 @@ describe('what the starter declares to the kit', () => {
 	test('names the site and its page size', () => {
 		expect(theme.seo.siteName).toBe('Gophenberg Starter')
 		expect(theme.pagination?.perPage).toBe(2)
+	})
+})
+
+describe('what the starter shows of an item', () => {
+	const layout = readFileSync(new URL('../src/layouts/Post.astro', import.meta.url), 'utf8')
+
+	test('renders the files a media field names', () => {
+		expect(layout).toContain('mediaFields')
+		expect(layout).toContain('mediaUrl')
+	})
+
+	test('addresses each file and describes it for a reader who cannot see it', () => {
+		expect(layout).toContain('alt={item.alt_text}')
+		expect(layout).toContain('src={mediaUrl(item.src)}')
+	})
+
+	test('gives an image its size so the page does not jump while it loads', () => {
+		expect(layout).toContain('width={item.width}')
+		expect(layout).toContain('height={item.height}')
 	})
 })

--- a/test/theme/test/contract.test.ts
+++ b/test/theme/test/contract.test.ts
@@ -55,4 +55,11 @@ describe('what the starter shows of an item', () => {
 		expect(layout).toContain("item.mime_type.startsWith('image/')")
 		expect(layout).toContain('<a href={mediaUrl(item.src)}')
 	})
+
+	test('ties a caption to the file it describes', () => {
+		const captioned = layout.slice(layout.indexOf('<figure>'), layout.indexOf('</figure>'))
+
+		expect(captioned).toContain('figcaption')
+		expect(captioned).toContain('mediaUrl(item.src)')
+	})
 })


### PR DESCRIPTION
Closes #138

## What

A published item's media fields now serve the files they name. A Media field serves one object and a Gallery serves a list, each carrying the file's address, its title, alt text and caption, its pixel size, and the renditions stored for it. A theme renders an image straight from the page answer, with no second request and no login.

Resolution happens as the answer is built, so it always reflects the library as it stands. A file deleted from the library drops out of a gallery, and a field whose only file is gone is left out of the answer entirely rather than serving a number that points at nothing. Both the ordinary item answer and a term page's own item are served through the same path, so they cannot drift apart.

The theme kit gained `mediaFields`, `mediaItems` and `mediaUrl` alongside the existing relation helpers, plus the types for what a media field serves. The starter theme renders a gallery, and the guide shows the same loop.

## Why

The public API served media as bare library numbers. Every route that could turn a number into a file sits behind a login, and the public file route is addressed by path, not number, so a theme fetching a published page had no way to render what an item held. Galleries made that a blocker rather than a footnote.

Inlining follows the pattern relations already set: resolve as the answer is built, filter to what a reader may see, and cost one extra query per page rather than one per item. It also keeps the library private, since only files a published item actually references ever leave the building.

A public lookup-by-number route was considered and rejected. Library numbers are sequential, so such a route would let anyone walk every upload ever made, including files no published page references, in exchange for a lazy-loading ability no theme has asked for. It can be added later without changing what this serves.

The validator needed no new machinery. It is computed over the whole served answer, so it already moves when an inlined file's words change, and the reference page's description of it was corrected to say so.

## Testing

1. `make dev`, then sign in.
2. Open **Media** and upload two images. Describe one of them, filling in its title, alt text and caption.
3. Open **Field Groups**, press **Fields** on a group placed on Posts, and add a field named Cover picking **Media**, then a field named Gallery picking **Gallery**.
4. Open a post, choose the described image for Cover, add both images to Gallery, and publish it.
5. `curl "http://localhost:8080/api/content/v1/resolve?path=<the post slug>" | jq '.item.fields'`. Cover is one object with `src` under `/media/`, the title, alt text and caption you typed, its width and height, and a `sizes` map. Gallery is a list of two in the order you added them.
6. Confirm no `description` appears anywhere in that output, since the library note stays private.
7. Note the `ETag` from the response headers. Edit the described image's alt text in the admin, resolve again, and the `ETag` differs.
8. Delete one gallery image from the library, resolve again, and it is gone from the list while the other remains. Delete the Cover image too, resolve again, and the `cover` key is absent.
9. `curl http://localhost:8080/api/content/v1 | jq .kit` lists both theme kit versions, so themes built on either keep working.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media fields now include file URLs, metadata, dimensions, and available renditions.
  * Deleted media is omitted from single-value and gallery fields.
  * Added Astro SDK helpers and types for media fields and asset URLs.
  * Astro themes can render images, link non-image files, and display captions.
  * Added support for Astro theme kit version 0.10.0 alongside 0.9.0.
  * Media IDs require valid positive whole numbers.
  * ETags now reflect changes to served media and content.

* **Documentation**
  * Updated Content API and theme guidance for media values, renditions, URLs, and ETags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->