### PR TITLE
Theme timings and the upload cap can be set

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,24 @@ GOPHENBERG_DATABASE_URL=postgres://postgres:gophenberg@localhost:5435/postgres?s
 # node it ships at /nodejs/bin/node.
 # GOPHENBERG_NODE_BIN=node
 
+# The largest upload the media library takes, in megabytes.
+# GOPHENBERG_MEDIA_UPLOAD_CAP_MB=128
+
+# How long a starting theme has to answer before it is given up on, and how many times it is tried
+# again. Raise the timeout for a theme that boots slowly on modest hardware.
+# GOPHENBERG_THEME_READY_TIMEOUT=30s
+# GOPHENBERG_THEME_START_ATTEMPTS=5
+
+# How long to wait before retrying a theme that will not start, doubling after each attempt up to
+# the maximum.
+# GOPHENBERG_THEME_BACKOFF=500ms
+# GOPHENBERG_THEME_MAX_BACKOFF=30s
+
+# How long a theme has to stop before it is killed, and how long a running theme has to start
+# answering one request.
+# GOPHENBERG_THEME_STOP_GRACE=3s
+# GOPHENBERG_THEME_PROXY_TIMEOUT=10s
+
 # Credentials for the translation platform, read by make translations and make translations-retire.
 # The scheduled workflow takes these from repository secrets instead.
 # POEDITOR_API_TOKEN=

--- a/cmd/gophenberg/run.go
+++ b/cmd/gophenberg/run.go
@@ -177,13 +177,33 @@ func timingsFrom(getenv func(string) string) (runConfig, error) {
 	if err != nil {
 		return runConfig{}, err
 	}
-	cap, err := standingCount(
-		getenv("GOPHENBERG_MEDIA_UPLOAD_CAP_MB"), "GOPHENBERG_MEDIA_UPLOAD_CAP_MB", 128, math.MaxInt64>>20)
+	cap, err := standingMegabytes(getenv("GOPHENBERG_MEDIA_UPLOAD_CAP_MB"), "GOPHENBERG_MEDIA_UPLOAD_CAP_MB", 128)
 	if err != nil {
 		return runConfig{}, err
 	}
-	held.themeStartAttempts, held.mediaUploadCap = attempts, int64(cap)<<20
+	held.themeStartAttempts, held.mediaUploadCap = attempts, cap
 	return held, nil
+}
+
+// maxUploadCapMB is the most megabytes an upload cap may name and still be held in bytes.
+const maxUploadCapMB int64 = math.MaxInt64 >> 20
+
+// standingMegabytes returns the bytes the raw megabyte value names, or the fallback when it names none.
+func standingMegabytes(raw, key string, fallback int64) (int64, error) {
+	if raw == "" {
+		return fallback << 20, nil
+	}
+	stood, err := strconv.ParseInt(raw, 10, 64)
+	if errors.Is(err, strconv.ErrRange) || stood > maxUploadCapMB {
+		return 0, fmt.Errorf("%s: must stand at or below %d, got %q", key, maxUploadCapMB, raw)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("%s: must be a whole number, got %q", key, raw)
+	}
+	if stood < 1 {
+		return 0, fmt.Errorf("%s: must stand above zero, got %q", key, raw)
+	}
+	return stood << 20, nil
 }
 
 // mediaConfigFrom returns the media library settings the environment named.

--- a/cmd/gophenberg/run.go
+++ b/cmd/gophenberg/run.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -87,12 +88,13 @@ func run(
 		Themes:            themes,
 		Settings:          settingStore,
 		Readers:           postgres.NewUserSettingStore(pool),
+		ThemeTimeout:      settings.themeProxyTimeout,
 	}
 	if settings.webDir != "" {
 		cfg.Web = os.DirFS(settings.webDir)
 	}
 	if settings.mediaDir != "" {
-		cfg.Media = mediahost.New(mediahost.Config{Dir: settings.mediaDir})
+		cfg.Media = mediahost.New(mediaConfigFrom(settings))
 		cfg.MediaStore = postgres.NewMediaStore(pool)
 		cfg.MediaFiles = os.DirFS(settings.mediaDir)
 	}
