### PR TITLE
Keep the language answer out of shared caches

### DIFF
--- a/docs/src/content/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/self-hosting/configuration.md
@@ -30,7 +30,7 @@ environment variables win over it.
 | `GOPHENBERG_THEME_PROXY_TIMEOUT` | No | `10s` | How long a running theme has to start answering one request |
 | `GOPHENBERG_CACHE_ASSET_MAX_AGE` | No | `1h` | How long a browser may keep a site stylesheet or icon. A proxy setting its own header wins |
 | `GOPHENBERG_CACHE_MEDIA_MAX_AGE` | No | `1h` | How long a browser may keep an uploaded file |
-| `GOPHENBERG_CACHE_CONTENT_SHARED_MAX_AGE` | No | `1m` | How long a shared cache may serve a content API answer, the language answer included |
+| `GOPHENBERG_CACHE_CONTENT_SHARED_MAX_AGE` | No | `1m` | How long a shared cache may serve a content API answer. The language answer is never shared, since it is resolved per reader |
 | `GOPHENBERG_CACHE_CONTENT_STALE_WHILE_REVALIDATE` | No | `5m` | How much longer that cache may serve the old answer while fetching a fresh one |
 | `GOPHENBERG_FEED_TITLE` | No | `Gophenberg` | The RSS channel title |
 | `GOPHENBERG_FEED_ITEMS` | No | `20` | How many posts the RSS feed carries |

--- a/internal/server/cache.go
+++ b/internal/server/cache.go
@@ -19,6 +19,9 @@ const DefaultContentSharedMaxAge = time.Minute
 // DefaultContentStaleWhileRevalidate is how long a shared cache may serve a stale read by default.
 const DefaultContentStaleWhileRevalidate = 5 * time.Minute
 
+// readerCacheControl is what an answer resolved for one reader carries, so no cache it does not belong to holds it.
+const readerCacheControl = "private, no-store"
+
 // CachePolicy is how long each kind of public answer may be kept. Zero applies the default.
 type CachePolicy struct {
 	// AssetMaxAge is how long a client may keep a site asset.

--- a/internal/server/cache_test.go
+++ b/internal/server/cache_test.go
@@ -90,14 +90,14 @@ func TestCacheWindowsCarryWhatTheDeploymentNamed(t *testing.T) {
 	}
 }
 
