### PR TITLE
Find content by the values it holds

### DIFF
--- a/docs/src/content/docs/extending/declare-content.md
+++ b/docs/src/content/docs/extending/declare-content.md
@@ -39,8 +39,9 @@ func (p *Plugin) DeclareTypes(ctx context.Context, types sdk.TypeRegistrar) erro
 
 `Conditions` says when a field shows, reading the fields standing
 beside it. Declare them in any order you like, the host writes the
-fields first and their conditions afterwards. `Listed: true` marks a
-field for the content list, which nothing reads yet.
+fields first and their conditions afterwards. `Listed: true` gives the
+field a column in the content list, and a filter above it when the
+field is a switch or a choice.
 
 Keys follow the same shape everywhere in Gophenberg. Start with a
 lowercase letter, then lowercase letters, numbers and hyphens.

--- a/docs/src/content/docs/guides/fields.md
+++ b/docs/src/content/docs/guides/fields.md
@@ -110,6 +110,12 @@ falls outside.
 both Lowest and Highest before it draws a slider, and is a plain
 number box without them, where Steps of reaches nothing.
 
+**In list** puts the field in the content list as a column of its
+own. Press it on a text, number, switch, date or choice field at the
+top of a group. A switch or a choice field also gets a filter above
+the table, so you can narrow the list to the items holding one value.
+See [the content list](/guides/posts/).
+
 ## Fields inside fields
 
 A **Section** bundles fields under one name. An Author section might
@@ -178,8 +184,12 @@ itself.
 
 What a hidden field already holds stays where it is. Turn the switch
 back on and the value is still there. While the field is hidden its
-value is not required to publish, it never reaches visitors, and the
-editor stops sending it.
+value is not required to publish, and it never reaches visitors.
+
+A field inside a section or a repeater row keeps its value the same
+way, with one difference worth knowing. A row is saved whole, so the
+editor keeps sending what a hidden field in that row holds. Nothing
+is lost when you delete the row above it or drag it somewhere else.
 
 Removing a field another field's rules read is refused, and so is
 moving it to another group. Change those rules first.

--- a/docs/src/content/docs/guides/posts.md
+++ b/docs/src/content/docs/guides/posts.md
@@ -16,6 +16,12 @@ Title or Date to sort by it. A post's title links to its editor,
 unpublished posts carry a status badge, and an untitled post shows
 `(no title)`.
 
+A field the type marks **In list** gets a column of its own beside
+these, showing what each post holds under it. A switch reads Yes or
+No, a date reads in your language, and a choice reads its label
+rather than its stored value. These columns do not sort. Hide any of
+them from **View options**.
+
 The date cell reads `Published <date>` once a post has ever been
 published, and `Last Modified <date>` before that. A post you
 returned to draft keeps its publication date, so its badge and its
@@ -31,6 +37,12 @@ Private filter appears only when a private post exists.
 The search box waits for you to stop typing, then matches titles
 and post content, so a result can be matching something in its
 body.
+
+A switch or a choice field marked In list also gets a filter above
+the table. Pick a value and the list narrows to the posts holding
+it. Pick values on two fields and a post has to hold both. The
+status counts stay as they are, counting every post of that status
+rather than only the narrowed ones.
 
 ## Creating a post
 

--- a/docs/src/content/docs/reference/content-api.md
+++ b/docs/src/content/docs/reference/content-api.md
@@ -124,8 +124,12 @@ published serves an empty page, not an error.
 Name a field and a value to list only the items holding it.
 
 ```sh
-curl "https://example.com/api/content/v1/items?type=post&field[on-sale]=true&field[colour]=red"
+curl --globoff "https://example.com/api/content/v1/items?type=post&field[on-sale]=true&field[colour]=red"
 ```
+
+`--globoff` tells curl the square brackets are part of the address
+rather than a range to expand. A browser, a script and every other
+client need nothing special.
 
 Name several and an item has to hold all of them. Five kinds can be
 named this way: text, number, boolean, date and choice. A media or

--- a/docs/src/content/docs/reference/content-api.md
+++ b/docs/src/content/docs/reference/content-api.md
@@ -89,6 +89,7 @@ curl "https://example.com/api/content/v1/items?type=post&page=1&per_page=20"
 | `type` | the default type | The content type to list |
 | `page` | `1` | Which page |
 | `per_page` | the size the site chose | Items per page, capped at 100 |
