### PR TITLE
Move a section or repeater together with its fields

### DIFF
--- a/internal/postgres/db/queries.sql.go
+++ b/internal/postgres/db/queries.sql.go
@@ -1899,6 +1899,27 @@ func (q *Queries) MoveContentField(ctx context.Context, arg MoveContentFieldPara
 	return i, err
 }
 
+const moveContentFieldDescendants = `-- name: MoveContentFieldDescendants :exec
+WITH RECURSIVE inside AS (
+    SELECT held.id FROM core.content_fields AS held WHERE held.parent_field_id = $2::integer
+    UNION ALL
+    SELECT below.id FROM core.content_fields AS below JOIN inside ON below.parent_field_id = inside.id
+)
+UPDATE core.content_fields AS moved
+SET group_id = $1
+WHERE moved.id IN (SELECT inside.id FROM inside)
+`
+
+type MoveContentFieldDescendantsParams struct {
+	ToGroup int32
+	ID      int32
+}
+
+func (q *Queries) MoveContentFieldDescendants(ctx context.Context, arg MoveContentFieldDescendantsParams) error {
+	_, err := q.db.Exec(ctx, moveContentFieldDescendants, arg.ToGroup, arg.ID)
+	return err
+}
+
 const moveDescendants = `-- name: MoveDescendants :exec
 WITH RECURSIVE moved AS (
     SELECT c.id, $3::text AS path

--- a/internal/postgres/field_parents_repair_test.go
+++ b/internal/postgres/field_parents_repair_test.go
@@ -4,10 +4,143 @@ package postgres_test
 
 import (
 	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gopherium/gophenberg/internal/content"
 	"github.com/gopherium/gophenberg/internal/postgres"
 )
+
+// plantTwin stores a field row of the kind under the parent, as a move that left fields behind could.
+func plantTwin(t *testing.T, pool *pgxpool.Pool, groupID, parentID int, key, kind string, depth int) int {
+	t.Helper()
+	var relatesTo *string
+	if kind == string(content.FieldKindRelation) {
+		category := "category"
+		relatesTo = &category
+	}
+	var id int
+	err := pool.QueryRow(t.Context(),
+		`INSERT INTO core.content_fields
+			(group_id, parent_field_id, key, label, kind, relates_to, many, depth, created_at, updated_at)
+		VALUES ($1, $2, $3, $3, $4, $5, $6, $7, now(), now())
+		RETURNING id`,
+		groupID, parentID, key, kind, relatesTo, relatesTo != nil, depth).Scan(&id)
+	if err != nil {
+		t.Fatalf("planting %s under field %d: %v, want nil", key, parentID, err)
+	}
+	return id
+}
+
+// fieldsKeyed counts the field rows carrying the key.
+func fieldsKeyed(t *testing.T, pool *pgxpool.Pool, key string) int {
+	t.Helper()
+	var held int
+	if err := pool.QueryRow(t.Context(),
+		`SELECT count(*) FROM core.content_fields WHERE key = $1`, key).Scan(&held); err != nil {
+		t.Fatalf("counting the fields keyed %s: %v, want nil", key, err)
+	}
+	return held
+}
+
+// rerunRepair rolls the schema back to before the repair and migrates forward again.
+func rerunRepair(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	url := pool.Config().ConnString()
+	if err := postgres.MigrateDownTo(t.Context(), url, 23); err != nil {
+		t.Fatalf("rolling back to before the repair: %v, want nil", err)
+	}
+	if err := postgres.Migrate(t.Context(), url); err != nil {
+		t.Fatalf("Migrate() error = %v, want nil", err)
+	}
+}
+
+func TestMigrationsKeepTheFieldsInsideAContainerLeftTwice(t *testing.T) {
+	t.Parallel()
+
+	store, _, pool := typedStore(t)
+	storeType(t, store, "car")
+	source, err := store.CreateGroup(t.Context(), content.Group{Title: "Details", Location: locationOf("car")})
+	if err != nil {
+		t.Fatalf("CreateGroup(Details) error = %v, want nil", err)
+	}
+	author, err := store.CreateFieldInGroup(
+		t.Context(), source.ID, fieldOn(t, "", "author", content.FieldKindSection, ""))
+	if err != nil {
+		t.Fatalf("CreateFieldInGroup(author) error = %v, want nil", err)
+	}
+	profile := declaredInside(t, store, author, "profile", content.FieldKindSection)
+	bio := declaredInside(t, store, profile, "bio", content.FieldKindText)
+	landing, err := store.CreateGroup(t.Context(), content.Group{Title: "Elsewhere", Location: locationOf("car")})
+	if err != nil {
+		t.Fatalf("CreateGroup(Elsewhere) error = %v, want nil", err)
+	}
+	if _, err := pool.Exec(t.Context(),
+		`UPDATE core.content_fields SET group_id = $1 WHERE id = $2`, landing.ID, author.ID); err != nil {
+		t.Fatalf("moving the section alone, as the old move did: %v, want nil", err)
+	}
+	twin := plantTwin(t, pool, landing.ID, author.ID, "profile", string(content.FieldKindSection), 1)
+	plantTwin(t, pool, landing.ID, twin, "title", string(content.FieldKindText), 2)
+
+	rerunRepair(t, pool)
+
+	for _, key := range []string{"bio", "title"} {
+		if held := fieldsKeyed(t, pool, key); held != 1 {
+			t.Errorf("%d fields keyed %s, want the one declared inside a profile kept", held, key)
+		}
+	}
+	if held := fieldsKeyed(t, pool, "profile"); held != 2 {
+		t.Errorf("%d fields keyed profile, want both twins left for the editor to settle", held)
+	}
+	if held := groupOfField(t, pool, bio.ID); held != landing.ID {
+		t.Errorf("bio sits in group %d, want it carried into %d with the section at the top", held, landing.ID)
+	}
+	if held := groupOfField(t, pool, profile.ID); held != source.ID {
+		t.Errorf("the twin left behind sits in group %d, want it left alone in %d", held, source.ID)
+	}
+}
+
+func TestMigrationsKeepWhatARelationLeftTwicePointsAt(t *testing.T) {
+	t.Parallel()
+
+	store, author, pool := relatingStore(t)
+	rowsPointing(t, pool)
+	news := publishItem(t, store, storedCategory(t, store, "News", author))
+	post := mustCreate(t, store, "Filed", author)
+	post.Fields = rowsFiledUnder(news.ID)
+	version := post.UpdatedAt
+	post.UpdatedAt = time.Now().UTC()
+	filed, err := store.Update(t.Context(), post, version, nil, 0)
+	if err != nil {
+		t.Fatalf("filing the post through the row: %v, want nil", err)
+	}
+	publishItem(t, store, filed)
+	var team int
+	if err := pool.QueryRow(t.Context(),
+		`SELECT id FROM core.content_fields WHERE key = 'team' AND parent_field_id IS NULL`).Scan(&team); err != nil {
+		t.Fatalf("reading the repeater: %v, want nil", err)
+	}
+	landing, err := postgres.NewTypeStore(pool).CreateGroup(
+		t.Context(), content.Group{Title: "Elsewhere", Location: locationOf("post")})
+	if err != nil {
+		t.Fatalf("CreateGroup(Elsewhere) error = %v, want nil", err)
+	}
+	if _, err := pool.Exec(t.Context(),
+		`UPDATE core.content_fields SET group_id = $1 WHERE id = $2`, landing.ID, team); err != nil {
+		t.Fatalf("moving the repeater alone, as the old move did: %v, want nil", err)
+	}
+	plantTwin(t, pool, landing.ID, team, "filed", string(content.FieldKindRelation), 1)
+
+	rerunRepair(t, pool)
+
+	if pointing := pointedAtBy(t, store, news.ID); pointing != 1 {
+		t.Errorf("%d items point at the category, want the filed post still found", pointing)
+	}
+	if held := fieldsKeyed(t, pool, "filed"); held != 2 {
+		t.Errorf("%d fields keyed filed, want both twins left for the editor to settle", held)
+	}
+}
 
 func TestMigrationsCarrySubFieldsIntoTheirContainersGroup(t *testing.T) {
 	t.Parallel()
@@ -38,14 +171,8 @@ func TestMigrationsCarrySubFieldsIntoTheirContainersGroup(t *testing.T) {
 	if planted != nil {
 		t.Fatalf("planting a second name under the moved section: %v, want nil", planted)
 	}
-	url := pool.Config().ConnString()
-	if err := postgres.MigrateDownTo(t.Context(), url, 23); err != nil {
-		t.Fatalf("rolling back to before the repair: %v, want nil", err)
-	}
 
-	if err := postgres.Migrate(t.Context(), url); err != nil {
-		t.Fatalf("Migrate() error = %v, want nil", err)
-	}
+	rerunRepair(t, pool)
 
 	for _, carried := range []struct {
 		what string
@@ -55,24 +182,13 @@ func TestMigrationsCarrySubFieldsIntoTheirContainersGroup(t *testing.T) {
 			t.Errorf("%s sits in group %d, want it carried into %d with its section", carried.what, held, landing.ID)
 		}
 	}
-	var twins int
-	if err := pool.QueryRow(t.Context(),
-		`SELECT count(*) FROM core.content_fields WHERE parent_field_id = $1 AND key = 'name'`,
-		section.ID).Scan(&twins); err != nil {
-		t.Fatalf("counting the fields named name under the section: %v, want nil", err)
+	if held := fieldsKeyed(t, pool, "name"); held != 2 {
+		t.Errorf("%d fields named name, want both twins left for the editor to settle", held)
 	}
-	if twins != 1 {
-		t.Errorf("the section holds %d fields named name, want the twins collapsed to one", twins)
+	if held := groupOfField(t, pool, name.ID); held != source.ID {
+		t.Errorf("the twin left behind sits in group %d, want it left alone in %d", held, source.ID)
 	}
 	if held := groupOfField(t, pool, twin); held != landing.ID {
-		t.Errorf("the surviving name sits in group %d, want the one already in %d kept", held, landing.ID)
-	}
-	var stale int
-	if err := pool.QueryRow(t.Context(),
-		`SELECT count(*) FROM core.content_fields WHERE id = $1`, name.ID).Scan(&stale); err != nil {
-		t.Fatalf("looking for the stale name: %v, want nil", err)
-	}
-	if stale != 0 {
-		t.Errorf("the stale name still exists, want the twin left in the old group taken away")
+		t.Errorf("the twin added later sits in group %d, want it left alone in %d", held, landing.ID)
 	}
 }

--- a/internal/postgres/field_parents_repair_test.go
+++ b/internal/postgres/field_parents_repair_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gopherium/gophenberg/internal/postgres"
 )
 
-// plantTwin stores a field row of the kind under the parent, as a move that left fields behind could.
+// plantTwin stores a field row of the kind under the parent in the group and returns its identity.
 func plantTwin(t *testing.T, pool *pgxpool.Pool, groupID, parentID int, key, kind string, depth int) int {
 	t.Helper()
 	var relatesTo *string
@@ -44,7 +44,7 @@ func fieldsKeyed(t *testing.T, pool *pgxpool.Pool, key string) int {
 	return held
 }
 
-// rerunRepair rolls the schema back to before the repair and migrates forward again.
+// rerunRepair runs the repair migration again on the database behind the pool.
 func rerunRepair(t *testing.T, pool *pgxpool.Pool) {
 	t.Helper()
 	url := pool.Config().ConnString()

--- a/internal/postgres/field_parents_repair_test.go
+++ b/internal/postgres/field_parents_repair_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres_test
+
+import (
+	"testing"
+
+	"github.com/gopherium/gophenberg/internal/content"
+	"github.com/gopherium/gophenberg/internal/postgres"
+)
+
+func TestMigrationsCarrySubFieldsIntoTheirContainersGroup(t *testing.T) {
+	t.Parallel()
+
+	store, _, pool := typedStore(t)
+	storeType(t, store, "car")
+	source, err := store.CreateGroup(t.Context(), content.Group{Title: "Details", Location: locationOf("car")})
+	if err != nil {
+		t.Fatalf("CreateGroup(Details) error = %v, want nil", err)
+	}
+	section, err := store.CreateFieldInGroup(
+		t.Context(), source.ID, fieldOn(t, "", "author", content.FieldKindSection, ""))
+	if err != nil {
+		t.Fatalf("CreateFieldInGroup(author) error = %v, want nil", err)
+	}
+	name := declaredInside(t, store, section, "name", content.FieldKindText)
+	rows := declaredInside(t, store, section, "rows", content.FieldKindRepeater)
+	title := declaredInside(t, store, rows, "title", content.FieldKindText)
+	landing, err := store.CreateGroup(t.Context(), content.Group{Title: "Elsewhere", Location: locationOf("car")})
+	if err != nil {
+		t.Fatalf("CreateGroup(Elsewhere) error = %v, want nil", err)
+	}
+	if _, err := pool.Exec(t.Context(),
+		`UPDATE core.content_fields SET group_id = $1 WHERE id = $2`, landing.ID, section.ID); err != nil {
+		t.Fatalf("moving the section alone, as the old move did: %v, want nil", err)
+	}
+	twin, planted := plantSubField(t, pool, landing.ID, &section.ID, "name")
+	if planted != nil {
+		t.Fatalf("planting a second name under the moved section: %v, want nil", planted)
+	}
+	url := pool.Config().ConnString()
+	if err := postgres.MigrateDownTo(t.Context(), url, 23); err != nil {
+		t.Fatalf("rolling back to before the repair: %v, want nil", err)
+	}
+
+	if err := postgres.Migrate(t.Context(), url); err != nil {
+		t.Fatalf("Migrate() error = %v, want nil", err)
+	}
+
+	for _, carried := range []struct {
+		what string
+		id   int
+	}{{"the repeater", rows.ID}, {"the field inside the repeater", title.ID}} {
+		if held := groupOfField(t, pool, carried.id); held != landing.ID {
+			t.Errorf("%s sits in group %d, want it carried into %d with its section", carried.what, held, landing.ID)
+		}
+	}
+	var twins int
+	if err := pool.QueryRow(t.Context(),
+		`SELECT count(*) FROM core.content_fields WHERE parent_field_id = $1 AND key = 'name'`,
+		section.ID).Scan(&twins); err != nil {
+		t.Fatalf("counting the fields named name under the section: %v, want nil", err)
+	}
+	if twins != 1 {
+		t.Errorf("the section holds %d fields named name, want the twins collapsed to one", twins)
+	}
+	if held := groupOfField(t, pool, twin); held != landing.ID {
+		t.Errorf("the surviving name sits in group %d, want the one already in %d kept", held, landing.ID)
+	}
+	var stale int
+	if err := pool.QueryRow(t.Context(),
+		`SELECT count(*) FROM core.content_fields WHERE id = $1`, name.ID).Scan(&stale); err != nil {
+		t.Fatalf("looking for the stale name: %v, want nil", err)
+	}
+	if stale != 0 {
+		t.Errorf("the stale name still exists, want the twin left in the old group taken away")
+	}
+}

--- a/internal/postgres/field_parents_test.go
+++ b/internal/postgres/field_parents_test.go
@@ -126,6 +126,134 @@ func TestMovingATopFieldLeavesASubFieldSharingItsKey(t *testing.T) {
 	}
 }
 
+// declaredInside declares a sub field of the kind under the parent through the store and returns it.
+func declaredInside(
+	t *testing.T, store *postgres.TypeStore, parent content.Field, key string, kind content.FieldKind,
+) content.Field {
+	t.Helper()
+	built, err := content.NewSubField(content.Field{Key: key, Label: key, Kind: kind}, parent.Kind)
+	if err != nil {
+		t.Fatalf("NewSubField(%s) error = %v, want nil", key, err)
+	}
+	stored, err := store.CreateSubField(t.Context(), parent.ID, built)
+	if err != nil {
+		t.Fatalf("CreateSubField(%s) error = %v, want nil", key, err)
+	}
+	return stored
+}
+
+// groupOfField returns the group the field row sits in.
+func groupOfField(t *testing.T, pool *pgxpool.Pool, id int) int {
+	t.Helper()
+	var held int
+	if err := pool.QueryRow(t.Context(),
+		`SELECT group_id FROM core.content_fields WHERE id = $1`, id).Scan(&held); err != nil {
+		t.Fatalf("reading the group of field %d: %v, want nil", id, err)
+	}
+	return held
+}
+
+func TestMovingASectionCarriesASubFieldTwoLevelsDown(t *testing.T) {
+	t.Parallel()
+
+	store, _, pool := typedStore(t)
+	storeType(t, store, "car")
+	source, err := store.CreateGroup(t.Context(), content.Group{Title: "Details", Location: locationOf("car")})
+	if err != nil {
+		t.Fatalf("CreateGroup(Details) error = %v, want nil", err)
+	}
+	section, err := store.CreateFieldInGroup(
+		t.Context(), source.ID, fieldOn(t, "", "author", content.FieldKindSection, ""))
+	if err != nil {
+		t.Fatalf("CreateFieldInGroup(author) error = %v, want nil", err)
+	}
+	rows := declaredInside(t, store, section, "rows", content.FieldKindRepeater)
+	title := declaredInside(t, store, rows, "title", content.FieldKindText)
+	landing, err := store.CreateGroup(t.Context(), content.Group{Title: "Elsewhere", Location: locationOf("car")})
+	if err != nil {
+		t.Fatalf("CreateGroup(Elsewhere) error = %v, want nil", err)
+	}
+
+	if _, err := store.MoveField(t.Context(), source.ID, "author", landing.ID); err != nil {
+		t.Fatalf("MoveField(author) error = %v, want nil", err)
+	}
+
+	if held := groupOfField(t, pool, title.ID); held != landing.ID {
+		t.Errorf("the field two levels down sits in group %d, want it carried into %d", held, landing.ID)
+	}
+}
+
+// movedSection holds a section declared in one group and moved into another, with the sub field it carries.
+type movedSection struct {
+	source, landing content.Group
+	section, sub    content.Field
+}
+
+// moveSection declares a section holding one text sub field in a group and moves it into a second group.
+func moveSection(t *testing.T, store *postgres.TypeStore) movedSection {
+	t.Helper()
+	source, err := store.CreateGroup(t.Context(), content.Group{Title: "Details", Location: locationOf("car")})
+	if err != nil {
+		t.Fatalf("CreateGroup(Details) error = %v, want nil", err)
+	}
+	section, err := store.CreateFieldInGroup(
+		t.Context(), source.ID, fieldOn(t, "", "author", content.FieldKindSection, ""))
+	if err != nil {
+		t.Fatalf("CreateFieldInGroup(author) error = %v, want nil", err)
+	}
+	sub := declaredInside(t, store, section, "name", content.FieldKindText)
+	landing, err := store.CreateGroup(t.Context(), content.Group{Title: "Elsewhere", Location: locationOf("car")})
+	if err != nil {
+		t.Fatalf("CreateGroup(Elsewhere) error = %v, want nil", err)
+	}
+	if _, err := store.MoveField(t.Context(), source.ID, "author", landing.ID); err != nil {
+		t.Fatalf("MoveField(author) error = %v, want nil", err)
+	}
+	return movedSection{source: source, landing: landing, section: section, sub: sub}
+}
+
+func TestMovingASectionCarriesItsSubFieldsAlong(t *testing.T) {
+	t.Parallel()
+
+	store, _, pool := typedStore(t)
+	storeType(t, store, "car")
+	moved := moveSection(t, store)
+
+	var carried int
+	if err := pool.QueryRow(t.Context(),
+		`SELECT group_id FROM core.content_fields WHERE id = $1`, moved.sub.ID).Scan(&carried); err != nil {
+		t.Fatalf("reading the sub field: %v, want nil", err)
+	}
+	if carried != moved.landing.ID {
+		t.Errorf("the sub field sits in group %d, want it carried into %d with its section",
+			carried, moved.landing.ID)
+	}
+}
+
+func TestDeletingTheGroupASectionLeftKeepsTheSectionWhole(t *testing.T) {
+	t.Parallel()
+
+	store, _, pool := typedStore(t)
+	storeType(t, store, "car")
+	moved := moveSection(t, store)
+
+	if err := store.DeleteGroup(t.Context(), moved.source.ID); err != nil {
+		t.Fatalf("DeleteGroup() error = %v, want the group the section left gone", err)
+	}
+
+	if held := groupHolding(t, store, "author"); held != moved.landing.ID {
+		t.Errorf("author is declared by group %d, want %d", held, moved.landing.ID)
+	}
+	var kept int
+	if err := pool.QueryRow(t.Context(),
+		`SELECT count(*) FROM core.content_fields WHERE parent_field_id = $1`, moved.section.ID).Scan(&kept); err != nil {
+		t.Fatalf("counting the section's sub fields: %v, want nil", err)
+	}
+	if kept != 1 {
+		t.Errorf("the section holds %d sub fields after the delete, want its one kept", kept)
+	}
+}
+
 func TestCreateSubFieldStoresTheKeyTheDomainSettledOn(t *testing.T) {
 	t.Parallel()
 	store, _, _ := typedStore(t)

--- a/internal/postgres/field_parents_test.go
+++ b/internal/postgres/field_parents_test.go
@@ -126,7 +126,7 @@ func TestMovingATopFieldLeavesASubFieldSharingItsKey(t *testing.T) {
 	}
 }
 
-// declaredInside declares a sub field of the kind under the parent through the store and returns it.
+// declaredInside declares a sub field of the kind under the parent and returns it.
 func declaredInside(
 	t *testing.T, store *postgres.TypeStore, parent content.Field, key string, kind content.FieldKind,
 ) content.Field {

--- a/internal/postgres/groups.go
+++ b/internal/postgres/groups.go
@@ -695,7 +695,9 @@ func (s *TypeStore) MoveField(
 			return err
 		}
 		moved = toField(row)
-		return nil
+		return queries.MoveContentFieldDescendants(ctx, db.MoveContentFieldDescendantsParams{
+			ID: row.ID, ToGroup: int32(toGroup),
+		})
 	})
 	if err != nil {
 		return content.Field{}, err

--- a/internal/postgres/migrations/00024_carry_sub_fields_with_their_container.sql
+++ b/internal/postgres/migrations/00024_carry_sub_fields_with_their_container.sql
@@ -6,25 +6,17 @@ WITH RECURSIVE rooted AS (
     UNION ALL
     SELECT below.id, rooted.group_id
     FROM core.content_fields AS below JOIN rooted ON below.parent_field_id = rooted.id
-), ranked AS (
-    SELECT held.id, row_number() OVER (
-        PARTITION BY held.parent_field_id, held.key
-        ORDER BY (held.group_id = rooted.group_id) DESC, held.id DESC
-    ) AS standing
-    FROM core.content_fields AS held JOIN rooted ON rooted.id = held.id
-    WHERE held.parent_field_id IS NOT NULL
-)
-DELETE FROM core.content_fields AS twin USING ranked WHERE twin.id = ranked.id AND ranked.standing > 1;
-
-WITH RECURSIVE rooted AS (
-    SELECT top.id, top.group_id FROM core.content_fields AS top WHERE top.parent_field_id IS NULL
-    UNION ALL
-    SELECT below.id, rooted.group_id
-    FROM core.content_fields AS below JOIN rooted ON below.parent_field_id = rooted.id
 )
 UPDATE core.content_fields AS carried
 SET group_id = rooted.group_id
 FROM rooted
-WHERE carried.id = rooted.id AND carried.group_id <> rooted.group_id;
+WHERE carried.id = rooted.id
+    AND carried.group_id <> rooted.group_id
+    AND NOT EXISTS (
+        SELECT 1 FROM core.content_fields AS twin
+        WHERE twin.parent_field_id = carried.parent_field_id
+            AND twin.key = carried.key
+            AND twin.id <> carried.id
+    );
 
 -- +goose Down

--- a/internal/postgres/migrations/00024_carry_sub_fields_with_their_container.sql
+++ b/internal/postgres/migrations/00024_carry_sub_fields_with_their_container.sql
@@ -1,0 +1,30 @@
+-- SPDX-License-Identifier: Apache-2.0
+
+-- +goose Up
+WITH RECURSIVE rooted AS (
+    SELECT top.id, top.group_id FROM core.content_fields AS top WHERE top.parent_field_id IS NULL
+    UNION ALL
+    SELECT below.id, rooted.group_id
+    FROM core.content_fields AS below JOIN rooted ON below.parent_field_id = rooted.id
+), ranked AS (
+    SELECT held.id, row_number() OVER (
+        PARTITION BY held.parent_field_id, held.key
+        ORDER BY (held.group_id = rooted.group_id) DESC, held.id DESC
+    ) AS standing
+    FROM core.content_fields AS held JOIN rooted ON rooted.id = held.id
+    WHERE held.parent_field_id IS NOT NULL
+)
+DELETE FROM core.content_fields AS twin USING ranked WHERE twin.id = ranked.id AND ranked.standing > 1;
+
+WITH RECURSIVE rooted AS (
+    SELECT top.id, top.group_id FROM core.content_fields AS top WHERE top.parent_field_id IS NULL
+    UNION ALL
+    SELECT below.id, rooted.group_id
+    FROM core.content_fields AS below JOIN rooted ON below.parent_field_id = rooted.id
+)
+UPDATE core.content_fields AS carried
+SET group_id = rooted.group_id
+FROM rooted
+WHERE carried.id = rooted.id AND carried.group_id <> rooted.group_id;
+
+-- +goose Down

--- a/internal/postgres/queries.sql
+++ b/internal/postgres/queries.sql
@@ -456,6 +456,16 @@ SELECT key FROM core.content_types ORDER BY created_at, key;
 SELECT id, key, label, kind, relates_to, many, required, created_at, updated_at, position, group_id, settings, parent_field_id, depth, origin
 FROM core.content_fields ORDER BY group_id, position, id;
 
+-- name: MoveContentFieldDescendants :exec
+WITH RECURSIVE inside AS (
+    SELECT held.id FROM core.content_fields AS held WHERE held.parent_field_id = @id::integer
+    UNION ALL
+    SELECT below.id FROM core.content_fields AS below JOIN inside ON below.parent_field_id = inside.id
+)
+UPDATE core.content_fields AS moved
+SET group_id = @to_group
+WHERE moved.id IN (SELECT inside.id FROM inside);
+
 -- name: ListContentFieldsOfGroup :many
 SELECT id, key, label, kind, relates_to, many, required, created_at, updated_at, position, group_id, settings, parent_field_id, depth, origin
 FROM core.content_fields WHERE group_id = @group_id ORDER BY position, id;

--- a/test/features/features/containers.feature
+++ b/test/features/features/containers.feature
@@ -108,3 +108,11 @@ Feature: Container fields
     And the post "Second post"
     When the administrator points "wrote" inside "author" of "Hello world" at "Second post"
     Then "Hello world" lists "Second post" in "wrote" inside "author"
+
+  Scenario: Moving a section carries its sub fields with it
+    Given the "section" field "author" in "Extras"
+    And the "text" field "name" inside "author"
+    And the group "Elsewhere" placed on "post"
+    When the administrator moves the field "author" from "Extras" to "Elsewhere"
+    And the administrator deletes the group "Extras"
+    Then the field "author" on "post" holds the sub field "name"

--- a/test/features/steps_containers_test.go
+++ b/test/features/steps_containers_test.go
@@ -276,6 +276,11 @@ func initializeContainers(sc *godog.ScenarioContext) {
 		theAdministratorDeclaresInside,
 	)
 	sc.When(
+		`^the administrator moves the field "([^"]*)" from "([^"]*)" to "([^"]*)"$`,
+		theAdministratorMovesTheField,
+	)
+	sc.When(`^the administrator deletes the group "([^"]*)"$`, theAdministratorDeletesTheGroup)
+	sc.When(
 		`^the administrator saves the section "([^"]*)" of "([^"]*)" as:$`,
 		theAdministratorSavesTheSection,
 	)


### PR DESCRIPTION
Closes #186

## What

Moving a Section or a Repeater into another field group now takes every field inside it along, at any depth.

A migration repairs sites where fields were already left behind. Each field with one clear place goes back into its container's group. Where a container ended up with two fields of the same name, both are left alone, and the old group stays until you remove one of them in the editor. Nothing is deleted, and stored values are not touched.

## Why

The fields inside stayed in the old group. The editor still looked right, but the old group could never be deleted, and the admin showed an internal error instead.

A field added after the move went to the new group. So one container could hold fields in two groups, and even two fields with the same name.

## Testing Instructions

1. Create two field groups on Posts. In the first, add a Section with a field inside it.
2. Move the Section to the second group, then delete the first group. The delete succeeds, and the Section still holds its field.
3. On a 0.13.0 database, make the same move. Start this build against it, then delete the first group. The delete succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Moving a section or content field now carries all nested sub-fields into the destination group.
  * Nested fields remain intact when the original group is deleted.
  * Migration repairs preserve field relationships and consistently remove duplicate sibling fields.

* **Tests**
  * Added coverage for nested field moves, relation fields, duplicate containers, and group deletion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->