-func TestTheLocaleAnswerRidesTheContentWindow(t *testing.T) {
+func TestTheLocaleAnswerStaysOutOfSharedCaches(t *testing.T) {
 	t.Parallel()
 
 	handler := cachingServer(t, server.CachePolicy{ContentSharedMaxAge: 30 * time.Second})
 
 	held := cacheControlAt(t, handler, "/api/locale")
 
-	if held != "public, s-maxage=30, stale-while-revalidate=300" {
-		t.Errorf("Cache-Control = %q, want the locale answer to ride the content window", held)
+	if held != "private, no-store" {
+		t.Errorf("Cache-Control = %q, want the locale answer kept out of shared caches", held)
 	}
 }

--- a/internal/server/content.go
+++ b/internal/server/content.go
@@ -146,7 +146,7 @@ func newPublishedSummary(c content.Content) publishedSummary {
 	}
 }
 
-// contentHeaders returns middleware marking a response public and cacheable for the given window.
+// contentHeaders returns middleware allowing cross-origin reads and carrying the given cache directive.
 func contentHeaders(header string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -99,9 +99,9 @@ func NewServer(cfg Config) http.Handler {
 	router.With(ratelimit.Middleware(ratelimit.Config{TrustedProxies: cfg.TrustedProxies})).
 		Post("/api/auth/login", auth.Login)
 	router.Post("/api/auth/logout", auth.Logout)
+	router.With(contentHeaders(readerCacheControl)).Get("/api/locale", s.handleLocaleGet())
 	router.Group(func(public chi.Router) {
 		public.Use(contentHeaders(headers.content))
-		public.Get("/api/locale", s.handleLocaleGet())
 		public.Get("/api/content/v1", s.handleContentHandshake())
 		public.Get("/api/content/v1/items", s.handlePublishedList())
 		public.Get("/api/content/v1/resolve", s.handleContentResolve())

--- a/test/features/features/locale-resolution.feature
+++ b/test/features/features/locale-resolution.feature
@@ -33,6 +33,11 @@ Feature: The admin speaks the reader's language
     And the administrator asks for the locale
     Then the locale answered is "es-ES"
 
+  Scenario: The language answer is kept out of shared caches
+    Given no site default locale
+    When a visitor asks for the locale preferring "es-ES"
+    Then the answer is kept out of shared caches
+
   Scenario: An unknown locale is refused with a code
     Given a signed in administrator
     When the administrator sets their locale to "xx-XX"

--- a/test/features/steps_locale_test.go
+++ b/test/features/steps_locale_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/cucumber/godog"
 )
@@ -147,6 +148,22 @@ func theReaderSettingsStoreCannotBeRead(ctx context.Context) error {
 	return nil
 }
 
+// theAnswerIsKeptOutOfSharedCaches asserts the last answer forbids every cache it does not belong to.
+func theAnswerIsKeptOutOfSharedCaches(ctx context.Context) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	if w.answer == nil {
+		return fmt.Errorf("nothing was answered yet")
+	}
+	held := w.answer.header.Get("Cache-Control")
+	if !strings.Contains(held, "private") || !strings.Contains(held, "no-store") {
+		return fmt.Errorf("Cache-Control = %q, want the answer kept out of shared caches", held)
+	}
+	return nil
+}
+
 // initializeLocale registers the steps of the locale resolution feature.
 func initializeLocale(sc *godog.ScenarioContext) {
 	sc.Before(provisionWorld)
@@ -165,6 +182,7 @@ func initializeLocale(sc *godog.ScenarioContext) {
 	sc.When(`^the administrator sets the site locale to "([^"]*)"$`, theAdministratorSetsTheSiteLocaleTo)
 	sc.When(`^the administrator sets their locale to "([^"]*)"$`, theAdministratorSetsTheirLocaleTo)
 	sc.Then(`^the locale answered is "([^"]*)"$`, theLocaleAnsweredIs)
+	sc.Then(`^the answer is kept out of shared caches$`, theAnswerIsKeptOutOfSharedCaches)
 	sc.Then(`^the locale is answered without an error$`, theLocaleIsAnsweredWithoutError)
 	sc.Then(`^the request is refused with the code "([^"]*)"$`, theRequestIsRefusedWithTheCode)
 }


### PR DESCRIPTION
Closes #159

## What

`GET /api/locale` no longer rides the shared content cache window. It carries `Cache-Control: private, no-store`, so no cache it does not belong to holds it. The three other public routes keep the window they had.

The answer that route gives is resolved per reader. It reads the signed in reader's stored language through the session cookie, falls back to the site setting, and falls back again to the `Accept-Language` header. None of that was declared to caches, and no `Vary` header exists anywhere in this server, so a shared cache in front of a site could serve one reader's language to another in either direction.

## Why

Two people signed in behind the same shared cache saw each other's admin language. Every site behind a proxy or a content delivery network had this.

The issue offered two ways out, either dropping the window or declaring `Vary` on `Accept-Language` and `Cookie`. This takes the first. `Vary: Cookie` is correct on paper but collapses the hit rate to nothing once any unrelated cookie changes, and enough caches strip or ignore it that the leak would have survived while looking mended. The answer is a few dozen bytes and the admin holds it in memory anyway, so nothing is lost by keeping it out of shared caches entirely.

There is no `Vary` header in the fix either. With `no-store` nothing caches the answer, so declaring what it varies by would be decorative.

## Testing

The leak was pinned by a passing test named `TestTheLocaleAnswerRidesTheContentWindow`, so this reverses an earlier decision rather than filling a gap. That test is inverted, and a scenario now covers the same ground in the language feature. Both failed first, naming the header they found:

```
Cache-Control = "public, s-maxage=60, stale-while-revalidate=300", want the answer kept out of shared caches
```

The scenario needed the first step in the suite that reads a response header, though the world already recorded them. The existing table test still proves the content API keeps its own window, so the change is confined to the one route.

`make cover` at 6659 of 6660 backend statements, the one gap pre-existing on main. `make lint`, `golangci-lint run --enable-only cyclop` and `go vet` clean. `make e2e` at 66 passing. The docs site builds its 29 pages.

## Notes for the reviewer

The route keeps `Access-Control-Allow-Origin: *`, unchanged. That is not a way around the fix, because a wildcard forbids credentialed cross origin requests, so a script on another origin only ever receives the anonymous answer.

Two neighbouring problems came up while reading this and are filed on their own rather than folded in. Public answers carry their cache window even when they failed, because the middleware stamps the header before the handler runs. And authenticated answers carry no cache directive at all, so browsers apply their own guess to them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Locale responses are now marked `private, no-store` so reader-specific language results are not stored in shared caches.
  - Locale resolution remains individualized for each reader, preventing cached responses from being reused across visitors.

- **Documentation**
  - Updated self-hosting configuration guidance to clarify that language answers are never shared through the content cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->