+| `field[<key>]` | nothing | Only items holding this value under the field |
 
 ```json
 {
@@ -117,6 +118,38 @@ a `per_page` above 100 quietly serves 100. A page or `per_page`
 below 1, or not a whole number, answers
 `400 {"error":"invalid list parameters"}`. A type with nothing
 published serves an empty page, not an error.
+
+### Narrowing by a field
+
+Name a field and a value to list only the items holding it.
+
+```sh
+curl "https://example.com/api/content/v1/items?type=post&field[on-sale]=true&field[colour]=red"
+```
+
+Name several and an item has to hold all of them. Five kinds can be
+named this way: text, number, boolean, date and choice. A media or
+relation field cannot, and neither can a field standing inside a
+section or a repeater.
+
+The value is read as the kind the field declares. A number is written
+plainly, `10` or `-2.5`. A boolean is the word `true` or `false`. A
+date is `YYYY-MM-DD`. Text and a choice are matched whole, so `red`
+finds an item holding exactly `red`, not one holding `dark red`. A
+field holding several choices matches when the value is one of them.
+
+Four things answer `400 {"error":"invalid list parameters"}`: a field
+the type does not declare, a field of a kind that cannot be named, a
+value the kind cannot read, and the same field named twice.
+
+Two behaviours are worth knowing. A field the item never held does
+not match, so asking for `field[on-sale]=false` skips items saved
+before that field existed rather than treating them as false. And a
+value a field's own rules currently hide is still stored, so it still
+matches, even though the item's answer does not carry it.
+
+Only this listing reads the parameter. Term pages and archives ignore
+it, as they ignore any parameter they do not read.
 
 ## Resolving an address
 

--- a/frontend/src/content/GroupFieldsDialog.tsx
+++ b/frontend/src/content/GroupFieldsDialog.tsx
@@ -704,7 +704,7 @@ const LISTABLE = ['text', 'number', 'boolean', 'date', 'choice']
 /**
  * Renders the control flipping whether a field stands as a column on the admin list.
  * @param props - The group, the field, and what to report.
- * @returns The control element, or nothing for a kind the list cannot show.
+ * @returns The control element, or nothing where the list never reaches.
  */
 function ListField(props: Inside) {
 	const listed = props.field.settings.listed === true
@@ -724,7 +724,7 @@ function ListField(props: Inside) {
 		},
 		onError: props.onRefused,
 	})
-	if (!LISTABLE.includes(props.field.kind)) {
+	if (props.path !== undefined || !LISTABLE.includes(props.field.kind)) {
 		return null
 	}
 	const asking = listed

--- a/frontend/src/content/PostsScreen.tsx
+++ b/frontend/src/content/PostsScreen.tsx
@@ -5,7 +5,7 @@ import type { View } from '@gophenberg/frontend-sdk/dataviews'
 import { __, sprintf } from '@wordpress/i18n'
 import { ErrorNotice, Page } from '@gopherium/godmin'
 import { useQuery } from '@tanstack/react-query'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import { usePostActions, useRefresh } from './actions'
 import type { PostNotice } from './actions'
@@ -38,6 +38,7 @@ const INITIAL_VIEW: View = {
 export function PostsScreen() {
 	const listed = useContentType()
 	const [view, setView] = useState<View>(INITIAL_VIEW)
+	const [offered, setOffered] = useState('')
 	const [status, setStatus] = useState('')
 	const [notice, setNotice] = useState<PostNotice | null>(null)
 	const [selection, setSelection] = useState<string[]>([])
@@ -55,9 +56,10 @@ export function PostsScreen() {
 	})
 	const columns = useMemo(() => postFields(listed), [listed])
 	const shown = columns.map((column) => column.id).join(',')
-	useEffect(() => {
+	if (offered !== shown) {
+		setOffered(shown)
 		setView((current) => ({ ...current, fields: shown.split(',').filter((id) => id !== 'title') }))
-	}, [shown])
+	}
 	const terms = fieldTerms(view.filters)
 	const posts = useQuery({
 		queryKey: ['posts', listed.key, status, view.search, view.page, view.sort, terms],

--- a/frontend/src/content/PostsScreen.tsx
+++ b/frontend/src/content/PostsScreen.tsx
@@ -5,14 +5,14 @@ import type { View } from '@gophenberg/frontend-sdk/dataviews'
 import { __, sprintf } from '@wordpress/i18n'
 import { ErrorNotice, Page } from '@gopherium/godmin'
 import { useQuery } from '@tanstack/react-query'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { usePostActions, useRefresh } from './actions'
 import type { PostNotice } from './actions'
 import { fetchPostCounts, listPosts } from './api'
 import type { PostCounts, PostPage } from './api'
 import { EmptyTrash } from './EmptyTrash'
-import { postFields } from './fields'
+import { fieldTerms, postFields } from './fields'
 import { PostsNotice } from './PostsNotice'
 import { StatusGhost, StatusViews } from './StatusViews'
 import { useContentType } from './useContentType'
@@ -53,8 +53,14 @@ export function PostsScreen() {
 		queryKey: ['post-counts', listed.key],
 		queryFn: () => fetchPostCounts(listed.key),
 	})
+	const columns = useMemo(() => postFields(listed), [listed])
+	const shown = columns.map((column) => column.id).join(',')
+	useEffect(() => {
+		setView((current) => ({ ...current, fields: shown.split(',').filter((id) => id !== 'title') }))
+	}, [shown])
+	const terms = fieldTerms(view.filters)
 	const posts = useQuery({
-		queryKey: ['posts', listed.key, status, view.search, view.page, view.sort],
+		queryKey: ['posts', listed.key, status, view.search, view.page, view.sort, terms],
 		queryFn: () =>
 			listPosts({
 				type: listed.key,
@@ -63,6 +69,7 @@ export function PostsScreen() {
 				page: view.page,
 				orderBy: view.sort?.field,
 				order: view.sort?.direction,
+				fields: terms,
 			}),
 	})
 	/**
@@ -103,7 +110,7 @@ export function PostsScreen() {
 				>
 					<DataViews
 						data={page.items}
-						fields={postFields}
+						fields={columns}
 						actions={actions}
 						view={view}
 						onChangeView={setView}

--- a/frontend/src/content/PostsScreen.tsx
+++ b/frontend/src/content/PostsScreen.tsx
@@ -56,13 +56,13 @@ export function PostsScreen() {
 	})
 	const columns = useMemo(() => postFields(listed), [listed])
 	const shown = columns.map((column) => column.id).join(',')
-	if (offered !== shown) {
-		const ids = shown.split(',')
-		setOffered(shown)
+	const settled = listed.key + ' ' + shown
+	if (offered !== settled) {
+		setOffered(settled)
 		setView((current) => ({
 			...current,
-			fields: ids.filter((id) => id !== 'title'),
-			filters: current.filters?.filter((filter) => ids.includes(filter.field)),
+			fields: shown.split(',').filter((id) => id !== 'title'),
+			filters: [],
 			page: 1,
 		}))
 	}

--- a/frontend/src/content/PostsScreen.tsx
+++ b/frontend/src/content/PostsScreen.tsx
@@ -57,8 +57,14 @@ export function PostsScreen() {
 	const columns = useMemo(() => postFields(listed), [listed])
 	const shown = columns.map((column) => column.id).join(',')
 	if (offered !== shown) {
+		const ids = shown.split(',')
 		setOffered(shown)
-		setView((current) => ({ ...current, fields: shown.split(',').filter((id) => id !== 'title') }))
+		setView((current) => ({
+			...current,
+			fields: ids.filter((id) => id !== 'title'),
+			filters: current.filters?.filter((filter) => ids.includes(filter.field)),
+			page: 1,
+		}))
 	}
 	const terms = fieldTerms(view.filters)
 	const posts = useQuery({

--- a/frontend/src/content/api.ts
+++ b/frontend/src/content/api.ts
@@ -26,6 +26,7 @@ const postSchema = z.object({
 	published_at: z.string().nullable().optional(),
 	created_at: z.string().optional(),
 	updated_at: z.string().optional(),
+	fields: z.record(z.string(), z.unknown()).optional(),
 })
 
 const detailSchema = postSchema.extend({
@@ -57,6 +58,7 @@ export interface Post {
 	publishedAt: string | null
 	createdAt: string
 	updatedAt: string
+	fields?: Record<string, unknown>
 }
 
 export interface PostPage {
@@ -72,6 +74,7 @@ export interface PostQuery {
 	perPage?: number
 	orderBy?: string
 	order?: string
+	fields?: Record<string, string>
 }
 
 export type PostCounts = Record<string, number>
@@ -96,6 +99,7 @@ function toPost(row: z.infer<typeof postSchema>): Post {
 		publishedAt: row.published_at ?? null,
 		createdAt: row.created_at ?? '',
 		updatedAt: row.updated_at ?? '',
+		fields: row.fields ?? {},
 	}
 }
 
@@ -308,30 +312,40 @@ export async function deletePost(id: string): Promise<void> {
 }
 
 /**
+ * Returns the query parameters a listing request carries.
+ * @param query - The filters, sort and page to ask for.
+ * @returns The parameters.
+ */
+function listingParams(query: PostQuery): URLSearchParams {
+	const params = new URLSearchParams({ per_page: String(query.perPage ?? POSTS_PER_PAGE) })
+	const named: Record<string, string | undefined> = {
+		type: query.type,
+		status: query.status,
+		search: query.search,
+		orderby: query.orderBy,
+		order: query.order,
+	}
+	for (const [name, value] of Object.entries(named)) {
+		if (value) {
+			params.set(name, value)
+		}
+	}
+	if (query.page && query.page > 1) {
+		params.set('page', String(query.page))
+	}
+	for (const [key, value] of Object.entries(query.fields ?? {})) {
+		params.set(`field[${key}]`, value)
+	}
+	return params
+}
+
+/**
  * Returns one page of posts matching the query.
  * @param query - The filters, sort and page to ask for.
  * @returns The page and the total number of matches.
  */
 export async function listPosts(query: PostQuery): Promise<PostPage> {
-	const params = new URLSearchParams({ per_page: String(query.perPage ?? POSTS_PER_PAGE) })
-	if (query.type) {
-		params.set('type', query.type)
-	}
-	if (query.status) {
-		params.set('status', query.status)
-	}
-	if (query.search) {
-		params.set('search', query.search)
-	}
-	if (query.page && query.page > 1) {
-		params.set('page', String(query.page))
-	}
-	if (query.orderBy) {
-		params.set('orderby', query.orderBy)
-	}
-	if (query.order) {
-		params.set('order', query.order)
-	}
+	const params = listingParams(query)
 	const response = await fetch(`/api/content?${params}`)
 	if (!response.ok) {
 		throw new Error(`listing posts failed with status ${response.status}`)

--- a/frontend/src/content/fields.tsx
+++ b/frontend/src/content/fields.tsx
@@ -7,6 +7,11 @@ import { Link } from '@tanstack/react-router'
 
 import { formatDate } from '@gopherium/gottext'
 import type { Post } from './api'
+import { pairsOf } from './types'
+import type { ContentField, ContentType } from './types'
+
+/** What a column id carries before the key of the field it shows. */
+export const fieldColumnPrefix = 'field.'
 
 /**
  * Returns the label shown beside the title of a post that is not published.
@@ -81,7 +86,7 @@ function DateCell({ item }: { item: Post }) {
 	)
 }
 
-export const postFields: Field<Post>[] = [
+const builtInFields: Field<Post>[] = [
 	{
 		id: 'title',
 		label: __('Title', 'gophenberg'),
@@ -92,3 +97,101 @@ export const postFields: Field<Post>[] = [
 	{ id: 'author', label: __('Author', 'gophenberg'), render: AuthorCell, enableSorting: false },
 	{ id: 'date', label: _x('Date', 'column', 'gophenberg'), render: DateCell, enableSorting: true },
 ]
+
+/**
+ * Returns the value a listed field holds on a post, as the column shows it.
+ * @param declared - The field the column stands for.
+ * @param held - The value the post holds under it.
+ * @returns The text of the cell.
+ */
+function shownValue(declared: ContentField, held: unknown): string {
+	if (held === undefined || held === null) {
+		return ''
+	}
+	if (declared.kind === 'boolean') {
+		return held === true ? __('Yes', 'gophenberg') : __('No', 'gophenberg')
+	}
+	if (declared.kind === 'date' && typeof held === 'string') {
+		return formatDate(held)
+	}
+	if (declared.kind === 'choice') {
+		return chosenLabels(declared, held)
+	}
+	return String(held)
+}
+
+/**
+ * Returns the labels a choice field gives the values a post holds.
+ * @param declared - The choice field the column stands for.
+ * @param held - The value or values the post holds.
+ * @returns The labels, joined by a comma when the field holds several.
+ */
+function chosenLabels(declared: ContentField, held: unknown): string {
+	const pairs = pairsOf(declared.settings)
+	const chosen = Array.isArray(held) ? held : [held]
+	return chosen
+		.map((one) => pairs.find((pair) => pair.value === one)?.label ?? String(one))
+		.join(', ')
+}
+
+/**
+ * Returns the elements a column offers as a filter, none for a kind that offers no chip.
+ * @param declared - The field the column stands for.
+ * @returns The elements, or nothing when the kind offers no chip.
+ */
+function filterElements(declared: ContentField) {
+	if (declared.kind === 'boolean') {
+		return [
+			{ value: 'true', label: __('Yes', 'gophenberg') },
+			{ value: 'false', label: __('No', 'gophenberg') },
+		]
+	}
+	if (declared.kind === 'choice') {
+		const pairs = pairsOf(declared.settings)
+		return pairs.length > 0 ? pairs : undefined
+	}
+	return undefined
+}
+
+/**
+ * Returns the column showing what a listed field holds.
+ * @param declared - The field the column stands for.
+ * @returns The column.
+ */
+function fieldColumn(declared: ContentField): Field<Post> {
+	const elements = filterElements(declared)
+	return {
+		id: `${fieldColumnPrefix}${declared.key}`,
+		label: declared.label,
+		enableSorting: false,
+		getValue: ({ item }: { item: Post }) => shownValue(declared, item.fields?.[declared.key]),
+		...(elements === undefined ? {} : { elements, filterBy: { operators: ['is' as const], isPrimary: true } }),
+	}
+}
+
+/**
+ * Returns the terms a view's chips narrow the listing by, keyed by the field each names.
+ * @param filters - The filters the view carries.
+ * @returns The terms, keyed by field key.
+ */
+export function fieldTerms(
+	filters: { field: string, value: unknown }[] | undefined,
+): Record<string, string> {
+	const terms: Record<string, string> = {}
+	for (const filter of filters ?? []) {
+		if (filter.field.startsWith(fieldColumnPrefix) && filter.value !== undefined) {
+			terms[filter.field.slice(fieldColumnPrefix.length)] = String(filter.value)
+		}
+	}
+	return terms
+}
+
+/**
+ * Returns the columns a content type's listing shows, one per field it marks for the list.
+ * @param listed - The type being listed.
+ * @returns The columns.
+ */
+export function postFields(listed: ContentType): Field<Post>[] {
+	const marked = listed.fields.filter((declared) => declared.settings.listed === true)
+	return [...builtInFields, ...marked.map(fieldColumn)]
+}

--- a/frontend/src/test/date-cells.test.tsx
+++ b/frontend/src/test/date-cells.test.tsx
@@ -5,6 +5,7 @@ import type { ReactElement } from 'react'
 import { afterEach, expect, test } from 'vitest'
 
 import { postFields } from '../content/fields'
+import { placeholderType } from '../content/useContentType'
 import { DEFAULT_LOCALE } from '../i18n/catalog'
 import { rememberLocale } from '@gopherium/gottext'
 import { mediaFields } from '../media/fields'
@@ -64,7 +65,7 @@ const item: MediaItem = {
 test('shows a post date in the language the reader settled on', () => {
 	rememberLocale('es-ES')
 
-	renderDate(postFields, post)
+	renderDate(postFields(placeholderType('post')), post)
 
 	expect(screen.getByText(/16\/8\/2026/)).toBeInTheDocument()
 })

--- a/frontend/src/test/group-conditions.test.tsx
+++ b/frontend/src/test/group-conditions.test.tsx
@@ -446,6 +446,18 @@ test('takes a field out of the admin list again', async () => {
 	)
 })
 
+test('offers no list flip inside a container, where the list never reaches', async () => {
+	const paid = { ...ON_SALE, key: 'paid', label: 'Paid' }
+	const crew = { ...ON_SALE, key: 'crew', label: 'Crew', kind: 'section', fields: [paid] }
+	server.use(http.get('/api/groups', () => HttpResponse.json({ items: [{ ...DETAILS, fields: [crew] }] })))
+	renderAt('/field-groups')
+
+	const dialog = await openFields()
+
+	const row = within(dialog).getByRole('listitem', { name: 'Paid' })
+	expect(within(row).queryByRole('button', { name: /in the list/ })).not.toBeInTheDocument()
+})
+
 test('offers no list flip on a kind the list cannot show', async () => {
 	renderAt('/field-groups')
 

--- a/frontend/src/test/posts-columns.test.tsx
+++ b/frontend/src/test/posts-columns.test.tsx
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { http, HttpResponse, server } from '@gophenberg/frontend-sdk/testing'
+import { screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, expect, test } from 'vitest'
+
+import { fieldTerms } from '../content/fields'
+import { renderAt } from './render'
+import { warmPostsScreen } from './warm'
+
+warmPostsScreen()
+
+const STAMP = '2026-07-20T10:00:00Z'
+
+const POST_TYPE = {
+	key: 'post',
+	singular_label: 'Post',
+	plural_label: 'Posts',
+	route_word: '',
+	hierarchical: false,
+	revisions: true,
+	revision_cap: 100,
+	page_kind: 'single',
+	default: true,
+	active: true,
+	created_at: STAMP,
+	updated_at: STAMP,
+	fields: [],
+}
+
+/**
+ * Returns a declared field of the kind carrying the settings.
+ * @param key - The key the field answers to.
+ * @param label - The label the column shows.
+ * @param kind - The kind the field holds.
+ * @param settings - The settings the field carries.
+ * @returns The field as the registry serves it.
+ */
+function field(key: string, label: string, kind: string, settings: Record<string, unknown>) {
+	return { key, label, kind, many: false, required: false, updated_at: STAMP, settings }
+}
+
+const PRICE = field('price', 'Price', 'number', { listed: true })
+const ON_SALE = field('on-sale', 'On sale', 'boolean', { listed: true })
+const SINCE = field('since', 'Since', 'date', { listed: true })
+const COLOUR = field('colour', 'Colour', 'choice', {
+	listed: true,
+	choices: [
+		{ value: 'red', label: 'Red' },
+		{ value: 'blue', label: 'Blue' },
+	],
+})
+const NOTE = field('note', 'Note', 'text', {})
+
+const ITEM = {
+	id: '019fb000-0000-7000-8000-000000000001',
+	type: 'post',
+	slug: 'welcome',
+	title: 'Welcome',
+	excerpt: '',
+	status: 'published',
+	author_id: '019fb000-0000-7000-8000-0000000000ff',
+	author_name: 'Maria Perez',
+	published_at: STAMP,
+	created_at: STAMP,
+	updated_at: STAMP,
+	fields: {
+		price: 10,
+		'on-sale': true,
+		since: '2026-09-05',
+		colour: 'red',
+		note: 'unlisted',
+	},
+}
+
+/**
+ * Serves the type declaring the given fields and one item holding values.
+ * @param fields - The fields the type declares.
+ * @returns The addresses the listing was asked for.
+ */
+function declaring(fields: Record<string, unknown>[]) {
+	const asked: string[] = []
+	server.use(
+		http.get('/api/types', () => HttpResponse.json({ items: [{ ...POST_TYPE, fields }] })),
+		http.get('/api/content', ({ request }) => {
+			asked.push(new URL(request.url).search)
+			return HttpResponse.json({ items: [ITEM], total: 1 })
+		}),
+	)
+	return asked
+}
+
+beforeEach(() => {
+	server.use(
+		http.get('/api/content/counts', () =>
+			HttpResponse.json({ draft: 0, published: 1, pending: 0, private: 0, trash: 0 }),
+		),
+	)
+})
+
+test('shows a column for every field the type marks for the list', async () => {
+	declaring([PRICE, ON_SALE, SINCE, COLOUR, NOTE])
+	renderAt('/content/post')
+
+	const table = await screen.findByRole('table')
+
+	for (const label of ['Price', 'On sale', 'Since', 'Colour']) {
+		expect(within(table).getByRole('columnheader', { name: label })).toBeInTheDocument()
+	}
+	expect(within(table).queryByRole('columnheader', { name: 'Note' })).not.toBeInTheDocument()
+})
+
+test('reads each value the way its kind is written', async () => {
+	declaring([PRICE, ON_SALE, SINCE, COLOUR])
+	renderAt('/content/post')
+
+	const row = within(await screen.findByRole('table')).getAllByRole('row')[1]
+
+	expect(row).toHaveTextContent('10')
+	expect(row).toHaveTextContent('Yes')
+	expect(row).toHaveTextContent('Red')
+})
+
+test('names a column by its key so a field called title never takes the title column', async () => {
+	declaring([field('title', 'Headline', 'text', { listed: true })])
+	renderAt('/content/post')
+
+	const table = await screen.findByRole('table')
+
+	expect(within(table).getByRole('columnheader', { name: 'Title' })).toBeInTheDocument()
+	expect(within(table).getByRole('columnheader', { name: 'Headline' })).toBeInTheDocument()
+})
+
+test('asks the server for the field a chip narrows by', async () => {
+	const asked = declaring([ON_SALE])
+	renderAt('/content/post')
+	await screen.findByRole('table')
+
+	await userEvent.click(screen.getAllByRole('button', { name: /On sale/ })[0])
+	await userEvent.click(await screen.findByRole('option', { name: 'Yes' }))
+
+	await waitFor(() => expect(asked.some((search) => search.includes('field%5Bon-sale%5D=true'))).toBe(true))
+})
+
+test('joins the labels a field holding several choices carries', async () => {
+	const tags = field('tags', 'Tags', 'choice', {
+		listed: true,
+		multiple: true,
+		choices: [{ value: 'red', label: 'Red' }],
+	})
+	declaring([tags])
+	server.use(
+		http.get('/api/content', () =>
+			HttpResponse.json({ items: [{ ...ITEM, fields: { tags: ['red', 'stray'] } }], total: 1 }),
+		),
+	)
+	renderAt('/content/post')
+
+	const row = within(await screen.findByRole('table')).getAllByRole('row')[1]
+
+	expect(row).toHaveTextContent('Red, stray')
+})
+
+test('offers no chip on a choice field nobody gave options', async () => {
+	declaring([field('colour', 'Colour', 'choice', { listed: true })])
+	renderAt('/content/post')
+	await screen.findByRole('table')
+
+	expect(screen.getAllByRole('button', { name: /Colour/ })).toHaveLength(1)
+})
+
+test('reads the terms a view narrows by, ignoring what names no field', () => {
+	const terms = fieldTerms([
+		{ field: 'field.price', value: 10 },
+		{ field: 'status', value: 'draft' },
+		{ field: 'field.note', value: undefined },
+	])
+
+	expect(terms).toEqual({ price: '10' })
+})
+
+test('reads no term from a view carrying no filter', () => {
+	expect(fieldTerms(undefined)).toEqual({})
+})
+
+test('reads a boolean nobody switched on as no', async () => {
+	declaring([ON_SALE])
+	server.use(
+		http.get('/api/content', () =>
+			HttpResponse.json({ items: [{ ...ITEM, fields: { 'on-sale': false } }], total: 1 }),
+		),
+	)
+	renderAt('/content/post')
+
+	const row = within(await screen.findByRole('table')).getAllByRole('row')[1]
+
+	expect(row).toHaveTextContent('No')
+})

--- a/frontend/src/test/posts-columns.test.tsx
+++ b/frontend/src/test/posts-columns.test.tsx
@@ -221,3 +221,32 @@ test('drops a filter the type it moves to never declared', async () => {
 	await waitFor(() => expect(asked.at(-1)).toContain('type=page'))
 	expect(asked.at(-1)).not.toContain('field%5Bon-sale%5D')
 })
+
+test('drops a filter the type it moves to declares under another kind', async () => {
+	const colour = field('shared', 'Shared', 'choice', {
+		listed: true,
+		choices: [{ value: 'red', label: 'Red' }],
+	})
+	const flag = field('shared', 'Shared', 'boolean', { listed: true })
+	const pageType = { ...POST_TYPE, key: 'page', plural_label: 'Pages', default: false, fields: [flag] }
+	const asked: string[] = []
+	server.use(
+		http.get('/api/types', () =>
+			HttpResponse.json({ items: [{ ...POST_TYPE, fields: [colour] }, pageType] }),
+		),
+		http.get('/api/content', ({ request }) => {
+			asked.push(new URL(request.url).search)
+			return HttpResponse.json({ items: [ITEM], total: 1 })
+		}),
+	)
+	const { router } = renderRoutedAt('/content/post')
+	await screen.findByRole('table')
+	await userEvent.click(screen.getAllByRole('button', { name: /Shared/ })[0])
+	await userEvent.click(await screen.findByRole('option', { name: 'Red' }))
+	await waitFor(() => expect(asked.some((search) => search.includes('field%5Bshared%5D=red'))).toBe(true))
+
+	await router.navigate({ to: '/content/$typeKey', params: { typeKey: 'page' } })
+
+	await waitFor(() => expect(asked.at(-1)).toContain('type=page'))
+	expect(asked.at(-1)).not.toContain('field%5Bshared%5D')
+})

--- a/frontend/src/test/posts-columns.test.tsx
+++ b/frontend/src/test/posts-columns.test.tsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event'
 import { beforeEach, expect, test } from 'vitest'
 
 import { fieldTerms } from '../content/fields'
-import { renderAt } from './render'
+import { renderAt, renderRoutedAt } from './render'
 import { warmPostsScreen } from './warm'
 
 warmPostsScreen()
@@ -196,4 +196,28 @@ test('reads a boolean nobody switched on as no', async () => {
 	const row = within(await screen.findByRole('table')).getAllByRole('row')[1]
 
 	expect(row).toHaveTextContent('No')
+})
+
+test('drops a filter the type it moves to never declared', async () => {
+	const pageType = { ...POST_TYPE, key: 'page', plural_label: 'Pages', default: false, fields: [] }
+	const asked: string[] = []
+	server.use(
+		http.get('/api/types', () =>
+			HttpResponse.json({ items: [{ ...POST_TYPE, fields: [ON_SALE] }, pageType] }),
+		),
+		http.get('/api/content', ({ request }) => {
+			asked.push(new URL(request.url).search)
+			return HttpResponse.json({ items: [ITEM], total: 1 })
+		}),
+	)
+	const { router } = renderRoutedAt('/content/post')
+	await screen.findByRole('table')
+	await userEvent.click(screen.getAllByRole('button', { name: /On sale/ })[0])
+	await userEvent.click(await screen.findByRole('option', { name: 'Yes' }))
+	await waitFor(() => expect(asked.some((search) => search.includes('field%5Bon-sale%5D'))).toBe(true))
+
+	await router.navigate({ to: '/content/$typeKey', params: { typeKey: 'page' } })
+
+	await waitFor(() => expect(asked.at(-1)).toContain('type=page'))
+	expect(asked.at(-1)).not.toContain('field%5Bon-sale%5D')
 })

--- a/frontend/src/test/render.tsx
+++ b/frontend/src/test/render.tsx
@@ -21,6 +21,21 @@ export function renderAt(
 	user: User | null = adminUser,
 	version: string | null = '0.0.0',
 ) {
+	return renderRoutedAt(path, user, version).client
+}
+
+/**
+ * Renders the admin at the path and returns the query client and the router behind it.
+ * @param path - The address to render at.
+ * @param user - The signed in user, none for a signed out admin.
+ * @param version - The version the admin reports, none to leave it unasked.
+ * @returns The query client and the router.
+ */
+export function renderRoutedAt(
+	path: string,
+	user: User | null = adminUser,
+	version: string | null = '0.0.0',
+) {
 	const client = createAuthQueryClient({
 		queries: { retry: false, staleTime: Infinity },
 	})
@@ -38,5 +53,5 @@ export function renderAt(
 			</AdminToaster>
 		</QueryClientProvider>,
 	)
-	return client
+	return { client, router }
 }

--- a/internal/content/filter.go
+++ b/internal/content/filter.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package content
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ErrFieldFilterInvalid reports a field filter term a list cannot read.
+var ErrFieldFilterInvalid = errors.New("content: field filter invalid")
+
+// The characters wrapping the key of a field filter parameter.
+const (
+	fieldTermPrefix = "field["
+	fieldTermSuffix = "]"
+)
+
+// termCoercers holds the readers of a filter value, one per kind a filter reads.
+var termCoercers = map[FieldKind]func(Field, string) (any, error){
+	FieldKindText:    coerceText,
+	FieldKindNumber:  coerceNumber,
+	FieldKindBoolean: coerceBoolean,
+	FieldKindDate:    coerceDate,
+	FieldKindChoice:  coerceChoice,
+}
+
+// ParseFieldFilter returns the containment object the field[<key>] parameters name, each coerced by its field's kind.
+func ParseFieldFilter(query url.Values, fields []Field) (map[string]any, error) {
+	var terms map[string]any
+	for name, raws := range query {
+		key, isTerm := termKey(name)
+		if !isTerm {
+			continue
+		}
+		if len(raws) > 1 {
+			return nil, refuseTerm(key, "named more than once")
+		}
+		f, err := fieldAmong(fields, key)
+		if err != nil {
+			return nil, refuseTerm(key, "not a field of the type")
+		}
+		value, err := coerceTerm(f, raws[0])
+		if err != nil {
+			return nil, err
+		}
+		if terms == nil {
+			terms = map[string]any{}
+		}
+		terms[key] = value
+	}
+	return terms, nil
+}
+
+// termKey returns the key a field[<key>] parameter names and whether the name has that shape.
+func termKey(name string) (string, bool) {
+	rest, prefixed := strings.CutPrefix(name, fieldTermPrefix)
+	if !prefixed {
+		return "", false
+	}
+	return strings.CutSuffix(rest, fieldTermSuffix)
+}
+
+// coerceTerm returns the raw value in the shape the field stores, refusing a kind no filter reads.
+func coerceTerm(f Field, raw string) (any, error) {
+	coerce, filterable := termCoercers[f.Kind]
+	if !filterable {
+		return nil, refuseTerm(f.Key, "not a kind a filter reads")
+	}
+	return coerce(f, raw)
+}
+
+// coerceText returns the raw value as written.
+func coerceText(_ Field, raw string) (any, error) {
+	return raw, nil
+}
+
+// coerceNumber returns the number the raw value writes, refusing words, NaN and the infinities.
+func coerceNumber(f Field, raw string) (any, error) {
+	number, err := strconv.ParseFloat(raw, 64)
+	if err != nil || math.IsNaN(number) || math.IsInf(number, 0) {
+		return nil, refuseTerm(f.Key, "not a number")
+	}
+	return number, nil
+}
+
+// coerceBoolean returns the boolean the words true and false name, refusing any other word.
+func coerceBoolean(f Field, raw string) (any, error) {
+	if raw != "true" && raw != "false" {
+		return nil, refuseTerm(f.Key, "not true or false")
+	}
+	return raw == "true", nil
+}
+
+// coerceDate returns the raw value once it reads as a calendar date.
+func coerceDate(f Field, raw string) (any, error) {
+	if _, err := time.Parse(dateLayout, raw); err != nil {
+		return nil, refuseTerm(f.Key, "not a date")
+	}
+	return raw, nil
+}
+
+// coerceChoice returns the raw value, inside a one member list when the field holds several.
+func coerceChoice(f Field, raw string) (any, error) {
+	if choiceMultiple(f) {
+		return []any{raw}, nil
+	}
+	return raw, nil
+}
+
+// refuseTerm returns the error naming what a field filter term could not read.
+func refuseTerm(key, reason string) error {
+	return fmt.Errorf("%w: field[%s] %s", ErrFieldFilterInvalid, key, reason)
+}
+
+// ListedValues returns the shown values under the fields opted into the admin list.
+func ListedValues(fields []Field, values Values) Values {
+	shown := Shown(fields, values)
+	listed := Values{}
+	for _, f := range fields {
+		if value, held := shown[f.Key]; held && Listed(f) {
+			listed[f.Key] = value
+		}
+	}
+	return listed
+}

--- a/internal/content/filter.go
+++ b/internal/content/filter.go
@@ -38,8 +38,8 @@ func ParseFieldFilter(query url.Values, fields []Field) (map[string]any, error) 
 		if !isTerm {
 			continue
 		}
-		if len(raws) > 1 {
-			return nil, refuseTerm(key, "named more than once")
+		if len(raws) != 1 {
+			return nil, refuseTerm(key, "not named once with one value")
 		}
 		f, err := fieldAmong(fields, key)
 		if err != nil {

--- a/internal/content/filter.go
+++ b/internal/content/filter.go
@@ -57,6 +57,16 @@ func ParseFieldFilter(query url.Values, fields []Field) (map[string]any, error) 
 	return terms, nil
 }
 
+// NamesFieldFilter reports whether the query names any field filter term.
+func NamesFieldFilter(query url.Values) bool {
+	for name := range query {
+		if _, isTerm := termKey(name); isTerm {
+			return true
+		}
+	}
+	return false
+}
+
 // termKey returns the key a field[<key>] parameter names and whether the name has that shape.
 func termKey(name string) (string, bool) {
 	rest, prefixed := strings.CutPrefix(name, fieldTermPrefix)

--- a/internal/content/filter_test.go
+++ b/internal/content/filter_test.go
@@ -64,6 +64,7 @@ func TestParseFieldFilterRefusesATermItCannotRead(t *testing.T) {
 
 	cases := map[string]url.Values{
 		"a key named twice":           {"field[note]": {"a", "b"}},
+		"a key naming no value":       {"field[note]": {}},
 		"a key the type lacks":        {"field[missing]": {"a"}},
 		"a key inside a container":    {"field[name]": {"a"}},
 		"a kind no filter reads":      {"field[cover]": {"a"}},

--- a/internal/content/filter_test.go
+++ b/internal/content/filter_test.go
@@ -121,3 +121,19 @@ func TestListedValuesAnswersAnEmptyObjectWhenNothingIsListed(t *testing.T) {
 		t.Errorf("ListedValues() = %#v, want an empty object", listed)
 	}
 }
+
+func TestNamesFieldFilterReadsWhetherAQueryCarriesATerm(t *testing.T) {
+	t.Parallel()
+
+	for name, held := range map[string]bool{
+		"field[price]": true, "field[]": true, "price": false, "page": false, "field": false,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if named := content.NamesFieldFilter(url.Values{name: {"10"}}); named != held {
+				t.Errorf("NamesFieldFilter(%q) = %v, want %v", name, named, held)
+			}
+		})
+	}
+}

--- a/internal/content/filter_test.go
+++ b/internal/content/filter_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package content_test
+
+import (
+	"errors"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/gopherium/gophenberg/internal/content"
+)
+
+// filterable returns one field of every kind a filter reads, one it does not, and a container holding a text.
+func filterable() []content.Field {
+	return []content.Field{
+		{Key: "note", Kind: content.FieldKindText},
+		{Key: "price", Kind: content.FieldKindNumber},
+		{Key: "on-sale", Kind: content.FieldKindBoolean},
+		{Key: "since", Kind: content.FieldKindDate},
+		{Key: "colour", Kind: content.FieldKindChoice},
+		{Key: "tags", Kind: content.FieldKindChoice, Settings: map[string]any{content.SettingMultiple: true}},
+		{Key: "cover", Kind: content.FieldKindMedia},
+		{Key: "crew", Kind: content.FieldKindRepeater, Fields: []content.Field{{Key: "name", Kind: content.FieldKindText}}},
+	}
+}
+
+func TestParseFieldFilterCoercesEachTermByItsKind(t *testing.T) {
+	t.Parallel()
+
+	query := url.Values{
+		"field[note]": {"half price"}, "field[price]": {"10"}, "field[on-sale]": {"true"},
+		"field[since]": {"2026-09-05"}, "field[colour]": {"red"}, "field[tags]": {"red"}, "page": {"2"},
+	}
+
+	terms, err := content.ParseFieldFilter(query, filterable())
+
+	if err != nil {
+		t.Fatalf("ParseFieldFilter() = %v, want every term read", err)
+	}
+	want := map[string]any{
+		"note": "half price", "price": 10.0, "on-sale": true, "since": "2026-09-05", "colour": "red", "tags": []any{"red"},
+	}
+	if !reflect.DeepEqual(terms, want) {
+		t.Errorf("terms = %#v, want %#v", terms, want)
+	}
+}
+
+func TestParseFieldFilterReadsNothingWhenNoTermIsNamed(t *testing.T) {
+	t.Parallel()
+
+	terms, err := content.ParseFieldFilter(url.Values{"page": {"2"}, "type": {"post"}}, filterable())
+
+	if err != nil {
+		t.Fatalf("ParseFieldFilter() = %v, want nothing refused", err)
+	}
+	if terms != nil {
+		t.Errorf("terms = %#v, want none", terms)
+	}
+}
+
+func TestParseFieldFilterRefusesATermItCannotRead(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]url.Values{
+		"a key named twice":           {"field[note]": {"a", "b"}},
+		"a key the type lacks":        {"field[missing]": {"a"}},
+		"a key inside a container":    {"field[name]": {"a"}},
+		"a kind no filter reads":      {"field[cover]": {"a"}},
+		"a number written in words":   {"field[price]": {"ten"}},
+		"a number that is not one":    {"field[price]": {"NaN"}},
+		"a number without a bound":    {"field[price]": {"Inf"}},
+		"a boolean that is a word":    {"field[on-sale]": {"yes"}},
+		"a date outside the calendar": {"field[since]": {"2026-13-01"}},
+	}
+	for name, query := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			terms, err := content.ParseFieldFilter(query, filterable())
+
+			if !errors.Is(err, content.ErrFieldFilterInvalid) {
+				t.Errorf("ParseFieldFilter() = %v, want %v", err, content.ErrFieldFilterInvalid)
+			}
+			if terms != nil {
+				t.Errorf("terms = %#v, want none beside a refusal", terms)
+			}
+		})
+	}
+}
+
+func TestListedValuesKeepsTheShownValuesUnderListedFields(t *testing.T) {
+	t.Parallel()
+
+	fields := []content.Field{
+		{Key: "note", Kind: content.FieldKindText, Settings: map[string]any{content.SettingListed: true}},
+		{Key: "price", Kind: content.FieldKindNumber},
+		{Key: "on-sale", Kind: content.FieldKindBoolean, Settings: map[string]any{content.SettingListed: true}},
+		{Key: "sale-note", Kind: content.FieldKindText, Settings: map[string]any{
+			content.SettingListed:     true,
+			content.SettingConditions: shownWhen("on-sale", content.OperatorIs, "true"),
+		}},
+		{Key: "since", Kind: content.FieldKindDate, Settings: map[string]any{content.SettingListed: true}},
+	}
+	values := content.Values{"note": "half price", "price": 10.0, "on-sale": false, "sale-note": "frozen"}
+
+	listed := content.ListedValues(fields, values)
+
+	want := content.Values{"note": "half price", "on-sale": false}
+	if !reflect.DeepEqual(listed, want) {
+		t.Errorf("ListedValues() = %#v, want %#v", listed, want)
+	}
+}
+
+func TestListedValuesAnswersAnEmptyObjectWhenNothingIsListed(t *testing.T) {
+	t.Parallel()
+
+	listed := content.ListedValues(filterable(), content.Values{"note": "half price"})
+
+	if !reflect.DeepEqual(listed, content.Values{}) {
+		t.Errorf("ListedValues() = %#v, want an empty object", listed)
+	}
+}

--- a/internal/content/store.go
+++ b/internal/content/store.go
@@ -111,6 +111,7 @@ type Filter struct {
 	Order   Order
 	Page    int
 	PerPage int
+	Fields  map[string]any
 }
 
 // Store persists content items and their revisions.

--- a/internal/postgres/content.go
+++ b/internal/postgres/content.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -191,44 +192,94 @@ func toContent(row db.CoreContent) content.Content {
 // total number matching it.
 func (s *ContentStore) List(ctx context.Context, f content.Filter) ([]content.Content, int, error) {
 	search := escapeLike(f.Search)
-	total, err := s.queries.CountContent(ctx, db.CountContentParams{
-		Type:   f.Type,
-		Status: string(f.Status),
-		Search: search,
-	})
+	total, err := s.countList(ctx, f, search)
 	if err != nil {
 		return nil, 0, fmt.Errorf("postgres: count content: %w", err)
 	}
-	rows, err := s.queries.ListContent(ctx, db.ListContentParams{
-		Type:      f.Type,
-		Status:    string(f.Status),
-		Search:    search,
-		OrderBy:   string(f.OrderBy),
-		OrderDir:  string(f.Order),
-		RowLimit:  int32(f.PerPage),
-		RowOffset: pageOffset(f.Page, f.PerPage),
-	})
+	rows, err := s.listRows(ctx, f, search)
 	if err != nil {
 		return nil, 0, fmt.Errorf("postgres: list content: %w", err)
 	}
 	items := make([]content.Content, len(rows))
 	for i, row := range rows {
-		items[i] = content.Content{
-			ID:          row.ID,
-			Type:        row.Type,
-			ParentID:    row.ParentID,
-			Path:        row.Path,
-			Status:      content.Status(row.Status),
-			Slug:        row.Slug,
-			Title:       row.Title,
-			Excerpt:     row.Excerpt,
-			AuthorID:    row.AuthorID,
-			PublishedAt: utcOrNil(row.PublishedAt),
-			CreatedAt:   row.CreatedAt.UTC(),
-			UpdatedAt:   row.UpdatedAt.UTC(),
-		}
+		items[i] = listedContent(row)
 	}
 	return items, int(total), nil
+}
+
+// countList returns how many items the filter matches, narrowing by field terms when it names any.
+func (s *ContentStore) countList(ctx context.Context, f content.Filter, search string) (int64, error) {
+	if len(f.Fields) == 0 {
+		return s.queries.CountContent(ctx, db.CountContentParams{
+			Type:   f.Type,
+			Status: string(f.Status),
+			Search: search,
+		})
+	}
+	return s.queries.CountContentByFields(ctx, db.CountContentByFieldsParams{
+		Type:        f.Type,
+		FieldFilter: termsJSON(f.Fields),
+		Status:      string(f.Status),
+		Search:      search,
+	})
+}
+
+// listRows returns the page the filter names, narrowing by field terms when it names any.
+func (s *ContentStore) listRows(ctx context.Context, f content.Filter, search string) ([]db.ListContentRow, error) {
+	if len(f.Fields) == 0 {
+		return s.queries.ListContent(ctx, db.ListContentParams{
+			Type:      f.Type,
+			Status:    string(f.Status),
+			Search:    search,
+			OrderBy:   string(f.OrderBy),
+			OrderDir:  string(f.Order),
+			RowLimit:  int32(f.PerPage),
+			RowOffset: pageOffset(f.Page, f.PerPage),
+		})
+	}
+	narrowed, err := s.queries.ListContentByFields(ctx, db.ListContentByFieldsParams{
+		Type:        f.Type,
+		FieldFilter: termsJSON(f.Fields),
+		Status:      string(f.Status),
+		Search:      search,
+		OrderBy:     string(f.OrderBy),
+		OrderDir:    string(f.Order),
+		RowLimit:    int32(f.PerPage),
+		RowOffset:   pageOffset(f.Page, f.PerPage),
+	})
+	if err != nil {
+		return nil, err
+	}
+	rows := make([]db.ListContentRow, len(narrowed))
+	for i, row := range narrowed {
+		rows[i] = db.ListContentRow(row)
+	}
+	return rows, nil
+}
+
+// termsJSON returns the containment object the filter names as the jsonb parameter holds it.
+func termsJSON(terms map[string]any) []byte {
+	raw, _ := json.Marshal(terms)
+	return raw
+}
+
+// listedContent returns one listed row as the item it stands for.
+func listedContent(row db.ListContentRow) content.Content {
+	return content.Content{
+		ID:          row.ID,
+		Type:        row.Type,
+		ParentID:    row.ParentID,
+		Path:        row.Path,
+		Status:      content.Status(row.Status),
+		Slug:        row.Slug,
+		Title:       row.Title,
+		Excerpt:     row.Excerpt,
+		AuthorID:    row.AuthorID,
+		PublishedAt: utcOrNil(row.PublishedAt),
+		CreatedAt:   row.CreatedAt.UTC(),
+		UpdatedAt:   row.UpdatedAt.UTC(),
+		Fields:      row.Fields,
+	}
 }
 
 // Update stores the item's editable fields and any snapshot, settling its address among its siblings.

--- a/internal/postgres/content_failure_test.go
+++ b/internal/postgres/content_failure_test.go
@@ -34,6 +34,12 @@ func TestContentStoreReportsDatabaseFailures(t *testing.T) {
 	if _, _, err := store.List(t.Context(), content.Filter{Type: content.TypePost, Page: 1, PerPage: 10}); err == nil {
 		t.Error("List() on a closed pool error = nil, want a failure")
 	}
+	narrowed := content.Filter{
+		Type: content.TypePost, Page: 1, PerPage: 10, Fields: map[string]any{"price": float64(10)},
+	}
+	if _, _, err := store.List(t.Context(), narrowed); err == nil {
+		t.Error("List() narrowed by fields on a closed pool error = nil, want a failure")
+	}
 	if _, err := store.Update(t.Context(), stored, stored.UpdatedAt, nil, 0); err == nil {
 		t.Error("Update() on a closed pool error = nil, want a failure")
 	}

--- a/internal/postgres/content_filter_test.go
+++ b/internal/postgres/content_filter_test.go
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gopherium/gophenberg/internal/content"
+	"github.com/gopherium/gophenberg/internal/postgres"
+)
+
+// declareFilterable declares one field of every kind a filter reads on the post type.
+func declareFilterable(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	declareField(t, pool, "note", content.FieldKindText)
+	declareField(t, pool, "price", content.FieldKindNumber)
+	declareField(t, pool, "on-sale", content.FieldKindBoolean)
+	declareField(t, pool, "since", content.FieldKindDate)
+	declareChoice(t, pool, "colour", false)
+	declareChoice(t, pool, "tags", true)
+}
+
+// declareChoice declares a choice field offering red, blue and warm, holding several when asked.
+func declareChoice(t *testing.T, pool *pgxpool.Pool, key string, multiple bool) {
+	t.Helper()
+	declared := fieldOn(t, content.TypePost, key, content.FieldKindChoice, "")
+	declared.Settings = map[string]any{
+		content.SettingChoices: []any{
+			map[string]any{"value": "red", "label": "Red"},
+			map[string]any{"value": "blue", "label": "Blue"},
+			map[string]any{"value": "warm", "label": "Warm"},
+		},
+		content.SettingMultiple: multiple,
+	}
+	if _, err := postgres.NewTypeStore(pool).CreateField(t.Context(), declared); err != nil {
+		t.Fatalf("declaring the %q field: %v, want nil", key, err)
+	}
+}
+
+// holding stores a draft post carrying the given field values.
+func holding(t *testing.T, store *postgres.ContentStore, title string, author uuid.UUID,
+	values content.Values) content.Content {
+	t.Helper()
+	created := mustCreate(t, store, title, author)
+	created.Fields = values
+	updated, err := store.Update(t.Context(), created, created.UpdatedAt, nil, 0)
+	if err != nil {
+		t.Fatalf("storing the values of %q: %v", title, err)
+	}
+	return updated
+}
+
+// listedUnder returns the titles and the total the filter answers, narrowed by the terms.
+func listedUnder(t *testing.T, store *postgres.ContentStore, terms map[string]any) ([]string, int) {
+	t.Helper()
+	rows, total, err := store.List(t.Context(), content.Filter{
+		Type: content.TypePost, OrderBy: content.OrderByTitle, Order: content.OrderAsc,
+		Page: 1, PerPage: 20, Fields: terms,
+	})
+	if err != nil {
+		t.Fatalf("List(%v): %v", terms, err)
+	}
+	return titlesOf(rows), total
+}
+
+func TestContentStoreListNarrowsByEachFilterableKind(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := newContentStoreWithPool(t)
+	declareFilterable(t, pool)
+	holding(t, store, "Match", author, content.Values{
+		"note": "half price", "price": float64(10), "on-sale": true,
+		"since": "2026-09-05", "colour": "red", "tags": []any{"red", "warm"},
+	})
+	holding(t, store, "Miss", author, content.Values{
+		"note": "full price", "price": float64(20), "on-sale": false,
+		"since": "2026-01-01", "colour": "blue", "tags": []any{"blue"},
+	})
+
+	cases := map[string]map[string]any{
+		"a number":        {"price": float64(10)},
+		"a boolean":       {"on-sale": true},
+		"a date":          {"since": "2026-09-05"},
+		"a text":          {"note": "half price"},
+		"a single choice": {"colour": "red"},
+		"a choice member": {"tags": []any{"red"}},
+		"two terms anded": {"price": float64(10), "on-sale": true},
+	}
+	for name, terms := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			rows, total, err := store.List(t.Context(), content.Filter{
+				Type: content.TypePost, OrderBy: content.OrderByTitle, Order: content.OrderAsc,
+				Page: 1, PerPage: 20, Fields: terms,
+			})
+
+			if err != nil {
+				t.Fatalf("List(%v): %v", terms, err)
+			}
+			if titles := titlesOf(rows); len(titles) != 1 || titles[0] != "Match" {
+				t.Errorf("titles = %v, want only the matching item", titles)
+			}
+			if total != 1 {
+				t.Errorf("total = %d, want 1", total)
+			}
+			if len(rows) == 1 && rows[0].Fields["note"] != "half price" {
+				t.Errorf("fields = %v, want the values carried onto the narrowed row", rows[0].Fields)
+			}
+		})
+	}
+}
+
+func TestContentStoreListLeavesAnUnfilteredListingWhole(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := newContentStoreWithPool(t)
+	declareFilterable(t, pool)
+	holding(t, store, "Match", author, content.Values{"price": float64(10)})
+	holding(t, store, "Miss", author, content.Values{"price": float64(20)})
+
+	titles, total := listedUnder(t, store, nil)
+
+	if len(titles) != 2 || total != 2 {
+		t.Errorf("titles = %v with total %d, want both items", titles, total)
+	}
+}
+
+func TestContentStoreListCarriesTheValuesOfEveryRow(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := newContentStoreWithPool(t)
+	declareFilterable(t, pool)
+	holding(t, store, "Match", author, content.Values{"note": "half price"})
+
+	rows, _, err := store.List(t.Context(), content.Filter{
+		Type: content.TypePost, OrderBy: content.OrderByTitle, Order: content.OrderAsc, Page: 1, PerPage: 20,
+	})
+
+	if err != nil {
+		t.Fatalf("List(): %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want the stored item", len(rows))
+	}
+	if rows[0].Fields["note"] != "half price" {
+		t.Errorf("fields = %v, want the values carried onto the listed row", rows[0].Fields)
+	}
+}
+
+func TestContentStoreListAnswersNothingWhenNoItemHoldsTheTerm(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := newContentStoreWithPool(t)
+	declareFilterable(t, pool)
+	holding(t, store, "Match", author, content.Values{"price": float64(10)})
+
+	titles, total := listedUnder(t, store, map[string]any{"price": float64(99)})
+
+	if len(titles) != 0 || total != 0 {
+		t.Errorf("titles = %v with total %d, want an empty page", titles, total)
+	}
+}
+
+func TestMigrationsIndexTheFieldValuesForContainment(t *testing.T) {
+	t.Parallel()
+
+	held := newTestDB(t)
+
+	var definition string
+	err := held.QueryRow(
+		`SELECT indexdef FROM pg_indexes
+		WHERE schemaname = 'core' AND tablename = 'content' AND indexname = 'content_field_values_idx'`,
+	).Scan(&definition)
+
+	if err != nil {
+		t.Fatalf("querying pg_indexes: %v", err)
+	}
+	for _, want := range []string{"USING gin", "jsonb_path_ops"} {
+		if !strings.Contains(definition, want) {
+			t.Errorf("index = %q, want it to carry %q", definition, want)
+		}
+	}
+}
+
+func TestContentStoreListNarrowedKeepsTheOrderAndThePage(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := newContentStoreWithPool(t)
+	declareFilterable(t, pool)
+	for _, title := range []string{"Charlie", "Alpha", "Bravo"} {
+		holding(t, store, title, author, content.Values{"price": float64(10)})
+	}
+	holding(t, store, "Delta", author, content.Values{"price": float64(20)})
+
+	first, total, err := store.List(t.Context(), content.Filter{
+		Type: content.TypePost, OrderBy: content.OrderByTitle, Order: content.OrderAsc,
+		Page: 1, PerPage: 2, Fields: map[string]any{"price": float64(10)},
+	})
+	if err != nil {
+		t.Fatalf("listing the first page: %v", err)
+	}
+	second, _, err := store.List(t.Context(), content.Filter{
+		Type: content.TypePost, OrderBy: content.OrderByTitle, Order: content.OrderAsc,
+		Page: 2, PerPage: 2, Fields: map[string]any{"price": float64(10)},
+	})
+	if err != nil {
+		t.Fatalf("listing the second page: %v", err)
+	}
+
+	if got := titlesOf(first); len(got) != 2 || got[0] != "Alpha" || got[1] != "Bravo" {
+		t.Errorf("first page = %v, want Alpha then Bravo", got)
+	}
+	if got := titlesOf(second); len(got) != 1 || got[0] != "Charlie" {
+		t.Errorf("second page = %v, want Charlie alone", got)
+	}
+	if total != 3 {
+		t.Errorf("total = %d, want the three matching items", total)
+	}
+}
+
+func TestContentStoreListNarrowedHonoursTheStatusItIsGiven(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := newContentStoreWithPool(t)
+	declareFilterable(t, pool)
+	holding(t, store, "Draft", author, content.Values{"price": float64(10)})
+	live := holding(t, store, "Published", author, content.Values{"price": float64(10)})
+	at := time.Now().UTC()
+	live.Status = content.StatusPublished
+	live.PublishedAt = &at
+	if _, err := store.Update(t.Context(), live, live.UpdatedAt, nil, 0); err != nil {
+		t.Fatalf("publishing: %v", err)
+	}
+
+	rows, total, err := store.List(t.Context(), content.Filter{
+		Type: content.TypePost, Status: content.StatusPublished, OrderBy: content.OrderByTitle, Order: content.OrderAsc,
+		Page: 1, PerPage: 20, Fields: map[string]any{"price": float64(10)},
+	})
+
+	if err != nil {
+		t.Fatalf("List(): %v", err)
+	}
+	if got := titlesOf(rows); len(got) != 1 || got[0] != "Published" {
+		t.Errorf("titles = %v, want only the published item", got)
+	}
+	if total != 1 {
+		t.Errorf("total = %d, want 1", total)
+	}
+}
+
+func TestContentStoreListNarrowedHonoursTheSearchItIsGiven(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := newContentStoreWithPool(t)
+	declareFilterable(t, pool)
+	holding(t, store, "Winter sale", author, content.Values{"price": float64(10)})
+	holding(t, store, "Summer sale", author, content.Values{"price": float64(10)})
+
+	rows, total, err := store.List(t.Context(), content.Filter{
+		Type: content.TypePost, Search: "Winter", OrderBy: content.OrderByTitle, Order: content.OrderAsc,
+		Page: 1, PerPage: 20, Fields: map[string]any{"price": float64(10)},
+	})
+
+	if err != nil {
+		t.Fatalf("List(): %v", err)
+	}
+	if got := titlesOf(rows); len(got) != 1 || got[0] != "Winter sale" {
+		t.Errorf("titles = %v, want only the searched item", got)
+	}
+	if total != 1 {
+		t.Errorf("total = %d, want 1", total)
+	}
+}
+
+func TestContentStoreReportsANarrowedListingItCannotRead(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := newContentStoreWithPool(t)
+	declareFilterable(t, pool)
+	holding(t, store, "Match", author, content.Values{"price": float64(10)})
+	sabotage(t, pool, "ALTER TABLE core.content DROP COLUMN excerpt CASCADE")
+
+	narrowed := content.Filter{
+		Type: content.TypePost, Page: 1, PerPage: 20, Fields: map[string]any{"price": float64(10)},
+	}
+	if _, _, err := store.List(t.Context(), narrowed); err == nil {
+		t.Error("List() narrowed by fields error = nil, want the unreadable listing reported")
+	}
+}

--- a/internal/postgres/db/queries.sql.go
+++ b/internal/postgres/db/queries.sql.go
@@ -191,6 +191,38 @@ func (q *Queries) CountContent(ctx context.Context, arg CountContentParams) (int
 	return count, err
 }
 
+const countContentByFields = `-- name: CountContentByFields :one
+SELECT count(*)
+FROM core.content p
+WHERE p.type = $1
+    AND p.fields @> $2::jsonb
+    AND ($3::text = '' OR p.status = $3)
+    AND (
+        $4::text = ''
+        OR p.title ILIKE '%' || $4 || '%'
+        OR p.content ILIKE '%' || $4 || '%'
+    )
+`
+
+type CountContentByFieldsParams struct {
+	Type        string
+	FieldFilter []byte
+	Status      string
+	Search      string
+}
+
+func (q *Queries) CountContentByFields(ctx context.Context, arg CountContentByFieldsParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countContentByFields,
+		arg.Type,
+		arg.FieldFilter,
+		arg.Status,
+		arg.Search,
+	)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countContentByStatus = `-- name: CountContentByStatus :many
 SELECT p.status, count(*) AS total
 FROM core.content p
