### PR TITLE
One rule decides what counts as a media identity

### DIFF
--- a/internal/content/values.go
+++ b/internal/content/values.go
@@ -103,7 +103,7 @@ func namedOnce(f Field, member any) any {
 	if f.Kind != FieldKindMedia {
 		return member
 	}
-	id, _ := mediaIdentity(member)
+	id, _ := MediaIdentity(member)
 	return id
 }
 
@@ -278,12 +278,12 @@ func isNumber(value any) bool {
 
 // isMediaID reports whether the value is a whole number the library can store as an identity.
 func isMediaID(value any) bool {
-	_, ok := mediaIdentity(value)
+	_, ok := MediaIdentity(value)
 	return ok
 }
 
-// mediaIdentity returns the identity the value names, and whether the library can store it.
-func mediaIdentity(value any) (int64, bool) {
+// MediaIdentity returns the identity the value names, and whether the library can store it.
+func MediaIdentity(value any) (int64, bool) {
 	switch held := value.(type) {
 	case int:
 		return int64(held), held >= 1

--- a/internal/content/values_test.go
+++ b/internal/content/values_test.go
@@ -134,6 +134,12 @@ func TestValuesShapeTheChoiceKindAndAManyMedia(t *testing.T) {
 		"a media refuses an item past the last one storable": {
 			shaped(t, content.FieldKindMedia, false, nil), float64(9223372036854775808), false,
 		},
+		"a media refuses a number that is nothing at all": {
+			shaped(t, content.FieldKindMedia, false, nil), math.NaN(), false,
+		},
+		"a media refuses a number without end": {
+			shaped(t, content.FieldKindMedia, false, nil), math.Inf(1), false,
+		},
 		"a media holds the largest item that stores": {
 			shaped(t, content.FieldKindMedia, false, nil), float64(9223372036854774784), true,
 		},

--- a/internal/server/content.go
+++ b/internal/server/content.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"math"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -347,32 +346,6 @@ func servedMediaOf(m media.Media) servedMedia {
 	}
 }
 
-// heldMediaID returns the value as a library identity, and whether it names one.
-func heldMediaID(value any) (int64, bool) {
-	switch held := value.(type) {
-	case float64:
-		return wholeMediaID(held)
-	case float32:
-		return wholeMediaID(float64(held))
-	case int64:
-		return held, held >= 1
-	case int32:
-		return int64(held), held >= 1
-	case int:
-		return int64(held), held >= 1
-	default:
-		return 0, false
-	}
-}
-
-// wholeMediaID returns the number as a library identity, and whether it names one whole file.
-func wholeMediaID(held float64) (int64, bool) {
-	if math.IsNaN(held) || held < 1 || held >= math.MaxInt64 || held != math.Trunc(held) {
-		return 0, false
-	}
-	return int64(held), true
-}
-
 // mediaIDsHeld returns every identity the values hold under the type's media fields.
 func mediaIDsHeld(t content.Type, values content.Values) []int64 {
 	var ids []int64
@@ -383,13 +356,13 @@ func mediaIDsHeld(t content.Type, values content.Values) []int64 {
 		if f.Many {
 			listed, _ := values[f.Key].([]any)
 			for _, member := range listed {
-				if id, ok := heldMediaID(member); ok {
+				if id, ok := content.MediaIdentity(member); ok {
 					ids = append(ids, id)
 				}
 			}
 			continue
 		}
-		if id, ok := heldMediaID(values[f.Key]); ok {
+		if id, ok := content.MediaIdentity(values[f.Key]); ok {
 			ids = append(ids, id)
 		}
 	}
@@ -428,7 +401,7 @@ func inlineMediaKey(f content.Field, values content.Values, byID map[int64]media
 
 // inlineMediaOne rewrites a field holding one file, deleting the key when it will not serve.
 func inlineMediaOne(key string, values content.Values, byID map[int64]media.Media) {
-	id, ok := heldMediaID(values[key])
+	id, ok := content.MediaIdentity(values[key])
 	m, found := byID[id]
 	if !ok || !found {
 		delete(values, key)
@@ -446,7 +419,7 @@ func inlineMediaList(key string, values content.Values, byID map[int64]media.Med
 	}
 	served := make([]servedMedia, 0, len(listed))
 	for _, member := range listed {
-		if id, ok := heldMediaID(member); ok {
+		if id, ok := content.MediaIdentity(member); ok {
 			if m, found := byID[id]; found {
 				served = append(served, servedMediaOf(m))
 			}

--- a/internal/server/content_media_internal_test.go
+++ b/internal/server/content_media_internal_test.go
@@ -3,69 +3,11 @@
 package server
 
 import (
-	"math"
 	"testing"
 
 	"github.com/gopherium/gophenberg/internal/content"
 	"github.com/gopherium/gophenberg/internal/media"
 )
-
-func TestHeldMediaIDReadsEveryNumberShapeAWriteAccepts(t *testing.T) {
-	t.Parallel()
-
-	for name, value := range map[string]any{
-		"a decoded number":       float64(7),
-		"a narrow decoded one":   float32(7),
-		"a written whole number": int(7),
-		"a narrow whole number":  int32(7),
-		"a wide whole number":    int64(7),
-	} {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			id, ok := heldMediaID(value)
-
-			if !ok || id != 7 {
-				t.Errorf("heldMediaID(%v) = %d, %v, want the identity read", value, id, ok)
-			}
-		})
-	}
-	if _, ok := heldMediaID("seven"); ok {
-		t.Error("heldMediaID(word) = true, want no identity in a word")
-	}
-}
-
-func TestHeldMediaIDNamesTheLastIdentityACallerWritesWhole(t *testing.T) {
-	t.Parallel()
-
-	id, ok := heldMediaID(int64(math.MaxInt64))
-
-	if !ok || id != math.MaxInt64 {
-		t.Errorf("heldMediaID(max) = %d, %v, want the identity read whole", id, ok)
-	}
-}
-
-func TestHeldMediaIDNamesNoFileFromAPartOfANumber(t *testing.T) {
-	t.Parallel()
-
-	for name, value := range map[string]any{
-		"a part of a number":                  float64(1.5),
-		"a narrow part":                       float32(1.5),
-		"nothing at all":                      math.NaN(),
-		"a number without end":                math.Inf(1),
-		"a number below one":                  float64(0),
-		"a number before it":                  float64(-3),
-		"a number past the last one storable": float64(9223372036854775808),
-	} {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			if id, ok := heldMediaID(value); ok {
-				t.Errorf("heldMediaID(%v) = %d, want no file named by it", value, id)
-			}
-		})
-	}
-}
 
 // galleryField returns one media field of the key, holding many when asked.
 func galleryField(key string, many bool) content.Field {


### PR DESCRIPTION
Closes #140

## What

The content package now exports the one converter that decides whether a value names a library file, and the server deletes its private copy and calls it. Four call sites rewired, twenty-five lines of duplicate logic and their separate float handling removed. No behavior changes.

## Why

Validation and serving must agree about what counts as a media identity. With two private copies of the rule, review on the media work kept finding them drifting apart, each fix landing in one copy while the other kept the old behavior. One shared function makes disagreement impossible rather than merely fixed.

## Testing

1. `go test ./...` stays green and coverage stays at one hundred percent.
2. The rejection cases that lived beside the deleted copy, a number that is not a number and one without end, now sit in the content package tests beside every other shape the rule judges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media identity validation for numeric values.
  * Invalid media identifiers, including `NaN` and positive infinity, are now consistently rejected.
  * Media identifiers are handled consistently across individual media values and media lists.
* **Tests**
  * Added coverage for invalid numeric media identities and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->