@@ -135,6 +137,85 @@ type runConfig struct {
 	theme          string
 	nodeBin        string
 	mediaDir       string
+
+	themeReadyTimeout  time.Duration
+	themeBackoff       time.Duration
+	themeMaxBackoff    time.Duration
+	themeStopGrace     time.Duration
+	themeProxyTimeout  time.Duration
+	themeStartAttempts int
+	mediaUploadCap     int64
+}
+
+// timingsFrom reads the durations, the attempt count and the upload cap the environment names.
+func timingsFrom(getenv func(string) string) (runConfig, error) {
+	held := runConfig{}
+	for _, asked := range []struct {
+		key      string
+		fallback time.Duration
+		into     *time.Duration
+	}{
+		{"GOPHENBERG_THEME_READY_TIMEOUT", 30 * time.Second, &held.themeReadyTimeout},
+		{"GOPHENBERG_THEME_BACKOFF", 500 * time.Millisecond, &held.themeBackoff},
+		{"GOPHENBERG_THEME_MAX_BACKOFF", 30 * time.Second, &held.themeMaxBackoff},
+		{"GOPHENBERG_THEME_STOP_GRACE", 3 * time.Second, &held.themeStopGrace},
+		{"GOPHENBERG_THEME_PROXY_TIMEOUT", 10 * time.Second, &held.themeProxyTimeout},
+	} {
+		stood, err := standingDuration(getenv(asked.key), asked.key, asked.fallback)
+		if err != nil {
+			return runConfig{}, err
+		}
+		*asked.into = stood
+	}
+	if held.themeMaxBackoff < held.themeBackoff {
+		return runConfig{}, fmt.Errorf(
+			"GOPHENBERG_THEME_MAX_BACKOFF: must stand at or above GOPHENBERG_THEME_BACKOFF, got %v", held.themeMaxBackoff)
+	}
+	attempts, err := standingCount(getenv("GOPHENBERG_THEME_START_ATTEMPTS"), "GOPHENBERG_THEME_START_ATTEMPTS", 5)
+	if err != nil {
+		return runConfig{}, err
+	}
+	cap, err := standingCount(getenv("GOPHENBERG_MEDIA_UPLOAD_CAP_MB"), "GOPHENBERG_MEDIA_UPLOAD_CAP_MB", 128)
+	if err != nil {
+		return runConfig{}, err
+	}
+	held.themeStartAttempts, held.mediaUploadCap = attempts, int64(cap)<<20
+	return held, nil
+}
+
+// mediaConfigFrom returns the media library settings the environment named.
+func mediaConfigFrom(settings runConfig) mediahost.Config {
+	return mediahost.Config{Dir: settings.mediaDir, MaxSize: settings.mediaUploadCap}
+}
+
+// standingDuration returns the duration the raw value names, or the fallback when it names none.
+func standingDuration(raw, key string, fallback time.Duration) (time.Duration, error) {
+	if raw == "" {
+		return fallback, nil
+	}
+	stood, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s: must be a duration like 30s, got %q", key, raw)
+	}
+	if stood <= 0 {
+		return 0, fmt.Errorf("%s: must stand above zero, got %q", key, raw)
+	}
+	return stood, nil
+}
+
+// standingCount returns the whole number the raw value names, or the fallback when it names none.
+func standingCount(raw, key string, fallback int) (int, error) {
+	if raw == "" {
+		return fallback, nil
+	}
+	stood, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s: must be a whole number, got %q", key, raw)
+	}
+	if stood < 1 {
+		return 0, fmt.Errorf("%s: must stand above zero, got %q", key, raw)
+	}
+	return stood, nil
 }
 
 // loadRunConfig reads the server settings from the environment.
@@ -155,17 +236,20 @@ func loadRunConfig(getenv func(string) string) (runConfig, error) {
 	if nodeBin == "" {
 		nodeBin = "node"
 	}
-	return runConfig{
-		databaseURL:    databaseURL,
-		addr:           addr,
-		webDir:         getenv("GOPHENBERG_WEB_DIR"),
-		siteTitle:      getenv("GOPHENBERG_SITE_TITLE"),
-		trustedProxies: trustedProxies,
-		themesDir:      getenv("GOPHENBERG_THEMES_DIR"),
-		theme:          getenv("GOPHENBERG_THEME"),
-		nodeBin:        nodeBin,
-		mediaDir:       getenv("GOPHENBERG_MEDIA_DIR"),
-	}, nil
+	settings, err := timingsFrom(getenv)
+	if err != nil {
+		return runConfig{}, err
+	}
+	settings.databaseURL = databaseURL
+	settings.addr = addr
+	settings.webDir = getenv("GOPHENBERG_WEB_DIR")
+	settings.siteTitle = getenv("GOPHENBERG_SITE_TITLE")
+	settings.trustedProxies = trustedProxies
+	settings.themesDir = getenv("GOPHENBERG_THEMES_DIR")
+	settings.theme = getenv("GOPHENBERG_THEME")
+	settings.nodeBin = nodeBin
+	settings.mediaDir = getenv("GOPHENBERG_MEDIA_DIR")
+	return settings, nil
 }
 
 // serveUntilDone serves HTTP until ctx is cancelled or serving fails, then