@@ -1171,6 +1203,99 @@ func (q *Queries) ListContent(ctx context.Context, arg ListContentParams) ([]Lis
 	var items []ListContentRow
 	for rows.Next() {
 		var i ListContentRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Type,
+			&i.Status,
+			&i.Slug,
+			&i.Title,
+			&i.Excerpt,
+			&i.AuthorID,
+			&i.PublishedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.ParentID,
+			&i.Path,
+			&i.Fields,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listContentByFields = `-- name: ListContentByFields :many
+SELECT p.id, p.type, p.status, p.slug, p.title, p.excerpt,
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields
+FROM core.content p
+WHERE p.type = $1
+    AND p.fields @> $2::jsonb
+    AND ($3::text = '' OR p.status = $3)
+    AND (
+        $4::text = ''
+        OR p.title ILIKE '%' || $4 || '%'
+        OR p.content ILIKE '%' || $4 || '%'
+    )
+ORDER BY
+    CASE WHEN $5::text = 'title' AND $6::text = 'asc' THEN p.title END ASC,
+    CASE WHEN $5::text = 'title' AND $6::text = 'desc' THEN p.title END DESC,
+    CASE WHEN $5::text <> 'title' AND $6::text = 'asc'
+        THEN COALESCE(p.published_at, p.created_at) END ASC,
+    CASE WHEN $5::text <> 'title' AND $6::text <> 'asc'
+        THEN COALESCE(p.published_at, p.created_at) END DESC,
+    p.id DESC
+LIMIT $8 OFFSET $7
+`
+
+type ListContentByFieldsParams struct {
+	Type        string
+	FieldFilter []byte
+	Status      string
+	Search      string
+	OrderBy     string
+	OrderDir    string
+	RowOffset   int32
+	RowLimit    int32
+}
+
+type ListContentByFieldsRow struct {
+	ID          uuid.UUID
+	Type        string
+	Status      string
+	Slug        string
+	Title       string
+	Excerpt     string
+	AuthorID    uuid.UUID
+	PublishedAt *time.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	ParentID    *uuid.UUID
+	Path        string
+	Fields      content.Values
+}
+
+func (q *Queries) ListContentByFields(ctx context.Context, arg ListContentByFieldsParams) ([]ListContentByFieldsRow, error) {
+	rows, err := q.db.Query(ctx, listContentByFields,
+		arg.Type,
+		arg.FieldFilter,
+		arg.Status,
+		arg.Search,
+		arg.OrderBy,
+		arg.OrderDir,
+		arg.RowOffset,
+		arg.RowLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListContentByFieldsRow
+	for rows.Next() {
+		var i ListContentByFieldsRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.Type,

--- a/internal/postgres/migrations/00020_index_content_field_values.sql
+++ b/internal/postgres/migrations/00020_index_content_field_values.sql
@@ -1,0 +1,7 @@
+-- SPDX-License-Identifier: Apache-2.0
+
+-- +goose Up
+CREATE INDEX content_field_values_idx ON core.content USING gin (fields jsonb_path_ops);
+
+-- +goose Down
+DROP INDEX core.content_field_values_idx;

--- a/internal/postgres/queries.sql
+++ b/internal/postgres/queries.sql
@@ -56,6 +56,40 @@ WHERE p.type = @type
         OR p.content ILIKE '%' || @search || '%'
     );
 
+-- name: ListContentByFields :many
+SELECT p.id, p.type, p.status, p.slug, p.title, p.excerpt,
+    p.author_id, p.published_at, p.created_at, p.updated_at, p.parent_id, p.path, p.fields
+FROM core.content p
+WHERE p.type = @type
+    AND p.fields @> @field_filter::jsonb
+    AND (@status::text = '' OR p.status = @status)
+    AND (
+        @search::text = ''
+        OR p.title ILIKE '%' || @search || '%'
+        OR p.content ILIKE '%' || @search || '%'
+    )
+ORDER BY
+    CASE WHEN @order_by::text = 'title' AND @order_dir::text = 'asc' THEN p.title END ASC,
+    CASE WHEN @order_by::text = 'title' AND @order_dir::text = 'desc' THEN p.title END DESC,
+    CASE WHEN @order_by::text <> 'title' AND @order_dir::text = 'asc'
+        THEN COALESCE(p.published_at, p.created_at) END ASC,
+    CASE WHEN @order_by::text <> 'title' AND @order_dir::text <> 'asc'
+        THEN COALESCE(p.published_at, p.created_at) END DESC,
+    p.id DESC
+LIMIT @row_limit OFFSET @row_offset;
+
+-- name: CountContentByFields :one
+SELECT count(*)
+FROM core.content p
+WHERE p.type = @type
+    AND p.fields @> @field_filter::jsonb
+    AND (@status::text = '' OR p.status = @status)
+    AND (
+        @search::text = ''
+        OR p.title ILIKE '%' || @search || '%'
+        OR p.content ILIKE '%' || @search || '%'
+    );
+
 -- name: UpdateContent :one
 UPDATE core.content AS p
 SET status = @status, slug = @slug, path = @path, parent_id = @parent_id, title = @title,

--- a/internal/server/content.go
+++ b/internal/server/content.go
@@ -582,6 +582,12 @@ func (s *server) handlePublishedList() http.HandlerFunc {
 			}
 			filter.Type = listed.Key
 		}
+		if err := s.narrowByFields(r, &filter); err != nil {
+			authkit.RespondError(w, http.StatusBadRequest, authkit.ErrorResponse{
+				Message: "invalid list parameters", Code: "list_parameters_invalid",
+			})
+			return
+		}
 		page, err := s.publishedPageOf(r, filter)
 		if err != nil {
 			respondDomainError(w, err)
@@ -589,6 +595,23 @@ func (s *server) handlePublishedList() http.HandlerFunc {
 		}
 		authkit.Respond(w, http.StatusOK, page)
 	}
+}
+
+// narrowByFields reads the field terms the query names into the filter, once its type is settled.
+func (s *server) narrowByFields(r *http.Request, filter *content.Filter) error {
+	if !content.NamesFieldFilter(r.URL.Query()) {
+		return nil
+	}
+	asked, err := s.types.ByKey(r.Context(), filter.Type)
+	if err != nil {
+		return err
+	}
+	terms, err := content.ParseFieldFilter(r.URL.Query(), asked.Fields)
+	if err != nil {
+		return err
+	}
+	filter.Fields = terms
+	return nil
 }
 
 // contentETag returns the validator standing for the answer a reader is served.

--- a/internal/server/content_admin.go
+++ b/internal/server/content_admin.go
@@ -52,9 +52,15 @@ type contentDetailResponse struct {
 	Fields  content.Values `json:"fields"`
 }
 
+// contentRow is one row of the admin listing, carrying the values its type marks for the list.
+type contentRow struct {
+	contentResponse
+	Fields content.Values `json:"fields"`
+}
+
 type contentListResponse struct {
-	Items []contentResponse `json:"items"`
-	Total int               `json:"total"`
+	Items []contentRow `json:"items"`
+	Total int          `json:"total"`
 }
 
 // newContentResponse builds a contentResponse from an item, normalizing timestamps to UTC.
@@ -117,6 +123,11 @@ func parseAdminContentFilter(query url.Values, contentType content.Type) (conten
 	if err := applyContentPaging(query, &filter); err != nil {
 		return content.Filter{}, err
 	}
+	terms, err := content.ParseFieldFilter(query, contentType.Fields)
+	if err != nil {
+		return content.Filter{}, err
+	}
+	filter.Fields = terms
 	return filter, nil
 }
 
@@ -183,9 +194,12 @@ func (s *server) handleContentList() http.HandlerFunc {
 			respondDomainError(w, err)
 			return
 		}
-		items := make([]contentResponse, len(rows))
+		items := make([]contentRow, len(rows))
 		for i, c := range rows {
-			items[i] = newContentResponse(c, names[c.AuthorID])
+			items[i] = contentRow{
+				contentResponse: newContentResponse(c, names[c.AuthorID]),
+				Fields:          content.ListedValues(contentType.Fields, c.Fields),
+			}
 		}
 		authkit.Respond(w, http.StatusOK, contentListResponse{Items: items, Total: total})
 	}

--- a/internal/server/content_query_test.go
+++ b/internal/server/content_query_test.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gopherium/gophenberg/internal/content"
+)
+
+// queryFields declares a listed price, an unlisted note and a sale note the price hides.
+func queryFields(t *testing.T, handler http.Handler) {
+	t.Helper()
+	declaredOn(t, handler, `{"key":"price","label":"Price","kind":"number","settings":{"listed":true}}`)
+	declaredOn(t, handler, `{"key":"note","label":"Note","kind":"text"}`)
+	declaredOn(t, handler, `{"key":"sale-note","label":"Sale note","kind":"text","settings":`+
+		`{"listed":true,"conditions":[[{"source":"price","operator":"==","value":"10"}]]}}`)
+}
+
+func TestPostListNarrowsByTheFieldTermItIsGiven(t *testing.T) {
+	t.Parallel()
+
+	handler, posts, _, _ := typedPostServer(t)
+	queryFields(t, handler)
+
+	recorder := doRequest(t, handler, http.MethodGet, "/api/content?field[price]=10", "")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body %s", recorder.Code, http.StatusOK, recorder.Body)
+	}
+	if posts.lastFilter.Fields["price"] != 10.0 {
+		t.Errorf("filter fields = %v, want the coerced term", posts.lastFilter.Fields)
+	}
+}
+
+func TestPostListCarriesNoTermWhenTheQueryNamesNone(t *testing.T) {
+	t.Parallel()
+
+	handler, posts, _, _ := typedPostServer(t)
+	queryFields(t, handler)
+
+	doRequest(t, handler, http.MethodGet, "/api/content?orderby=title", "")
+
+	if posts.lastFilter.Fields != nil {
+		t.Errorf("filter fields = %v, want none", posts.lastFilter.Fields)
+	}
+}
+
+func TestPostListRefusesAFieldTermItCannotRead(t *testing.T) {
+	t.Parallel()
+
+	for name, query := range map[string]string{
+		"a key the type lacks":      "field[missing]=10",
+		"a kind no filter reads":    "field[cover]=10",
+		"a value that is no number": "field[price]=ten",
+		"a key named twice":         "field[price]=10&field[price]=20",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			handler, _, _, _ := typedPostServer(t)
+			queryFields(t, handler)
+			declaredOn(t, handler, `{"key":"cover","label":"Cover","kind":"media"}`)
+
+			recorder := doRequest(t, handler, http.MethodGet, "/api/content?"+query, "")
+
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d, body %s", recorder.Code, http.StatusBadRequest, recorder.Body)
+			}
+			if code := errorCode(t, recorder); code != "list_parameters_invalid" {
+				t.Errorf("code = %q, want list_parameters_invalid", code)
+			}
+		})
+	}
+}
+
+func TestPostListRowsCarryTheValuesTheTypeMarksForTheList(t *testing.T) {
+	t.Parallel()
+
+	handler := authedTypeServer(t)
+	queryFields(t, handler)
+	held := draftedPost(t, handler)
+	held = patchValues(t, handler, held, `{"price":10,"note":"unlisted","sale-note":"frozen by the price"}`)
+	patchValues(t, handler, held, `{"price":20}`)
+
+	listed := decodeBody[contentListHeld](t, doRequest(t, handler, http.MethodGet, "/api/content", ""))
+
+	if len(listed.Items) != 1 {
+		t.Fatalf("items = %d, want the stored item", len(listed.Items))
+	}
+	fields := listed.Items[0].Fields
+	if fields["price"] != 20.0 {
+		t.Errorf("fields = %v, want the listed value carried", fields)
+	}
+	if _, carried := fields["note"]; carried {
+		t.Errorf("fields = %v, want no value the type leaves off the list", fields)
+	}
+	if _, carried := fields["sale-note"]; carried {
+		t.Errorf("fields = %v, want no value the rules hide", fields)
+	}
+}
+
+func TestPublishedListNarrowsByTheFieldTermItIsGiven(t *testing.T) {
+	t.Parallel()
+
+	handler, posts, _, _ := typedPostServer(t)
+	queryFields(t, handler)
+
+	recorder := doRequest(t, handler, http.MethodGet, "/api/content/v1/items?type=post&field[price]=10", "")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body %s", recorder.Code, http.StatusOK, recorder.Body)
+	}
+	if posts.lastFilter.Fields["price"] != 10.0 {
+		t.Errorf("filter fields = %v, want the coerced term", posts.lastFilter.Fields)
+	}
+}
+
+func TestPublishedListRefusesAFieldTermItCannotRead(t *testing.T) {
+	t.Parallel()
+
+	handler, _, _, _ := typedPostServer(t)
+	queryFields(t, handler)
+
+	recorder := doRequest(t, handler, http.MethodGet, "/api/content/v1/items?type=post&field[missing]=10", "")
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d, body %s", recorder.Code, http.StatusBadRequest, recorder.Body)
+	}
+	if code := errorCode(t, recorder); code != "list_parameters_invalid" {
+		t.Errorf("code = %q, want list_parameters_invalid", code)
+	}
+}
+
+func TestPublishedListRefusesATermUnderATypeNobodyDeclared(t *testing.T) {
+	t.Parallel()
+
+	handler, _, _, _ := typedPostServer(t)
+	queryFields(t, handler)
+
+	recorder := doRequest(t, handler, http.MethodGet, "/api/content/v1/items?type=nothing&field[price]=10", "")
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d, body %s", recorder.Code, http.StatusBadRequest, recorder.Body)
+	}
+	if code := errorCode(t, recorder); code != "list_parameters_invalid" {
+		t.Errorf("code = %q, want list_parameters_invalid", code)
+	}
+}
+
+func TestPublishedListAnswersAnEmptyPageForATypeNobodyDeclared(t *testing.T) {
+	t.Parallel()
+
+	handler, _, _, _ := typedPostServer(t)
+	queryFields(t, handler)
+
+	recorder := doRequest(t, handler, http.MethodGet, "/api/content/v1/items?type=nothing", "")
+
+	if recorder.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d, body %s", recorder.Code, http.StatusOK, recorder.Body)
+	}
+}
+
+// contentListHeld is the admin listing as its readers decode it.
+type contentListHeld struct {
+	Items []struct {
+		ID     string         `json:"id"`
+		Fields content.Values `json:"fields"`
+	} `json:"items"`
+	Total int `json:"total"`
+}

