### PR TITLE
The editor names a number outside its limits

### DIFF
--- a/docs/src/content/docs/guides/fields.md
+++ b/docs/src/content/docs/guides/fields.md
@@ -97,9 +97,11 @@ your typing. Anything else the field will not take is refused when
 you save, drafts included, and autosave keeps it meanwhile so you
 fix the value rather than lose it. That covers a number outside
 Lowest or Highest, an address that does not read as one, and an
-answer a choice does not list. Tightening any of these leaves
-stored values alone, and is refused while the field's own Default
-falls outside.
+answer a choice does not list. The editor also names a number
+outside Lowest or Highest under its own control as you fill the
+item in, so you can mend it before saving rather than after.
+Tightening any of these leaves stored values alone, and is refused
+while the field's own Default falls outside.
 
 **Steps of** moves a Range field's slider one notch. A Range needs
 both Lowest and Highest before it draws a slider, and is a plain

--- a/frontend/src/content/FieldsPanel.tsx
+++ b/frontend/src/content/FieldsPanel.tsx
@@ -2,11 +2,17 @@
 
 import { RangeControl, Stack } from '@gophenberg/frontend-sdk'
 import { DataForm } from '@gophenberg/frontend-sdk/dataviews'
-import type { DataFormControlProps, Field } from '@gophenberg/frontend-sdk/dataviews'
-import { __ } from '@wordpress/i18n'
+import type {
+	DataFormControlProps,
+	Field,
+	FieldValidity,
+	FormValidity,
+} from '@gophenberg/frontend-sdk/dataviews'
+import { __, sprintf } from '@wordpress/i18n'
 import { useMemo } from 'react'
 import type { ComponentType } from 'react'
 
+import { errorTemplates } from '../i18n/errorTemplates'
 import { GalleryField, MediaField, galleryHeld, mediaHeld } from './MediaField'
 import { RelationPicker, targetsHeld } from './RelationPicker'
 import { pairsOf } from './types'