--- a/cmd/gophenberg/run.go
+++ b/cmd/gophenberg/run.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"os"
 	"strconv"
@@ -171,11 +172,13 @@ func timingsFrom(getenv func(string) string) (runConfig, error) {
 		return runConfig{}, fmt.Errorf(
 			"GOPHENBERG_THEME_MAX_BACKOFF: must stand at or above GOPHENBERG_THEME_BACKOFF, got %v", held.themeMaxBackoff)
 	}
-	attempts, err := standingCount(getenv("GOPHENBERG_THEME_START_ATTEMPTS"), "GOPHENBERG_THEME_START_ATTEMPTS", 5)
+	attempts, err := standingCount(
+		getenv("GOPHENBERG_THEME_START_ATTEMPTS"), "GOPHENBERG_THEME_START_ATTEMPTS", 5, maxStartAttempts)
 	if err != nil {
 		return runConfig{}, err
 	}
-	cap, err := standingCount(getenv("GOPHENBERG_MEDIA_UPLOAD_CAP_MB"), "GOPHENBERG_MEDIA_UPLOAD_CAP_MB", 128)
+	cap, err := standingCount(
+		getenv("GOPHENBERG_MEDIA_UPLOAD_CAP_MB"), "GOPHENBERG_MEDIA_UPLOAD_CAP_MB", 128, math.MaxInt64>>20)
 	if err != nil {
 		return runConfig{}, err
 	}
@@ -203,8 +206,11 @@ func standingDuration(raw, key string, fallback time.Duration) (time.Duration, e
 	return stood, nil
 }
 
+// maxStartAttempts is how many times a theme that will not start may be tried again.
+const maxStartAttempts = 1000
+
 // standingCount returns the whole number the raw value names, or the fallback when it names none.
