### PR TITLE
Serve the fields a container holds

### DIFF
--- a/docs/src/content/docs/reference/content-api.md
+++ b/docs/src/content/docs/reference/content-api.md
@@ -78,6 +78,25 @@ field holds a list, and a choice says the same thing through its
 `multiple` setting instead. A `page_kind` of `archive` marks a type
 whose items answer with a term page, covered below.
 
+A Section or a Repeater lists the fields it holds under its own
+`fields`, the same shape again, as deep as the group declares. The key
+is absent on a field holding none, so a reader can tell a container
+from a plain field by asking whether it lists any.
+
+```json
+{
+  "key": "team",
+  "label": "Team",
+  "kind": "repeater",
+  "many": false,
+  "required": false,
+  "fields": [
+    { "key": "name", "label": "Name", "kind": "text", "many": false, "required": true },
+    { "key": "role", "label": "Role", "kind": "text", "many": false, "required": false }
+  ]
+}
+```
+
 ## Listing items
 
 ```sh

--- a/docs/src/content/docs/reference/content-api.md
+++ b/docs/src/content/docs/reference/content-api.md
@@ -79,9 +79,9 @@ field holds a list, and a choice says the same thing through its
 whose items answer with a term page, covered below.
 
 A Section or a Repeater lists the fields it holds under its own
-`fields`, the same shape again, as deep as the group declares. The key
-is absent on a field holding none, so a reader can tell a container
-from a plain field by asking whether it lists any.
+`fields`, the same shape again, as deep as the group declares. Read
+`kind` to tell a container from a plain field, since the key is absent
+on any field holding none, a container nobody has filled in included.
 
 ```json
 {

--- a/internal/postgres/handshake_golden_test.go
+++ b/internal/postgres/handshake_golden_test.go
@@ -11,12 +11,27 @@ import (
 
 // handshakeField mirrors the served field shape a theme reads from the public handshake.
 type handshakeField struct {
-	Key       string `json:"key"`
-	Label     string `json:"label"`
-	Kind      string `json:"kind"`
-	RelatesTo string `json:"relates_to,omitempty"`
-	Many      bool   `json:"many"`
-	Required  bool   `json:"required"`
+	Key       string           `json:"key"`
+	Label     string           `json:"label"`
+	Kind      string           `json:"kind"`
+	RelatesTo string           `json:"relates_to,omitempty"`
+	Many      bool             `json:"many"`
+	Required  bool             `json:"required"`
+	Settings  map[string]any   `json:"settings,omitempty"`
+	Fields    []handshakeField `json:"fields,omitempty"`
+}
+
+// handshakeFields returns the served view of field definitions, however deep they run.
+func handshakeFields(held []content.Field) []handshakeField {
+	served := make([]handshakeField, len(held))
+	for i, f := range held {
+		served[i] = handshakeField{
+			Key: f.Key, Label: f.Label, Kind: string(f.Kind),
+			RelatesTo: f.RelatesTo, Many: f.Many, Required: f.Required,
+			Settings: f.Settings, Fields: handshakeFields(f.Fields),
+		}
+	}
+	return served
 }
 
 // handshakeFieldsOf returns the served view of a stored type's fields.
@@ -26,14 +41,7 @@ func handshakeFieldsOf(t *testing.T, listed []content.Type, typeKey string) stri
 		if held.Key != typeKey {
 			continue
 		}
-		served := make([]handshakeField, len(held.Fields))
-		for i, f := range held.Fields {
-			served[i] = handshakeField{
-				Key: f.Key, Label: f.Label, Kind: string(f.Kind),
-				RelatesTo: f.RelatesTo, Many: f.Many, Required: f.Required,
-			}
-		}
-		raw, err := json.Marshal(served)
+		raw, err := json.Marshal(handshakeFields(held.Fields))
 		if err != nil {
 			t.Fatalf("marshaling the served fields of %s: %v", typeKey, err)
 		}
@@ -41,6 +49,16 @@ func handshakeFieldsOf(t *testing.T, listed []content.Type, typeKey string) stri
 	}
 	t.Fatalf("type %s is not listed", typeKey)
 	return ""
+}
+
+// mustField returns the field the domain settles on, failing the test when it refuses one.
+func mustField(t *testing.T, seed content.Field) content.Field {
+	t.Helper()
+	built, err := content.NewField(seed)
+	if err != nil {
+		t.Fatalf("NewField(%s) error = %v, want nil", seed.Key, err)
+	}
+	return built
 }
 
 func TestStoredFieldsServeTheGoldenHandshakeShape(t *testing.T) {
@@ -71,6 +89,18 @@ func TestStoredFieldsServeTheGoldenHandshakeShape(t *testing.T) {
 		}
 	}
 