@@ -53,6 +59,44 @@ function fieldType(field: ContentField): string | undefined {
  */
 export function editableFields(declared: ContentField[]): ContentField[] {
 	return declared.filter((field) => fieldType(field) !== undefined)
+}
+
+/**
+ * Returns the sentence a number outside its bounds earns, or nothing when the value stands.
+ * @param field - The declared field the value sits under.
+ * @param value - The buffered value.
+ * @returns The sentence, or undefined.
+ */
+function boundBroken(field: ContentField, value: unknown): string | undefined {
+	if (field.kind !== 'number' || typeof value !== 'number') {
+		return undefined
+	}
+	const low = field.settings.min
+	if (typeof low === 'number' && value < low) {
+		return sprintf(errorTemplates().field_min, { field: field.label, limit: low } as never)
+	}
+	const high = field.settings.max
+	if (typeof high === 'number' && value > high) {
+		return sprintf(errorTemplates().field_max, { field: field.label, limit: high } as never)
+	}
+	return undefined
+}
+
+/**
+ * Returns the bound complaints the buffered values earn, keyed by field key.
+ * @param declared - The fields the type declares.
+ * @param values - The buffered values under edit.
+ * @returns The complaints DataForm shows, or nothing when every value sits inside its bounds.
+ */
+export function fieldValidity(declared: ContentField[], values: FieldValues): FormValidity {
+	const spoken: Record<string, FieldValidity> = {}
+	for (const field of declared) {
+		const message = boundBroken(field, values[field.key])
+		if (message !== undefined) {
+			spoken[field.key] = { custom: { type: 'invalid', message } }
+		}
+	}
+	return Object.keys(spoken).length > 0 ? spoken : undefined
 }
 
 /**

--- a/frontend/src/content/FieldsPanel.tsx
+++ b/frontend/src/content/FieldsPanel.tsx
@@ -282,6 +282,7 @@ export function FieldsPanel({
 	const related = useMemo(() => relationFields(declared), [declared])
 	const pictured = useMemo(() => mediaFields(declared), [declared])
 	const descriptors = useMemo(() => fieldDescriptors(rendered), [rendered])
+	const complaints = useMemo(() => fieldValidity(rendered, buffer.fields), [rendered, buffer.fields])
 	if (rendered.length === 0 && related.length === 0 && pictured.length === 0) {
 		return null
 	}
@@ -292,6 +293,7 @@ export function FieldsPanel({
 					data={buffer.fields}
 					fields={descriptors}
 					form={{ fields: rendered.map((field) => field.key) }}
+					validity={complaints}
 					onChange={(edits: FieldValues) =>
 						buffer.setFields({ ...buffer.fields, ...clearedEdits(edits) })
 					}

--- a/frontend/src/test/editor-fields.test.tsx
+++ b/frontend/src/test/editor-fields.test.tsx
@@ -124,6 +124,54 @@ test('names the ceiling under a number typed above its max', async () => {
 	)
 })
 
+test('leaves a sibling its own complaint while a number sits outside its max', async () => {
+	server.use(
+		http.get('/api/types', () =>
+			HttpResponse.json({
+				items: [
+					{
+						...TYPE_WITH_FIELDS,
+						fields: [
+							{
+								key: 'doors',
+								label: 'Doors',
+								kind: 'number',
+								many: false,
+								required: false,
+								settings: { max: 10 },
+								updated_at: STAMP,
+							},
+							{
+								key: 'color',
+								label: 'Color',
+								kind: 'text',
+								many: false,
+								required: true,
+								settings: { maxlength: 8 },
+								updated_at: STAMP,
+							},
+						],
+					},
+				],
+			}),
+		),
+	)
+	renderAt(EDITOR_PATH)
+	const doors = await screen.findByLabelText('Doors')
+	const color = screen.getByLabelText(/Color/)
+
+	await userEvent.type(doors, '50')
+	await userEvent.clear(color)
+	await userEvent.tab()
+
+	expect(
+		await screen.findByText('Doors goes no higher than 10. Lower the value and save again.'),
+	).toBeInTheDocument()
+	expect(color).toBeRequired()
+	expect(color).toHaveAttribute('maxlength', '8')
+	expect((color as HTMLInputElement).validationMessage).not.toBe('')
+})
+
 test('shows the instructions a field carries under its control', async () => {
 	declaring({ ...A_TEXT_FIELD, settings: { instructions: 'Name the colour.' } })
 	renderAt(EDITOR_PATH)

--- a/frontend/src/test/editor-fields.test.tsx
+++ b/frontend/src/test/editor-fields.test.tsx
@@ -94,6 +94,36 @@ const A_TEXT_FIELD = {
 	updated_at: STAMP,
 }
 
+test('names the ceiling under a number typed above its max', async () => {
+	declaring({
+		key: 'doors',
+		label: 'Doors',
+		kind: 'number',
+		many: false,
+		required: false,
+		settings: { max: 10 },
+	})
+	renderAt(EDITOR_PATH)
+
+	const control = await screen.findByLabelText('Doors')
+	await userEvent.type(control, '50')
+	await userEvent.tab()
+
+	expect(
+		await screen.findByText('Doors goes no higher than 10. Lower the value and save again.'),
+	).toBeInTheDocument()
+
+	await userEvent.clear(control)
+	await userEvent.type(control, '5')
+	await userEvent.tab()
+
+	await waitFor(() =>
+		expect(
+			screen.queryByText('Doors goes no higher than 10. Lower the value and save again.'),
+		).toBeNull(),
+	)
+})
+
 test('shows the instructions a field carries under its control', async () => {
 	declaring({ ...A_TEXT_FIELD, settings: { instructions: 'Name the colour.' } })
 	renderAt(EDITOR_PATH)

--- a/frontend/src/test/fields-panel.test.ts
+++ b/frontend/src/test/fields-panel.test.ts
@@ -2,7 +2,7 @@
 
 import { expect, test } from 'vitest'
 
-import { clearedEdits, editableFields, fieldDescriptors } from '../content/FieldsPanel'
+import { clearedEdits, editableFields, fieldDescriptors, fieldValidity } from '../content/FieldsPanel'
 import type { ContentField } from '../content/types'
 
 /**
@@ -200,4 +200,48 @@ test('ignores a setting whose value is the wrong shape', () => {
 	const held = fieldDescriptors([carrying('number', { min: 'low', max: true })])
 
 	expect(held[0].isValid).toEqual({ required: false })
+})
+
+test('names the floor under a number below its min', () => {
+	const spoken = fieldValidity([carrying('number', { min: 5 })], { 'a-number': 2 })
+
+	expect(spoken).toEqual({
+		'a-number': {
+			custom: {
+				type: 'invalid',
+				message: 'number goes no lower than 5. Raise the value and save again.',
+			},
+		},
+	})
+})
+
+test('names the ceiling over a number above its max', () => {
+	const spoken = fieldValidity([carrying('number', { max: 10 })], { 'a-number': 50 })
+
+	expect(spoken).toEqual({
+		'a-number': {
+			custom: {
+				type: 'invalid',
+				message: 'number goes no higher than 10. Lower the value and save again.',
+			},
+		},
+	})
+})
+
+test('holds no complaint for what the bounds allow', () => {
+	const bounded = [carrying('number', { min: 1, max: 10 })]
+
+	expect(fieldValidity(bounded, { 'a-number': 5 })).toBeUndefined()
+	expect(fieldValidity(bounded, { 'a-number': 1 })).toBeUndefined()
+	expect(fieldValidity(bounded, { 'a-number': 10 })).toBeUndefined()
+	expect(fieldValidity(bounded, {})).toBeUndefined()
+	expect(fieldValidity(bounded, { 'a-number': null })).toBeUndefined()
+	expect(fieldValidity(bounded, { 'a-number': 'five' })).toBeUndefined()
+})
+
+test('holds no complaint for an unbounded number or a bounded text', () => {
+	expect(fieldValidity([carrying('number', {})], { 'a-number': 50 })).toBeUndefined()
+	expect(
+		fieldValidity([carrying('text', { maxlength: 2 })], { 'a-text': 'far too long' }),
+	).toBeUndefined()
 })


### PR DESCRIPTION
Closes #144

## What

A number typed outside the lowest or highest value its field allows now says so beneath its own control, instead of sitting quietly until the save is turned away. The sentence it shows is the same one the save would have answered with, naming the field and the limit it passed.

## Why

Authors filling in a long item had no way to know a value would be turned away until they tried to save, and then had to hunt for which field caused it. The warning now arrives where the value was typed, while they are still looking at it.

## Testing

1. `pnpm vitest run` and `pnpm cover` stay green at one hundred percent.
2. By hand: give a number field a highest value of 10, open an item, type 50 into it and move to the next field. The sentence appears under the control. Correct it to 5 and the sentence goes.
3. The value is still kept by autosave while it stands outside the limits, and saving still turns it away.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Numeric fields now show validation messages immediately when values fall below the minimum or exceed the maximum.
  * Validation messages clear automatically when a valid value is entered.
  * Boundary values and unbounded numeric fields are handled correctly.

* **Documentation**
  * Updated the Fields guide to explain that invalid numeric values are flagged while editing, before saving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->