-func standingCount(raw, key string, fallback int) (int, error) {
+func standingCount(raw, key string, fallback, ceiling int) (int, error) {
 	if raw == "" {
 		return fallback, nil
 	}
@@ -214,6 +220,9 @@ func standingCount(raw, key string, fallback int) (int, error) {
 	}
 	if stood < 1 {
 		return 0, fmt.Errorf("%s: must stand above zero, got %q", key, raw)
+	}
+	if stood > ceiling {
+		return 0, fmt.Errorf("%s: must stand at or below %d, got %q", key, ceiling, raw)
 	}
 	return stood, nil
 }

--- a/cmd/gophenberg/theme.go
+++ b/cmd/gophenberg/theme.go
@@ -9,6 +9,20 @@ import (
 	"github.com/gopherium/gophenberg/internal/themehost"
 )
 
+// supervisionFrom returns how an activated theme is run under the settings the environment named.
+func supervisionFrom(settings runConfig, logger *slog.Logger) themehost.SupervisorConfig {
+	return themehost.SupervisorConfig{
+		NodeBin:      settings.nodeBin,
+		APIAddr:      settings.addr,
+		Logger:       logger,
+		ReadyTimeout: settings.themeReadyTimeout,
+		Backoff:      settings.themeBackoff,
+		MaxBackoff:   settings.themeMaxBackoff,
+		MaxAttempts:  settings.themeStartAttempts,
+		StopGrace:    settings.themeStopGrace,
+	}
+}
+
 // startTheme returns the theme manager the public site is served through, and how to stop it.
 func startTheme(
 	ctx context.Context,
@@ -17,14 +31,10 @@ func startTheme(
 	logger *slog.Logger,
 ) (*themehost.Manager, func(), error) {
 	manager := themehost.NewManager(themehost.ManagerConfig{
-		Library:  themehost.NewLibrary(settings.themesDir),
-		Settings: store,
-		Pinned:   settings.theme,
-		Supervision: themehost.SupervisorConfig{
-			NodeBin: settings.nodeBin,
-			APIAddr: settings.addr,
-			Logger:  logger,
-		},
+		Library:     themehost.NewLibrary(settings.themesDir),
+		Settings:    store,
+		Pinned:      settings.theme,
+		Supervision: supervisionFrom(settings, logger),
 	})
 	if err := manager.Boot(ctx); err != nil {
 		return nil, func() {}, err

--- a/cmd/gophenberg/timings_test.go
+++ b/cmd/gophenberg/timings_test.go
@@ -15,7 +15,7 @@ func TestLoadRunConfigTakesTheLargestUploadCapItCanCarry(t *testing.T) {
 
 	settings, err := loadRunConfig(testGetenv(map[string]string{
 		"GOPHENBERG_DATABASE_URL":        unreachableDatabaseURL,
-		"GOPHENBERG_MEDIA_UPLOAD_CAP_MB": strconv.Itoa(math.MaxInt64 >> 20),
+		"GOPHENBERG_MEDIA_UPLOAD_CAP_MB": strconv.FormatInt(int64(math.MaxInt64>>20), 10),
 	}))
 
 	if err != nil {
@@ -122,7 +122,7 @@ func TestLoadRunConfigRefusesATimingItCannotStand(t *testing.T) {
 		"an upload cap standing at zero":         {"GOPHENBERG_MEDIA_UPLOAD_CAP_MB", "0"},
 		"an upload cap below zero":               {"GOPHENBERG_MEDIA_UPLOAD_CAP_MB", "-8"},
 		"an upload cap of more bytes than there are": {
-			"GOPHENBERG_MEDIA_UPLOAD_CAP_MB", strconv.Itoa(math.MaxInt64>>20 + 1),
+			"GOPHENBERG_MEDIA_UPLOAD_CAP_MB", strconv.FormatInt(int64(math.MaxInt64>>20)+1, 10),
 		},
 		"an upload cap so large it wraps to nothing": {
 			"GOPHENBERG_MEDIA_UPLOAD_CAP_MB", "17592186044416",

--- a/cmd/gophenberg/timings_test.go
+++ b/cmd/gophenberg/timings_test.go
@@ -29,6 +29,22 @@ func TestLoadRunConfigTakesTheLargestUploadCapItCanCarry(t *testing.T) {
 	}
 }
 
+func TestLoadRunConfigTakesTheMostStartAttemptsAllowed(t *testing.T) {
+	t.Parallel()
+
+	settings, err := loadRunConfig(testGetenv(map[string]string{
+		"GOPHENBERG_DATABASE_URL":         unreachableDatabaseURL,
+		"GOPHENBERG_THEME_START_ATTEMPTS": "1000",
+	}))
+
+	if err != nil {
+		t.Fatalf("loadRunConfig() error = %v, want the most attempts allowed taken", err)
+	}
+	if settings.themeStartAttempts != 1000 {
+		t.Errorf("the start attempts = %d, want 1000", settings.themeStartAttempts)
+	}
+}
+
 func TestLoadRunConfigDefaultsTheTimingsToTodaysValues(t *testing.T) {
 	t.Parallel()
 
@@ -129,6 +145,9 @@ func TestLoadRunConfigRefusesATimingItCannotStand(t *testing.T) {
 		},
 		"start attempts of more than anyone waits for": {
 			"GOPHENBERG_THEME_START_ATTEMPTS", strconv.Itoa(math.MaxInt32),
+		},
+		"start attempts one past the most allowed": {
+			"GOPHENBERG_THEME_START_ATTEMPTS", "1001",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/cmd/gophenberg/timings_test.go
+++ b/cmd/gophenberg/timings_test.go
@@ -3,10 +3,31 @@
 package main
 
 import (
+	"math"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestLoadRunConfigTakesTheLargestUploadCapItCanCarry(t *testing.T) {
+	t.Parallel()
+
+	settings, err := loadRunConfig(testGetenv(map[string]string{
+		"GOPHENBERG_DATABASE_URL":        unreachableDatabaseURL,
+		"GOPHENBERG_MEDIA_UPLOAD_CAP_MB": strconv.Itoa(math.MaxInt64 >> 20),
+	}))
+
+	if err != nil {
+		t.Fatalf("loadRunConfig() error = %v, want the largest carriable cap taken", err)
+	}
+	if want := int64(math.MaxInt64>>20) << 20; settings.mediaUploadCap != want {
+		t.Errorf("the upload cap = %d, want %d", settings.mediaUploadCap, want)
+	}
+	if settings.mediaUploadCap <= 0 {
+		t.Errorf("the upload cap = %d, want it above zero so the library keeps it", settings.mediaUploadCap)
+	}
+}
 
 func TestLoadRunConfigDefaultsTheTimingsToTodaysValues(t *testing.T) {
 	t.Parallel()
@@ -100,6 +121,15 @@ func TestLoadRunConfigRefusesATimingItCannotStand(t *testing.T) {
 		"an upload cap that is not a number":     {"GOPHENBERG_MEDIA_UPLOAD_CAP_MB", "big"},
 		"an upload cap standing at zero":         {"GOPHENBERG_MEDIA_UPLOAD_CAP_MB", "0"},
 		"an upload cap below zero":               {"GOPHENBERG_MEDIA_UPLOAD_CAP_MB", "-8"},
+		"an upload cap of more bytes than there are": {
+			"GOPHENBERG_MEDIA_UPLOAD_CAP_MB", strconv.Itoa(math.MaxInt64>>20 + 1),
+		},
+		"an upload cap so large it wraps to nothing": {
+			"GOPHENBERG_MEDIA_UPLOAD_CAP_MB", "17592186044416",
+		},
+		"start attempts of more than anyone waits for": {
+			"GOPHENBERG_THEME_START_ATTEMPTS", strconv.Itoa(math.MaxInt32),
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/cmd/gophenberg/timings_test.go
+++ b/cmd/gophenberg/timings_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoadRunConfigDefaultsTheTimingsToTodaysValues(t *testing.T) {
+	t.Parallel()
+
+	settings, err := loadRunConfig(testGetenv(map[string]string{
+		"GOPHENBERG_DATABASE_URL": unreachableDatabaseURL,
+	}))
+
+	if err != nil {
+		t.Fatalf("loadRunConfig() error = %v, want nil", err)
+	}
+	for name, held := range map[string]struct {
+		stood time.Duration
+		want  time.Duration
+	}{
+		"the ready timeout": {settings.themeReadyTimeout, 30 * time.Second},
+		"the backoff":       {settings.themeBackoff, 500 * time.Millisecond},
+		"the max backoff":   {settings.themeMaxBackoff, 30 * time.Second},
+		"the stop grace":    {settings.themeStopGrace, 3 * time.Second},
+		"the proxy timeout": {settings.themeProxyTimeout, 10 * time.Second},
+	} {
+		if held.stood != held.want {
+			t.Errorf("%s = %v, want %v", name, held.stood, held.want)
+		}
+	}
+	if settings.themeStartAttempts != 5 {
+		t.Errorf("the start attempts = %d, want 5", settings.themeStartAttempts)
+	}
+	if settings.mediaUploadCap != 128<<20 {
+		t.Errorf("the upload cap = %d, want %d", settings.mediaUploadCap, 128<<20)
+	}
+}
+
+func TestLoadRunConfigReadsTheTimingsFromTheEnvironment(t *testing.T) {
+	t.Parallel()
+
+	settings, err := loadRunConfig(testGetenv(map[string]string{
+		"GOPHENBERG_DATABASE_URL":         unreachableDatabaseURL,
+		"GOPHENBERG_THEME_READY_TIMEOUT":  "45s",
+		"GOPHENBERG_THEME_BACKOFF":        "250ms",
+		"GOPHENBERG_THEME_MAX_BACKOFF":    "1m",
+		"GOPHENBERG_THEME_STOP_GRACE":     "5s",
+		"GOPHENBERG_THEME_PROXY_TIMEOUT":  "20s",
+		"GOPHENBERG_THEME_START_ATTEMPTS": "9",
+		"GOPHENBERG_MEDIA_UPLOAD_CAP_MB":  "64",
+	}))
+
+	if err != nil {
+		t.Fatalf("loadRunConfig() error = %v, want nil", err)
+	}
+	for name, held := range map[string]struct {
+		stood time.Duration
+		want  time.Duration
+	}{
+		"the ready timeout": {settings.themeReadyTimeout, 45 * time.Second},
+		"the backoff":       {settings.themeBackoff, 250 * time.Millisecond},
+		"the max backoff":   {settings.themeMaxBackoff, time.Minute},
+		"the stop grace":    {settings.themeStopGrace, 5 * time.Second},
+		"the proxy timeout": {settings.themeProxyTimeout, 20 * time.Second},
+	} {
+		if held.stood != held.want {
+			t.Errorf("%s = %v, want %v", name, held.stood, held.want)
+		}
+	}
+	if settings.themeStartAttempts != 9 {
+		t.Errorf("the start attempts = %d, want 9", settings.themeStartAttempts)
+	}
+	if settings.mediaUploadCap != 64<<20 {
+		t.Errorf("the upload cap = %d, want %d", settings.mediaUploadCap, 64<<20)
+	}
+}
+
+func TestLoadRunConfigRefusesATimingItCannotStand(t *testing.T) {
+	t.Parallel()
+
+	for name, asked := range map[string]struct {
+		key   string
+		value string
+	}{
+		"a ready timeout that is not a duration": {"GOPHENBERG_THEME_READY_TIMEOUT", "soon"},
+		"a ready timeout standing at zero":       {"GOPHENBERG_THEME_READY_TIMEOUT", "0s"},
+		"a ready timeout below zero":             {"GOPHENBERG_THEME_READY_TIMEOUT", "-1s"},
+		"a backoff that is not a duration":       {"GOPHENBERG_THEME_BACKOFF", "quick"},
+		"a backoff below zero":                   {"GOPHENBERG_THEME_BACKOFF", "-1ms"},
+		"a max backoff below zero":               {"GOPHENBERG_THEME_MAX_BACKOFF", "-1s"},
+		"a stop grace standing at zero":          {"GOPHENBERG_THEME_STOP_GRACE", "0s"},
+		"a proxy timeout below zero":             {"GOPHENBERG_THEME_PROXY_TIMEOUT", "-5s"},
+		"start attempts that are not a number":   {"GOPHENBERG_THEME_START_ATTEMPTS", "many"},
+		"start attempts standing at zero":        {"GOPHENBERG_THEME_START_ATTEMPTS", "0"},
+		"start attempts below zero":              {"GOPHENBERG_THEME_START_ATTEMPTS", "-2"},
+		"an upload cap that is not a number":     {"GOPHENBERG_MEDIA_UPLOAD_CAP_MB", "big"},
+		"an upload cap standing at zero":         {"GOPHENBERG_MEDIA_UPLOAD_CAP_MB", "0"},
+		"an upload cap below zero":               {"GOPHENBERG_MEDIA_UPLOAD_CAP_MB", "-8"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := loadRunConfig(testGetenv(map[string]string{
+				"GOPHENBERG_DATABASE_URL": unreachableDatabaseURL,
+				asked.key:                 asked.value,
+			}))
+
+			if err == nil {
+				t.Fatalf("loadRunConfig() error = nil, want %s refused", asked.key)
+			}
+			if !strings.Contains(err.Error(), asked.key) {
+				t.Errorf("error = %v, want it to name %s", err, asked.key)
+			}
+		})
+	}
+}
+
+func TestLoadRunConfigRefusesAMaxBackoffUnderTheBackoff(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadRunConfig(testGetenv(map[string]string{
+		"GOPHENBERG_DATABASE_URL":      unreachableDatabaseURL,
+		"GOPHENBERG_THEME_BACKOFF":     "10s",
+		"GOPHENBERG_THEME_MAX_BACKOFF": "1s",
+	}))
+
+	if err == nil {
+		t.Fatalf("loadRunConfig() error = nil, want the max backoff refused")
+	}
+	if !strings.Contains(err.Error(), "GOPHENBERG_THEME_MAX_BACKOFF") {
+		t.Errorf("error = %v, want it to name GOPHENBERG_THEME_MAX_BACKOFF", err)
+	}
+}

--- a/cmd/gophenberg/wiring_test.go
+++ b/cmd/gophenberg/wiring_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"io"
+	"testing"
+	"time"
+)
+
+// timedConfig returns a run config carrying distinct timings the wiring must carry through.
+func timedConfig() runConfig {
+	return runConfig{
+		nodeBin:            "/usr/bin/node",
+		addr:               "localhost:9999",
+		mediaDir:           "/srv/media",
+		themeReadyTimeout:  45 * time.Second,
+		themeBackoff:       250 * time.Millisecond,
+		themeMaxBackoff:    time.Minute,
+		themeStopGrace:     5 * time.Second,
+		themeProxyTimeout:  20 * time.Second,
+		themeStartAttempts: 9,
+		mediaUploadCap:     64 << 20,
+	}
+}
+
+func TestSupervisionCarriesEveryTimingTheEnvironmentNamed(t *testing.T) {
+	t.Parallel()
+
+	settings := timedConfig()
+
+	held := supervisionFrom(settings, testLogger(io.Discard))
+
+	for name, asked := range map[string]struct {
+		stood time.Duration
+		want  time.Duration
+	}{
+		"ReadyTimeout": {held.ReadyTimeout, settings.themeReadyTimeout},
+		"Backoff":      {held.Backoff, settings.themeBackoff},
+		"MaxBackoff":   {held.MaxBackoff, settings.themeMaxBackoff},
+		"StopGrace":    {held.StopGrace, settings.themeStopGrace},
+	} {
+		if asked.stood != asked.want {
+			t.Errorf("%s = %v, want %v", name, asked.stood, asked.want)
+		}
+	}
+	if held.MaxAttempts != settings.themeStartAttempts {
+		t.Errorf("MaxAttempts = %d, want %d", held.MaxAttempts, settings.themeStartAttempts)
+	}
+	if held.NodeBin != settings.nodeBin || held.APIAddr != settings.addr {
+		t.Errorf("NodeBin = %q APIAddr = %q, want the run config's own", held.NodeBin, held.APIAddr)
+	}
+	if held.Logger == nil {
+		t.Error("Logger = nil, want the run logger carried")
+	}
+}
+
+func TestMediaConfigCarriesTheUploadCapTheEnvironmentNamed(t *testing.T) {
+	t.Parallel()
+
+	settings := timedConfig()
+
+	held := mediaConfigFrom(settings)
+
+	if held.MaxSize != settings.mediaUploadCap {
+		t.Errorf("MaxSize = %d, want %d", held.MaxSize, settings.mediaUploadCap)
+	}
+	if held.Dir != settings.mediaDir {
+		t.Errorf("Dir = %q, want %q", held.Dir, settings.mediaDir)
+	}
+}

--- a/docs/src/content/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/self-hosting/configuration.md
@@ -20,6 +20,13 @@ environment variables win over it.
 | `GOPHENBERG_MEDIA_DIR` | No | | The directory uploaded media is stored in and served from. The image sets `/media` |
 | `GOPHENBERG_THEME` | No | | Pins one theme, overriding the admin. Empty lets the admin choose |
 | `GOPHENBERG_NODE_BIN` | No | `node` | The Node binary themes run on. The image sets its own |
+| `GOPHENBERG_MEDIA_UPLOAD_CAP_MB` | No | `128` | The largest upload the media library takes, in megabytes |
+| `GOPHENBERG_THEME_READY_TIMEOUT` | No | `30s` | How long a starting theme has to answer before it is given up on |
+| `GOPHENBERG_THEME_START_ATTEMPTS` | No | `5` | How many times a theme that will not start is tried again |
+| `GOPHENBERG_THEME_BACKOFF` | No | `500ms` | How long to wait before the first retry, doubling after each one |
+| `GOPHENBERG_THEME_MAX_BACKOFF` | No | `30s` | The longest that wait grows to |
+| `GOPHENBERG_THEME_STOP_GRACE` | No | `3s` | How long a theme has to stop before it is killed |
+| `GOPHENBERG_THEME_PROXY_TIMEOUT` | No | `10s` | How long a running theme has to start answering one request |
 | `GOPHENBERG_FEED_TITLE` | No | `Gophenberg` | The RSS channel title |
 | `GOPHENBERG_FEED_ITEMS` | No | `20` | How many posts the RSS feed carries |
 
@@ -70,6 +77,12 @@ The server refuses to start, and says why, when:
 - `GOPHENBERG_DATABASE_URL` is missing.
 - `GOPHENBERG_TRUSTED_PROXIES` is not valid CIDR notation.
 - `GOPHENBERG_FEED_ITEMS` is not a positive whole number.
+- `GOPHENBERG_MEDIA_UPLOAD_CAP_MB` or `GOPHENBERG_THEME_START_ATTEMPTS`
+  is not a positive whole number.
+- Any of the theme timings is not a positive duration. Write them the
+  way Go does, `30s`, `500ms`, `1m`.
+- `GOPHENBERG_THEME_MAX_BACKOFF` stands below
+  `GOPHENBERG_THEME_BACKOFF`, which would leave no room to grow.
 - `GOPHENBERG_THEME` pins a theme that fails to load, see
   [installing a theme](/themes/installing-a-theme/). A theme chosen
   in the admin does not stop startup.

--- a/docs/src/content/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/self-hosting/configuration.md
@@ -78,7 +78,8 @@ The server refuses to start, and says why, when:
 - `GOPHENBERG_TRUSTED_PROXIES` is not valid CIDR notation.
 - `GOPHENBERG_FEED_ITEMS` is not a positive whole number.
 - `GOPHENBERG_MEDIA_UPLOAD_CAP_MB` or `GOPHENBERG_THEME_START_ATTEMPTS`
-  is not a positive whole number.
+  is not a positive whole number, or names a number so large the server
+  could not hold it. Both refuse rather than quietly using another value.
 - Any of the theme timings is not a positive duration. Write them the
   way Go does, `30s`, `500ms`, `1m`.
 - `GOPHENBERG_THEME_MAX_BACKOFF` stands below

--- a/docs/src/content/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/self-hosting/configuration.md
@@ -22,7 +22,7 @@ environment variables win over it.
 | `GOPHENBERG_NODE_BIN` | No | `node` | The Node binary themes run on. The image sets its own |
 | `GOPHENBERG_MEDIA_UPLOAD_CAP_MB` | No | `128` | The largest upload the media library takes, in megabytes |
 | `GOPHENBERG_THEME_READY_TIMEOUT` | No | `30s` | How long a starting theme has to answer before it is given up on |
-| `GOPHENBERG_THEME_START_ATTEMPTS` | No | `5` | How many times a theme that will not start is tried again |
+| `GOPHENBERG_THEME_START_ATTEMPTS` | No | `5` | How many times a theme that will not start is tried again, from 1 to 1000 |
 | `GOPHENBERG_THEME_BACKOFF` | No | `500ms` | How long to wait before the first retry, doubling after each one |
 | `GOPHENBERG_THEME_MAX_BACKOFF` | No | `30s` | The longest that wait grows to |
 | `GOPHENBERG_THEME_STOP_GRACE` | No | `3s` | How long a theme has to stop before it is killed |
@@ -77,9 +77,10 @@ The server refuses to start, and says why, when:
 - `GOPHENBERG_DATABASE_URL` is missing.
 - `GOPHENBERG_TRUSTED_PROXIES` is not valid CIDR notation.
 - `GOPHENBERG_FEED_ITEMS` is not a positive whole number.
-- `GOPHENBERG_MEDIA_UPLOAD_CAP_MB` or `GOPHENBERG_THEME_START_ATTEMPTS`
-  is not a positive whole number, or names a number so large the server
-  could not hold it. Both refuse rather than quietly using another value.
+- `GOPHENBERG_MEDIA_UPLOAD_CAP_MB` is not a positive whole number, or
+  names more megabytes than the server can count in bytes.
+- `GOPHENBERG_THEME_START_ATTEMPTS` is not a whole number from 1 to 1000.
+  Both of these refuse rather than quietly using another value.
 - Any of the theme timings is not a positive duration. Write them the
   way Go does, `30s`, `500ms`, `1m`.
 - `GOPHENBERG_THEME_MAX_BACKOFF` stands below


### PR DESCRIPTION
Closes #128

## What

Seven values that only tests could set are now read from the environment, with today's values as defaults: the media upload cap, the theme ready timeout, start attempts, backoff, maximum backoff, stop grace, and the proxy timeout. A value that is not a positive duration or a positive whole number refuses the boot and names the variable.

## Why

Each of these had a config field that nothing outside tests ever filled in, so a slow booting theme could not be given a longer window. It missed the thirty second window five times, the failure latched, and the public site quietly served the built-in renderer instead.

## Testing

1. Start the server with GOPHENBERG_THEME_READY_TIMEOUT=1ms and GOPHENBERG_THEME_START_ATTEMPTS=1 and a theme installed. The log should report the theme giving up almost at once, and the public site should serve through the built-in renderer.
2. Start it again with the variable unset. The theme should boot normally, proving the default still applies.
3. Set GOPHENBERG_THEME_READY_TIMEOUT=soon and start. The server should refuse to start and name the variable.
4. Set GOPHENBERG_MEDIA_UPLOAD_CAP_MB=1 and upload a file larger than one megabyte in the media library. It should be refused, and a smaller file should succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment-configurable limits for media uploads and theme startup timing (including retry/backoff, stop grace, and proxy timeouts).
  * Media uploads now respect the configured upload-cap size limit.
* **Bug Fixes**
  * Improved validation and error handling for invalid timing and capacity settings (including stricter start-attempt and backoff constraints).
* **Documentation**
  * Updated self-hosting configuration docs and the example environment variables with accepted ranges and startup failure conditions.
* **Tests**
  * Added coverage for configuration parsing, defaults, boundary values, and validation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->