+	crew, err := store.CreateField(ctx, mustField(t, content.Field{
+		TypeKey: "book", Key: "crew", Label: "Crew", Kind: content.FieldKindRepeater,
+	}))
+	if err != nil {
+		t.Fatalf("CreateField(crew) error = %v, want nil", err)
+	}
+	if _, err := store.CreateSubField(ctx, crew.ID, mustField(t, content.Field{
+		Key: "name", Label: "Name", Kind: content.FieldKindText, Required: true,
+	})); err != nil {
+		t.Fatalf("CreateSubField(name) error = %v, want nil", err)
+	}
+
 	listed, err := store.List(ctx)
 
 	if err != nil {
@@ -81,7 +111,9 @@ func TestStoredFieldsServeTheGoldenHandshakeShape(t *testing.T) {
 	if got := handshakeFieldsOf(t, listed, "car"); got != carGolden {
 		t.Errorf("car fields = %s, want the golden %s", got, carGolden)
 	}
-	bookGolden := `[{"key":"pages","label":"Pages","kind":"number","many":false,"required":false}]`
+	bookGolden := `[{"key":"pages","label":"Pages","kind":"number","many":false,"required":false},` +
+		`{"key":"crew","label":"Crew","kind":"repeater","many":false,"required":false,` +
+		`"fields":[{"key":"name","label":"Name","kind":"text","many":false,"required":true}]}]`
 	if got := handshakeFieldsOf(t, listed, "book"); got != bookGolden {
 		t.Errorf("book fields = %s, want the golden %s", got, bookGolden)
 	}

--- a/internal/server/content.go
+++ b/internal/server/content.go
@@ -60,6 +60,7 @@ type servedField struct {
 	Many      bool           `json:"many"`
 	Required  bool           `json:"required"`
 	Settings  map[string]any `json:"settings,omitempty"`
+	Fields    []servedField  `json:"fields,omitempty"`
 }
 
 // newServedType returns the public view of a content type.
@@ -72,14 +73,14 @@ func newServedType(t content.Type) servedType {
 		Hierarchical: t.Hierarchical,
 		PageKind:     string(t.PageKind),
 		Default:      t.Default,
-		Fields:       servedFields(t),
+		Fields:       servedFields(t.Fields),
 	}
 }
 
-// servedFields returns the type's field definitions as a public reader sees them.
-func servedFields(t content.Type) []servedField {
-	fields := make([]servedField, len(t.Fields))
-	for i, f := range t.Fields {
+// servedFields returns field definitions as a public reader sees them, however deep they run.
+func servedFields(held []content.Field) []servedField {
+	fields := make([]servedField, len(held))
+	for i, f := range held {
 		fields[i] = servedField{
 			Key:       f.Key,
 			Label:     f.Label,
@@ -88,6 +89,7 @@ func servedFields(t content.Type) []servedField {
 			Many:      f.Many,
 			Required:  f.Required,
 			Settings:  f.Settings,
+			Fields:    servedFields(f.Fields),
 		}
 	}
 	return fields

--- a/internal/server/content_test.go
+++ b/internal/server/content_test.go
@@ -72,7 +72,7 @@ func TestContentAPIAnswersTheHandshakeWithoutASession(t *testing.T) {
 	if !strings.Contains(body, `"api":0`) {
 		t.Errorf("body = %q, want the api generation", body)
 	}
-	if !strings.Contains(body, `"kit":["0.9.0","0.10.0","0.11.0","0.12.0"]`) {
+	if !strings.Contains(body, `"kit":["0.9.0","0.10.0","0.11.0","0.12.0","0.13.0"]`) {
 		t.Errorf("body = %q, want the kit versions served", body)
 	}
 	if !strings.Contains(body, `"gophenberg"`) {
@@ -341,7 +341,7 @@ func TestContentAPIAdvertisesTheTypesItServes(t *testing.T) {
 	if handshake.API != 0 {
 		t.Errorf("api = %d, want 0", handshake.API)
 	}
-	if !slices.Equal(handshake.Kit, []string{"0.9.0", "0.10.0", "0.11.0", "0.12.0"}) {
+	if !slices.Equal(handshake.Kit, []string{"0.9.0", "0.10.0", "0.11.0", "0.12.0", "0.13.0"}) {
 		t.Errorf("kit = %v, want the kit versions this release serves", handshake.Kit)
 	}
 	if len(handshake.Types) != 1 {
@@ -353,6 +353,69 @@ func TestContentAPIAdvertisesTheTypesItServes(t *testing.T) {
 	}
 	if listed.PluralName != "Posts" || listed.PageKind != string(content.PageKindSingle) {
 		t.Errorf("type = %+v, want its labels and page kind", listed)
+	}
+}
+
+func TestContentAPIServesATypeWithoutFieldsAsAnEmptyList(t *testing.T) {
+	t.Parallel()
+
+	handler := contentServer(t)
+
+	recorder := getContent(t, handler, "/api/content/v1")
+
+	if !strings.Contains(recorder.Body.String(), `"fields":[]`) {
+		t.Errorf("body = %s, want a type carrying no fields to serve an empty list", recorder.Body)
+	}
+}
+
+func TestContentAPIServesTheFieldsAContainerHolds(t *testing.T) {
+	t.Parallel()
+
+	users := newFakeUserStore()
+	types := newFakeTypeStore()
+	crew := postType()
+	crew.Fields = []content.Field{{
+		Key: "crew", Label: "Crew", Kind: content.FieldKindRepeater,
+		Fields: []content.Field{
+			{Key: "name", Label: "Name", Kind: content.FieldKindText},
+			{Key: "role", Label: "Role", Kind: content.FieldKindChoice, Required: true},
+		},
+	}}
+	types.types = []content.Type{crew}
+	handler := server.NewServer(server.Config{Users: users, Content: newFakePostStore(), Types: types})
+
+	recorder := getContent(t, handler, "/api/content/v1")
+
+	var handshake struct {
+		Types []struct {
+			Fields []struct {
+				Key      string `json:"key"`
+				Kind     string `json:"kind"`
+				Required bool   `json:"required"`
+				Fields   []struct {
+					Key      string `json:"key"`
+					Label    string `json:"label"`
+					Kind     string `json:"kind"`
+					Required bool   `json:"required"`
+				} `json:"fields"`
+			} `json:"fields"`
+		} `json:"types"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &handshake); err != nil {
+		t.Fatalf("reading the handshake: %v", err)
+	}
+	if len(handshake.Types) != 1 || len(handshake.Types[0].Fields) != 1 {
+		t.Fatalf("types = %+v, want the one type carrying the container", handshake.Types)
+	}
+	held := handshake.Types[0].Fields[0]
+	if len(held.Fields) != 2 {
+		t.Fatalf("the container carries %d fields, want the two it holds", len(held.Fields))
+	}
+	if held.Fields[0].Key != "name" || held.Fields[0].Kind != string(content.FieldKindText) {
+		t.Errorf("the first held field = %+v, want the text it declares", held.Fields[0])
+	}
+	if held.Fields[1].Label != "Role" || !held.Fields[1].Required {
+		t.Errorf("the second held field = %+v, want its label and that it is required", held.Fields[1])
 	}
 }
 

--- a/internal/themehost/kit.go
+++ b/internal/themehost/kit.go
@@ -9,7 +9,7 @@ import (
 )
 
 // servedKits names the theme kit versions this release serves, oldest first.
-var servedKits = []string{"0.9.0", "0.10.0", "0.11.0", "0.12.0"}
+var servedKits = []string{"0.9.0", "0.10.0", "0.11.0", "0.12.0", "0.13.0"}
 
 // ServedKits returns the theme kit versions this release serves.
 func ServedKits() []string {

--- a/internal/themehost/kit_test.go
+++ b/internal/themehost/kit_test.go
@@ -17,10 +17,10 @@ func TestServedKitsNamesWhatThisReleaseServes(t *testing.T) {
 
 	served := themehost.ServedKits()
 
-	if !slices.Equal(served, []string{"0.9.0", "0.10.0", "0.11.0", "0.12.0"}) {
+	if !slices.Equal(served, []string{"0.9.0", "0.10.0", "0.11.0", "0.12.0", "0.13.0"}) {
 		t.Errorf("ServedKits() = %v, want the kit versions this release serves", served)
 	}
-	if themehost.NewestKit() != "0.12.0" {
+	if themehost.NewestKit() != "0.13.0" {
 		t.Errorf("NewestKit() = %q, want the newest of them", themehost.NewestKit())
 	}
 }
@@ -28,7 +28,7 @@ func TestServedKitsNamesWhatThisReleaseServes(t *testing.T) {
 func TestAThemeOnEitherServedKitIsAccepted(t *testing.T) {
 	t.Parallel()
 
-	for _, declared := range []string{"0.9.0", "0.10.0", "0.11.0", "0.12.0"} {
+	for _, declared := range []string{"0.9.0", "0.10.0", "0.11.0", "0.12.0", "0.13.0"} {
 		if !themehost.ServesKit(declared) {
 			t.Errorf("ServesKit(%q) = false, want a theme on a served kit accepted", declared)
 		}
@@ -45,7 +45,7 @@ func TestServedKitsCannotBeChangedByACaller(t *testing.T) {
 
 	themehost.ServedKits()[0] = "9.9.9"
 
-	if themehost.NewestKit() != "0.12.0" {
+	if themehost.NewestKit() != "0.13.0" {
 		t.Errorf("NewestKit() = %q after a caller wrote to the returned slice", themehost.NewestKit())
 	}
 }

--- a/sdk/astro/CHANGELOG.md
+++ b/sdk/astro/CHANGELOG.md
@@ -11,6 +11,12 @@ npm-style tag stays invisible to the Go toolchain, unlike a
 `sdk/astro/vX.Y.Z` tag naming the directory as a module. Versions
 through 0.8.0 shipped in step with Gophenberg under its `vX.Y.Z` tags.
 
+## Unreleased
+
+### Added
+
+- `ContentTypeField` carries the `fields` a section or a repeater holds.
+
 ## [0.12.0] - 2026-09-05
 
 ### Added

--- a/sdk/astro/content.ts
+++ b/sdk/astro/content.ts
@@ -55,6 +55,7 @@ export interface ContentTypeField {
 	many: boolean
 	required: boolean
 	settings?: Record<string, unknown>
+	fields?: ContentTypeField[]
 }
 
 /** A content type as the handshake advertises it. */

--- a/sdk/astro/package.json
+++ b/sdk/astro/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gophenberg/astro",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "Build a Gophenberg theme in Astro: routes, block rendering, and the theme contract.",

--- a/sdk/astro/test/client.test.ts
+++ b/sdk/astro/test/client.test.ts
@@ -52,6 +52,19 @@ test('a type carries the settings an operator set on its fields', () => {
 	expect(field.settings?.step).toBe(5)
 })
 
+test('a container carries the fields it holds', () => {
+	const field: ContentTypeField = {
+		key: 'crew',
+		label: 'Crew',
+		kind: 'repeater',
+		many: false,
+		required: false,
+		fields: [{ key: 'name', label: 'Name', kind: 'text', many: false, required: false }],
+	}
+
+	expect(field.fields?.[0].key).toBe('name')
+})
+
 test('a field carrying no settings leaves the key absent', () => {
 	const field: ContentTypeField = {
 		key: 'subtitle',


### PR DESCRIPTION
Closes #152

## What

A Section or a Repeater now lists the fields it holds on the public type metadata, under its own `fields`, the same shape again as deep as the group declares. The key is absent on a field holding none, so a reader can tell a container from a plain field by asking whether it lists any.

The theme kit types it, so `ContentTypeField` carries `fields`. That reaches the kit at 0.13.0, which this release serves.

Nothing new is read from the database. `grownField` has always built the whole tree into the type at load time, and the public shape was discarding it below the top level. All four places that build a public type inherit the nesting for free, so the handshake, a resolved item, a term page and an archive all carry it.

## Why

The last release told theme authors how to read a Section and a Repeater and pointed them at this reference for the shapes, while the public metadata described only the top level. A theme received the values a container holds with no way to tell what its child keys, kinds or required flags meant. The administrative API has carried the whole tree all along, so this is the public half catching up.

## Testing

The recursion mirrors the administrative `newFieldResponse`, which has worked this way since containers landed.

One regression came out of writing it. My first version returned nil for an empty list, which turned the type level `"fields": []` into `"fields": null`, and the kit types that member as a non-optional array, so `type.fields.map(...)` would have thrown in every theme. A test reproduced it before the fix, and `omitempty` on the nested member already covers the empty case without a guard.

`handshakeField` in the storage golden test carries a docblock saying it mirrors the served public shape, but it lacked `settings` before this change and would have lacked `fields` after, so it could not catch the drift it exists for. It now carries both, recurses, and the test seeds a repeater with a child so the golden exercises nesting rather than asserting a flat list.

The kit bump, the served kit list and its four pinned tests land in one commit, because CI builds the starter theme from the workspace and the server would otherwise refuse the theme it just built. Verified rather than assumed: the built theme declares kit 0.13.0 and all 66 end to end tests pass against it.

`make cover` at 6659 of 6660 backend statements, the one gap pre-existing on main. 1063 frontend and 191 kit tests. `make lint`, `golangci-lint run --enable-only cyclop`, eslint and oxlint clean. The docs site builds its 29 pages.

## Notes for the reviewer

Kit 0.13.0 rather than a patch, because 0.10.0 was minted for adding `settings` to this same interface and this is the identical shape of change. A theme reading `field.fields` against an older server would otherwise see undefined and render nothing, which is exactly what the kit version exists to refuse.

A resolved item's ETag is computed over the whole served answer, so it moves for any type that declares a container. That is correct, since the answer genuinely changed, and it means one revalidation per cached address after an update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Content type metadata now exposes nested fields for sections and repeaters, including recursively nested structures.
  - Astro SDK content type fields support accessing nested child fields.
  - Added Astro SDK version 0.13.0.

- **Documentation**
  - Updated Content API reference documentation with nested-field details and a repeater example.
  - Added the change to the Astro SDK changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->