--- a/internal/server/content_test.go
+++ b/internal/server/content_test.go
@@ -72,7 +72,7 @@ func TestContentAPIAnswersTheHandshakeWithoutASession(t *testing.T) {
 	if !strings.Contains(body, `"api":0`) {
 		t.Errorf("body = %q, want the api generation", body)
 	}
-	if !strings.Contains(body, `"kit":["0.9.0","0.10.0","0.11.0"]`) {
+	if !strings.Contains(body, `"kit":["0.9.0","0.10.0","0.11.0","0.12.0"]`) {
 		t.Errorf("body = %q, want the kit versions served", body)
 	}
 	if !strings.Contains(body, `"gophenberg"`) {
@@ -341,7 +341,7 @@ func TestContentAPIAdvertisesTheTypesItServes(t *testing.T) {
 	if handshake.API != 0 {
 		t.Errorf("api = %d, want 0", handshake.API)
 	}
-	if !slices.Equal(handshake.Kit, []string{"0.9.0", "0.10.0", "0.11.0"}) {
+	if !slices.Equal(handshake.Kit, []string{"0.9.0", "0.10.0", "0.11.0", "0.12.0"}) {
 		t.Errorf("kit = %v, want the kit versions this release serves", handshake.Kit)
 	}
 	if len(handshake.Types) != 1 {

--- a/internal/themehost/kit.go
+++ b/internal/themehost/kit.go
@@ -9,7 +9,7 @@ import (
 )
 
 // servedKits names the theme kit versions this release serves, oldest first.
-var servedKits = []string{"0.9.0", "0.10.0", "0.11.0"}
+var servedKits = []string{"0.9.0", "0.10.0", "0.11.0", "0.12.0"}
 
 // ServedKits returns the theme kit versions this release serves.
 func ServedKits() []string {

--- a/internal/themehost/kit_test.go
+++ b/internal/themehost/kit_test.go
@@ -17,10 +17,10 @@ func TestServedKitsNamesWhatThisReleaseServes(t *testing.T) {
 
 	served := themehost.ServedKits()
 
-	if !slices.Equal(served, []string{"0.9.0", "0.10.0", "0.11.0"}) {
+	if !slices.Equal(served, []string{"0.9.0", "0.10.0", "0.11.0", "0.12.0"}) {
 		t.Errorf("ServedKits() = %v, want the kit versions this release serves", served)
 	}
-	if themehost.NewestKit() != "0.11.0" {
+	if themehost.NewestKit() != "0.12.0" {
 		t.Errorf("NewestKit() = %q, want the newest of them", themehost.NewestKit())
 	}
 }
@@ -28,7 +28,7 @@ func TestServedKitsNamesWhatThisReleaseServes(t *testing.T) {
 func TestAThemeOnEitherServedKitIsAccepted(t *testing.T) {
 	t.Parallel()
 
-	for _, declared := range []string{"0.9.0", "0.10.0", "0.11.0"} {
+	for _, declared := range []string{"0.9.0", "0.10.0", "0.11.0", "0.12.0"} {
 		if !themehost.ServesKit(declared) {
 			t.Errorf("ServesKit(%q) = false, want a theme on a served kit accepted", declared)
 		}
@@ -45,7 +45,7 @@ func TestServedKitsCannotBeChangedByACaller(t *testing.T) {
 
 	themehost.ServedKits()[0] = "9.9.9"
 
-	if themehost.NewestKit() != "0.11.0" {
+	if themehost.NewestKit() != "0.12.0" {
 		t.Errorf("NewestKit() = %q after a caller wrote to the returned slice", themehost.NewestKit())
 	}
 }

--- a/sdk/astro/CHANGELOG.md
+++ b/sdk/astro/CHANGELOG.md
@@ -13,6 +13,11 @@ through 0.8.0 shipped in step with Gophenberg under its `vX.Y.Z` tags.
 
 ## Unreleased
 
+### Added
+
+- `listPosts` narrows a listing to the items holding a value, named as `fields`.
+- A live collection narrows by the same `fields`.
+
 ### Changed
 
 - `listPosts` asks for a page size only when the caller names one, so the size the site chose applies.

--- a/sdk/astro/client.ts
+++ b/sdk/astro/client.ts
@@ -10,6 +10,7 @@ export interface ListQuery {
 	type?: string
 	page?: number
 	perPage?: number
+	fields?: Record<string, string | number | boolean>
 }
 
 /** What a caller may ask an archive for. */
@@ -49,6 +50,9 @@ export class GophenbergClient {
 		}
 		if (query.type !== undefined) {
 			search.set('type', query.type)
+		}
+		for (const [key, value] of Object.entries(query.fields ?? {})) {
+			search.set(`field[${key}]`, String(value))
 		}
 		const response = await this.read(`/items?${search}`)
 		return (await response.json()) as Page<PostSummary>

--- a/sdk/astro/loader.ts
+++ b/sdk/astro/loader.ts
@@ -15,6 +15,7 @@ export interface PostCollectionFilter {
 	type?: string
 	page?: number
 	perPage?: number
+	fields?: Record<string, string | number | boolean>
 }
 
 /** How a page addresses one live post. */

--- a/sdk/astro/package.json
+++ b/sdk/astro/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gophenberg/astro",
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "Build a Gophenberg theme in Astro: routes, block rendering, and the theme contract.",

--- a/sdk/astro/test/client.test.ts
+++ b/sdk/astro/test/client.test.ts
@@ -116,6 +116,27 @@ describe('listPosts', () => {
 		expect(urls[0]).toBe('https://example.com/api/content/v1/items?page=3&per_page=5&type=page')
 	})
 
+	test('names each field the caller narrows by', async () => {
+		const { fetch, urls } = fetchReturning(page)
+
+		await new GophenbergClient({ baseUrl: 'https://example.com', fetch }).listPosts({
+			fields: { price: 10, 'on-sale': true, colour: 'red' },
+		})
+
+		expect(urls[0]).toBe(
+			'https://example.com/api/content/v1/items?page=1&field%5Bprice%5D=10' +
+				'&field%5Bon-sale%5D=true&field%5Bcolour%5D=red',
+		)
+	})
+
+	test('names no field when the caller narrows by none', async () => {
+		const { fetch, urls } = fetchReturning(page)
+
+		await new GophenbergClient({ baseUrl: 'https://example.com', fetch }).listPosts({ fields: {} })
+
+		expect(urls[0]).toBe('https://example.com/api/content/v1/items?page=1')
+	})
+
 	test('reports a listing it could not read', async () => {
 		const { fetch } = fetchReturning({ error: 'boom' }, 500)
 

--- a/sdk/astro/test/loader.test.ts
+++ b/sdk/astro/test/loader.test.ts
@@ -78,6 +78,14 @@ describe('loadCollection', () => {
 		expect(listPosts).toHaveBeenCalledWith({ type: 'page', page: 2, perPage: 5 })
 	})
 
+	test('narrows by the field values a page asked for', async () => {
+		const { loader, listPosts } = loaderOver({})
+
+		await loader.loadCollection({ collection: 'posts', filter: { fields: { price: 10 } } })
+
+		expect(listPosts).toHaveBeenCalledWith({ fields: { price: 10 } })
+	})
+
 	test('reports a listing it could not read', async () => {
 		const { loader } = loaderOver({
 			listPosts: async () => {

--- a/test/features/features/field-query.feature
+++ b/test/features/features/field-query.feature
@@ -1,0 +1,83 @@
+Feature: Finding content by the values it holds
+  A listing narrows to the items holding a value under a field, named as a
+  field[key] parameter and read by the kind the field declares. A key the
+  type does not declare, a kind no filter reads, a value the kind cannot
+  take and a key named twice are all refused. Term pages and archives
+  ignore the parameter the way they ignore any other they do not read.
+
+  Background:
+    Given a running Gophenberg with the default content types
+    And a signed in administrator
+    And the group "Extras" placed on "post"
+    And the "number" field "price" in "Extras" with settings:
+      """
+      {"listed": true}
+      """
+    And the "boolean" field "on-sale" in "Extras" with settings:
+      """
+      {}
+      """
+    And the "media" field "cover" in "Extras" with settings:
+      """
+      {}
+      """
+    And the post "Winter sale"
+    And the post "Winter sale" holding:
+      """
+      {"price": 10, "on-sale": true}
+      """
+    And the post "Summer sale"
+    And the post "Summer sale" holding:
+      """
+      {"price": 20, "on-sale": false}
+      """
+
+  Scenario: A listing narrows to the items holding a number
+    When the administrator lists content where "price" is "10"
+    Then the listing holds only "Winter sale"
+
+  Scenario: A listing narrows to the items holding a boolean
+    When the administrator lists content where "on-sale" is "false"
+    Then the listing holds only "Summer sale"
+
+  Scenario: A listing nobody narrows holds every item
+    When the administrator lists content where "" is ""
+    Then the listing holds 2 items
+
+  Scenario: A listing narrowed to a value nobody holds is empty
+    When the administrator lists content where "price" is "99"
+    Then the listing holds 0 items
+
+  Scenario: A listing carries the values the type marks for the list
+    When the administrator lists content where "price" is "10"
+    Then the listed item "Winter sale" carries "10" under "price"
+
+  Scenario: A listing carries no value the type leaves off the list
+    When the administrator lists content where "price" is "10"
+    Then the listed item "Winter sale" carries nothing under "on-sale"
+
+  Scenario: A key the type does not declare is refused
+    When the administrator lists content where "vanished" is "10"
+    Then the request is refused with the code "list_parameters_invalid"
+
+  Scenario: A kind no filter reads is refused
+    When the administrator lists content where "cover" is "10"
+    Then the request is refused with the code "list_parameters_invalid"
+
+  Scenario: A value the kind cannot take is refused
+    When the administrator lists content where "price" is "ten"
+    Then the request is refused with the code "list_parameters_invalid"
+
+  Scenario: A key named twice is refused
+    When the administrator lists content where "price" is "10" and "10" again
+    Then the request is refused with the code "list_parameters_invalid"
+
+  Scenario: A reader narrows the published items by a value
+    Given the administrator publishes "Winter sale"
+    And the administrator publishes "Summer sale"
+    When a visitor lists published "post" where "price" is "10"
+    Then the listing holds only "Winter sale"
+
+  Scenario: A reader naming a key the type lacks is refused
+    When a visitor lists published "post" where "vanished" is "10"
+    Then the request is refused with the code "list_parameters_invalid"

--- a/test/features/features_test.go
+++ b/test/features/features_test.go
@@ -58,6 +58,10 @@ func TestConditionalLogic(t *testing.T) {
 	runFeature(t, "features/conditional-logic.feature", initializeConditionalLogic)
 }
 
+func TestFieldQuery(t *testing.T) {
+	runFeature(t, "features/field-query.feature", initializeFieldQuery)
+}
+
 func TestContainers(t *testing.T) {
 	runFeature(t, "features/containers.feature", initializeContainers)
 }

--- a/test/features/memorycontent_test.go
+++ b/test/features/memorycontent_test.go
@@ -313,12 +313,50 @@ func (s *memoryContent) List(_ context.Context, f content.Filter) ([]content.Con
 	defer s.mu.Unlock()
 	matched := make([]content.Content, 0, len(s.items))
 	for _, stored := range s.items {
-		if stored.Type == f.Type && (f.Status == "" || stored.Status == f.Status) {
+		if stored.Type == f.Type && (f.Status == "" || stored.Status == f.Status) && narrowed(stored.Fields, f.Fields) {
 			matched = append(matched, stored)
 		}
 	}
 	slices.SortFunc(matched, func(a, b content.Content) int { return b.CreatedAt.Compare(a.CreatedAt) })
 	return paged(matched, f), len(matched), nil
+}
+
+// narrowed reports whether the stored values hold every term the filter names.
+func narrowed(values content.Values, terms map[string]any) bool {
+	for key, term := range terms {
+		if !holdsTerm(values[key], term) {
+			return false
+		}
+	}
+	return true
+}
+
+// holdsTerm reports whether a stored value carries the term, a list carrying it as a member.
+func holdsTerm(held, term any) bool {
+	wanted, listed := term.([]any)
+	if !listed {
+		return held == term
+	}
+	members, ok := held.([]any)
+	if !ok {
+		return false
+	}
+	for _, want := range wanted {
+		if !among(members, want) {
+			return false
+		}
+	}
+	return true
+}
+
+// among reports whether the members carry the wanted value.
+func among(members []any, wanted any) bool {
+	for _, member := range members {
+		if member == wanted {
+			return true
+		}
+	}
+	return false
 }
 
 // paged returns the page of items the filter asks for.

--- a/test/features/steps_field_query_test.go
+++ b/test/features/steps_field_query_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package features_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/cucumber/godog"
+)
+
+// narrowedRow is one row of a listing as its readers decode it.
+type narrowedRow struct {
+	Title  string                     `json:"title"`
+	Fields map[string]json.RawMessage `json:"fields"`
+}
+
+// narrowedPage is a listing as its readers decode it.
+type narrowedPage struct {
+	Items []narrowedRow `json:"items"`
+	Total int           `json:"total"`
+}
+
+// fieldQuery returns the query string naming the term, empty when the key is unnamed.
+func fieldQuery(key string, values ...string) string {
+	if key == "" {
+		return ""
+	}
+	query := url.Values{}
+	for _, value := range values {
+		query.Add("field["+key+"]", value)
+	}
+	return "&" + query.Encode()
+}
+
+// theAdministratorListsContentWhere reads the admin listing narrowed by the term.
+func theAdministratorListsContentWhere(ctx context.Context, key, value string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	return w.get(contentPath + "?type=post" + fieldQuery(key, value))
+}
+
+// theAdministratorListsContentWhereTwice reads the admin listing naming one term twice.
+func theAdministratorListsContentWhereTwice(ctx context.Context, key, first, second string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	return w.get(contentPath + "?type=post" + fieldQuery(key, first, second))
+}
+
+// aVisitorListsPublishedWhere reads the published listing of the type narrowed by the term.
+func aVisitorListsPublishedWhere(ctx context.Context, typeKey, key, value string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	return w.get("/api/content/v1/items?type=" + typeKey + fieldQuery(key, value))
+}
+
+// listedAnswer returns the listing the last answer carries.
+func listedAnswer(w *world) (narrowedPage, error) {
+	if w.answer == nil {
+		return narrowedPage{}, fmt.Errorf("nothing was listed yet")
+	}
+	var held narrowedPage
+	if err := json.Unmarshal(w.answer.body, &held); err != nil {
+		return narrowedPage{}, fmt.Errorf("reading the listing: %w", err)
+	}
+	return held, nil
+}
+
+// theListingHoldsOnly asserts the listing carries the one titled item.
+func theListingHoldsOnly(ctx context.Context, title string) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	held, err := listedAnswer(w)
+	if err != nil {
+		return err
+	}
+	if len(held.Items) != 1 || held.Items[0].Title != title {
+		return fmt.Errorf("the listing holds %v, want only %q", titlesListed(held), title)
+	}
+	return nil
+}
+
+// theListingHoldsItems asserts how many items the listing carries.
+func theListingHoldsItems(ctx context.Context, count int) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	held, err := listedAnswer(w)
+	if err != nil {
+		return err
+	}
+	if len(held.Items) != count {
+		return fmt.Errorf("the listing holds %v, want %d items", titlesListed(held), count)
+	}
+	return nil
+}
+
+// titlesListed returns the titles the listing carries.
+func titlesListed(held narrowedPage) []string {
+	titles := make([]string, len(held.Items))
+	for i, item := range held.Items {
+		titles[i] = item.Title
+	}
+	return titles
+}
+
+// theListedItemCarries asserts the listed item carries the value under the key.
+func theListedItemCarries(ctx context.Context, title, value, key string) error {
+	row, err := rowListed(ctx, title)
+	if err != nil {
+		return err
+	}
+	raw, found := row.Fields[key]
+	if !found {
+		return fmt.Errorf("the listed %q holds no %q, want %q", title, key, value)
+	}
+	if string(raw) != value {
+		return fmt.Errorf("the listed %q holds %s in %q, want %q", title, raw, key, value)
+	}
+	return nil
+}
+
+// theListedItemCarriesNothingUnder asserts the listed item carries nothing under the key.
+func theListedItemCarriesNothingUnder(ctx context.Context, title, key string) error {
+	row, err := rowListed(ctx, title)
+	if err != nil {
+		return err
+	}
+	if raw, found := row.Fields[key]; found {
+		return fmt.Errorf("the listed %q holds %s in %q, want nothing", title, raw, key)
+	}
+	return nil
+}
+
+// rowListed returns the listed row carrying the title.
+func rowListed(ctx context.Context, title string) (narrowedRow, error) {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return narrowedRow{}, err
+	}
+	held, err := listedAnswer(w)
+	if err != nil {
+		return narrowedRow{}, err
+	}
+	for _, item := range held.Items {
+		if item.Title == title {
+			return item, nil
+		}
+	}
+	return narrowedRow{}, fmt.Errorf("the listing holds %v, want %q among them", titlesListed(held), title)
+}
+
+// initializeFieldQuery registers the steps of the field query feature.
+func initializeFieldQuery(sc *godog.ScenarioContext) {
+	sc.Before(provisionWorld)
+	sc.After(retireWorld)
+	sc.Given(`^a running Gophenberg with the default content types$`, aRunningGophenbergWithTheDefaultContentTypes)
+	sc.Given(`^a signed in administrator$`, aSignedInAdministrator)
+	sc.Given(`^the group "([^"]*)" placed on "([^"]*)"$`, theGroupExists)
+	sc.Given(`^the "([^"]*)" field "([^"]*)" in "([^"]*)" with settings:$`, theFieldWithSettingsExists)
+	sc.Given(`^the post "([^"]*)"$`, thePostExists)
+	sc.Given(`^the post "([^"]*)" holding:$`, thePostHoldsTheValues)
+	sc.Given(`^the administrator publishes "([^"]*)"$`, theAdministratorPublishes)
+	sc.When(`^the administrator lists content where "([^"]*)" is "([^"]*)"$`, theAdministratorListsContentWhere)
+	sc.When(
+		`^the administrator lists content where "([^"]*)" is "([^"]*)" and "([^"]*)" again$`,
+		theAdministratorListsContentWhereTwice,
+	)
+	sc.When(
+		`^a visitor lists published "([^"]*)" where "([^"]*)" is "([^"]*)"$`,
+		aVisitorListsPublishedWhere,
+	)
+	sc.Then(`^the listing holds only "([^"]*)"$`, theListingHoldsOnly)
+	sc.Then(`^the listing holds (\d+) items$`, theListingHoldsItems)
+	sc.Then(`^the listed item "([^"]*)" carries "([^"]*)" under "([^"]*)"$`, theListedItemCarries)
+	sc.Then(`^the listed item "([^"]*)" carries nothing under "([^"]*)"$`, theListedItemCarriesNothingUnder)
+	sc.Then(`^the request is refused with the code "([^"]*)"$`, theRequestIsRefusedWithTheCode)
+}


### PR DESCRIPTION
Closes #106

## What

A content listing can now be narrowed to the items holding a value under a field, and the admin list can show those values as columns.

A field marked In list gets a column of its own in the admin table, reading its value the way its kind is written: a switch as Yes or No, a date in the reader's language, a choice by its label. A switch or a choice column also gets a filter above the table.

Both the admin listing and the public one read `field[<key>]` query parameters. Five kinds can be named this way: text, number, boolean, date and choice. The value is read as the kind the field declares, so a number is written plainly, a boolean is the word true or false, and a date is `YYYY-MM-DD`. Naming several fields means an item has to hold all of them. A field the type does not declare, a field of a kind that cannot be named, a value the kind cannot read, and the same field named twice each answer 400.

Under it, `core.content.fields` gains a GIN index with `jsonb_path_ops`, and the filtered listing runs as its own pair of statements rather than sharing one with the unfiltered listing, so it keeps its own query plan and can actually reach the index.

The theme kit reaches 0.12.0, where `listPosts` and a live collection both take a `fields` record. The server serves that kit version from this release.

## Why

Issue 106 asked for conditional logic and query by field. The logic half shipped in #163. This is the query half, which is what makes the In list flag that shipped with it mean anything.

## Testing

`make cover` at 6658 of 6659 backend statements, the one gap pre-existing on main and untouched here. `pnpm cover` at 100 percent statements, branches, functions and lines across 1061 frontend tests, plus 190 kit tests. `make lint`, `golangci-lint run --enable-only cyclop`, `go vet`, `tsc -b`, oxlint, eslint and knip all clean. `make e2e` at 66 passing. The docs site builds its 29 pages.

Twelve godog scenarios cover finding content by a value on both listings, including the four refusals, and prove the parameter is read only by the listings and not by term pages or archives.

The storage half is proved against a real database rather than a double: each of the five kinds narrows correctly, an unfiltered listing is left whole, and the values ride back on every listed row. I mutated the shipped SQL to check those tests bite. Inverting the filtered ORDER BY and inverting its status clause both passed the suite at first, so the ordering, paging, status and search arms of the new statements now have tests of their own, and I re-ran both mutations to confirm each is caught.

The index is reached rather than decorative. On 2000 rows, after six unfiltered executions so the plan cache had settled:

```
Aggregate
  ->  Bitmap Heap Scan on content p
        Recheck Cond: (fields @> '{"price": 1999}'::jsonb)
        Filter: (type = 'post'::text)
        ->  Bitmap Index Scan on content_field_values_idx
              Index Cond: (fields @> '{"price": 1999}'::jsonb)
```

The kit version bump, the served kit list and its pinned tests land in one commit, because CI builds the starter theme from the workspace on every run and the server would otherwise refuse the theme it just built. Verified: the built theme declares kit 0.12.0 and all 66 end to end tests pass against it.

## Notes for the reviewer

Two behaviours are worth knowing and are written into the content API reference. A field an item never held does not match, so asking for `field[on-sale]=false` skips items saved before that field existed rather than counting them as false. And a value a field's rules currently hide is still stored, so it still matches, even though the item's answer does not carry it.

Repeater rows carry no identity, so a filter cannot address one row rather than another. That is the same gap that shaped the freeze rules in #163 and it stays open here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Content lists now support columns for fields marked “In list.”
  - Switch and choice fields can be used as list filters, including combined filters.
  - Published and admin content APIs support filtering by text, number, boolean, date, and choice values.
  - Astro SDK list queries and live collections support field-based filters.
  - Listed field values appear in content-list results with appropriate formatting.

- **Documentation**
  - Added guidance for list columns, filters, custom fields, hidden values, and API filtering behavior.

- **Chores**
  - Added support for theme kit version 0.12.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->