### PR TITLE
Themes built on the current kit are served again

### DIFF
--- a/internal/server/content_test.go
+++ b/internal/server/content_test.go
@@ -72,7 +72,7 @@ func TestContentAPIAnswersTheHandshakeWithoutASession(t *testing.T) {
 	if !strings.Contains(body, `"api":0`) {
 		t.Errorf("body = %q, want the api generation", body)
 	}
-	if !strings.Contains(body, `"kit":["0.9.0","0.10.0"]`) {
+	if !strings.Contains(body, `"kit":["0.9.0","0.10.0","0.11.0"]`) {
 		t.Errorf("body = %q, want the kit versions served", body)
 	}
 	if !strings.Contains(body, `"gophenberg"`) {
@@ -341,7 +341,7 @@ func TestContentAPIAdvertisesTheTypesItServes(t *testing.T) {
 	if handshake.API != 0 {
 		t.Errorf("api = %d, want 0", handshake.API)
 	}
-	if !slices.Equal(handshake.Kit, []string{"0.9.0", "0.10.0"}) {
+	if !slices.Equal(handshake.Kit, []string{"0.9.0", "0.10.0", "0.11.0"}) {
 		t.Errorf("kit = %v, want the kit versions this release serves", handshake.Kit)
 	}
 	if len(handshake.Types) != 1 {

--- a/internal/themehost/kit.go
+++ b/internal/themehost/kit.go
@@ -9,7 +9,7 @@ import (
 )
 
 // servedKits names the theme kit versions this release serves, oldest first.
-var servedKits = []string{"0.9.0", "0.10.0"}
+var servedKits = []string{"0.9.0", "0.10.0", "0.11.0"}
 
 // ServedKits returns the theme kit versions this release serves.
 func ServedKits() []string {

--- a/internal/themehost/kit_test.go
+++ b/internal/themehost/kit_test.go
@@ -17,10 +17,10 @@ func TestServedKitsNamesWhatThisReleaseServes(t *testing.T) {
 
 	served := themehost.ServedKits()
 
-	if !slices.Equal(served, []string{"0.9.0", "0.10.0"}) {
+	if !slices.Equal(served, []string{"0.9.0", "0.10.0", "0.11.0"}) {
 		t.Errorf("ServedKits() = %v, want the kit versions this release serves", served)
 	}
-	if themehost.NewestKit() != "0.10.0" {
+	if themehost.NewestKit() != "0.11.0" {
 		t.Errorf("NewestKit() = %q, want the newest of them", themehost.NewestKit())
 	}
 }
@@ -28,7 +28,7 @@ func TestServedKitsNamesWhatThisReleaseServes(t *testing.T) {
 func TestAThemeOnEitherServedKitIsAccepted(t *testing.T) {
 	t.Parallel()
 
-	for _, declared := range []string{"0.9.0", "0.10.0"} {
+	for _, declared := range []string{"0.9.0", "0.10.0", "0.11.0"} {
 		if !themehost.ServesKit(declared) {
 			t.Errorf("ServesKit(%q) = false, want a theme on a served kit accepted", declared)
 		}
@@ -45,7 +45,7 @@ func TestServedKitsCannotBeChangedByACaller(t *testing.T) {
 
 	themehost.ServedKits()[0] = "9.9.9"
 
-	if themehost.NewestKit() != "0.10.0" {
+	if themehost.NewestKit() != "0.11.0" {
 		t.Errorf("NewestKit() = %q after a caller wrote to the returned slice", themehost.NewestKit())
 	}
 }


### PR DESCRIPTION
## What

The server now serves themes built on theme kit 0.11.0, alongside 0.9.0 and 0.10.0.

## Why

Publishing kit 0.11.0 bumped the version the starter theme builds against, but the server still listed only 0.9.0 and 0.10.0 as versions it serves. It refused the theme, activation failed, and the end to end suite stopped on its first step. Main has been red since that release.

## Testing

1. Run make e2e. All 65 tests should pass, including the setup step that activates the starter theme.
2. Check test/theme/dist/theme.json after a theme build. It should say kit 0.11.0, the version the server now accepts.