### PR TITLE
Never cache a public answer that failed

### DIFF
--- a/docs/src/content/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/self-hosting/configuration.md
@@ -47,6 +47,10 @@ Three rows deserve a warning:
   it at a volume that survives a restart, and back it up alongside
   the database.
 
+Every cache window applies only to an answer that succeeded. An
+address nothing holds, a file that is missing or a request the server
+refused is never kept by any cache, however the windows are set.
+
 ## Which theme serves
 
 Two things can name a theme, and they do not carry equal weight:

--- a/internal/server/assets.go
+++ b/internal/server/assets.go
@@ -17,9 +17,9 @@ const assetDir = "gophenberg"
 func siteAssets(webFS fs.FS, header string) http.Handler {
 	assets, err := assetFS(webFS)
 	if err != nil {
-		return http.HandlerFunc(respondNotFound)
+		return cacheStamped(http.HandlerFunc(respondNotFound), header)
 	}
-	return http.StripPrefix(assetPrefix+"/", cacheAssets(http.FileServerFS(assets), header))
+	return cacheStamped(http.StripPrefix(assetPrefix+"/", http.FileServerFS(assets)), header)
 }
 
 // assetFS returns the subdirectory of the web root holding the site's assets.
@@ -28,12 +28,4 @@ func assetFS(webFS fs.FS) (fs.FS, error) {
 		return nil, fs.ErrNotExist
 	}
 	return fs.Sub(webFS, assetDir)
-}
-
-// cacheAssets returns next with its responses marked cacheable.
-func cacheAssets(next http.Handler, header string) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Cache-Control", header)
-		next.ServeHTTP(w, r)
-	})
 }

--- a/internal/server/cache.go
+++ b/internal/server/cache.go
@@ -4,6 +4,7 @@ package server
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 )
 
@@ -21,6 +22,44 @@ const DefaultContentStaleWhileRevalidate = 5 * time.Minute
 
 // readerCacheControl is what an answer resolved for one reader carries, so no cache it does not belong to holds it.
 const readerCacheControl = "private, no-store"
+
+// uncachedControl is what a failed answer carries, so no cache keeps it.
+const uncachedControl = "no-store"
+
+// cacheStamp is a writer stamping the Cache-Control an answer earns once its status is known.
+type cacheStamp struct {
+	http.ResponseWriter
+	header  string
+	stamped bool
+}
+
+// WriteHeader stamps the window on a success and no-store on a failure, then sends the status.
+func (c *cacheStamp) WriteHeader(status int) {
+	if !c.stamped {
+		c.stamped = true
+		control := c.header
+		if status >= http.StatusBadRequest {
+			control = uncachedControl
+		}
+		c.Header().Set("Cache-Control", control)
+	}
+	c.ResponseWriter.WriteHeader(status)
+}
+
+// Write sends the body, stamping a success first when no status went out.
+func (c *cacheStamp) Write(body []byte) (int, error) {
+	if !c.stamped {
+		c.WriteHeader(http.StatusOK)
+	}
+	return c.ResponseWriter.Write(body)
+}
+
+// cacheStamped returns next answering through a writer that stamps the header the answer earns.
+func cacheStamped(next http.Handler, header string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(&cacheStamp{ResponseWriter: w, header: header}, r)
+	})
+}
 
 // CachePolicy is how long each kind of public answer may be kept. Zero applies the default.
 type CachePolicy struct {

--- a/internal/server/cache_internal_test.go
+++ b/internal/server/cache_internal_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCacheStampMarksAnAnswerWrittenWithoutAStatus(t *testing.T) {
+	t.Parallel()
+
+	handler := cacheStamped(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("served"))
+	}), "public, max-age=1")
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if held := recorder.Header().Get("Cache-Control"); held != "public, max-age=1" {
+		t.Errorf("Cache-Control = %q, want an answer written straight away stamped as a success", held)
+	}
+}

--- a/internal/server/cache_test.go
+++ b/internal/server/cache_test.go
@@ -90,6 +90,33 @@ func TestCacheWindowsCarryWhatTheDeploymentNamed(t *testing.T) {
 	}
 }
 
+func TestAFailedPublicAnswerIsNeverCached(t *testing.T) {
+	t.Parallel()
+
+	handler := cachingServer(t, server.CachePolicy{})
+
+	for name, path := range map[string]string{
+		"an address nothing holds": "/api/content/v1/resolve?path=/nowhere/at/all",
+		"a page size out of range": "/api/content/v1/items?per_page=0",
+		"a missing site asset":     "/gophenberg/missing.css",
+		"a missing upload":         "/media/missing.jpg",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, path, nil))
+
+			if recorder.Code < http.StatusBadRequest {
+				t.Fatalf("status = %d, want a failed answer to test against", recorder.Code)
+			}
+			if held := recorder.Header().Get("Cache-Control"); held != "no-store" {
+				t.Errorf("Cache-Control = %q, want no cache to keep a failed answer", held)
+			}
+		})
+	}
+}
+
 func TestTheLocaleAnswerStaysOutOfSharedCaches(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/content.go
+++ b/internal/server/content.go
@@ -149,13 +149,13 @@ func newPublishedSummary(c content.Content) publishedSummary {
 	}
 }
 
-// contentHeaders returns middleware allowing cross-origin reads and carrying the given cache directive.
+// contentHeaders returns middleware allowing cross-origin reads and stamping the cache directive an answer earns.
 func contentHeaders(header string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
+		stamped := cacheStamped(next, header)
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Access-Control-Allow-Origin", "*")
-			w.Header().Set("Cache-Control", header)
-			next.ServeHTTP(w, r)
+			stamped.ServeHTTP(w, r)
 		})
 	}
 }

--- a/internal/server/media.go
+++ b/internal/server/media.go
@@ -427,7 +427,7 @@ func (s *server) handleMediaDelete() http.HandlerFunc {
 }
 
 // mediaAssets returns the handler serving stored uploads to every visitor.
-func mediaAssets(files fs.FS, header string) http.Handler {
+func mediaAssets(files fs.FS) http.Handler {
 	fileServer := http.FileServerFS(files)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		name, ok := mediaFileName(r.URL.Path)
@@ -440,7 +440,6 @@ func mediaAssets(files fs.FS, header string) http.Handler {
 			respondNotFound(w, r)
 			return
 		}
-		w.Header().Set("Cache-Control", header)
 		r = r.Clone(r.Context())
 		r.URL.Path = "/" + name
 		fileServer.ServeHTTP(w, r)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -122,7 +122,7 @@ func NewServer(cfg Config) http.Handler {
 	}
 	router.With(identify(cfg.Version)).Handle(assetPrefix+"/*", siteAssets(cfg.Web, headers.asset))
 	if cfg.MediaFiles != nil {
-		router.With(identify(cfg.Version)).Handle(mediaPrefix+"/*", mediaAssets(cfg.MediaFiles, headers.media))
+		router.With(identify(cfg.Version)).Handle(mediaPrefix+"/*", cacheStamped(mediaAssets(cfg.MediaFiles), headers.media))
 	}
 	site := builtInSite(cfg, s.types)
 	renderer := identify(cfg.Version)(site)

--- a/test/features/features/content-serving.feature
+++ b/test/features/features/content-serving.feature
@@ -40,6 +40,10 @@ Feature: Serving content by address
   Scenario: An unknown address answers not found
     Then "/nowhere/at/all" answers not found
 
+  Scenario: An answer that failed is never cached
+    When a visitor resolves "/nowhere/at/all" and finds nothing
+    Then the answer is never cached
+
   Scenario: A page number below the first answers not found
     Then "/page/0" answers not found
 

--- a/test/features/features/media-serving.feature
+++ b/test/features/features/media-serving.feature
@@ -36,6 +36,11 @@ Feature: Serving media files
     When a visitor requests that hidden file
     Then the request reports the file does not exist
 
+  Scenario: A missing file is never cached
+    When a visitor requests an unknown media path
+    Then the request reports the file does not exist
+    And the answer is never cached
+
   Scenario: The media prefix never falls through to a theme
     Given "driftwood" is installed and active
     When a visitor requests an unknown media path

--- a/test/features/steps_content_serving_test.go
+++ b/test/features/steps_content_serving_test.go
@@ -118,6 +118,30 @@ func theAddressAnswersNotFound(ctx context.Context, address string) error {
 	return w.expect(http.StatusNotFound)
 }
 
+// aVisitorResolvesNothingAt asks the resolver about an address nothing holds.
+func aVisitorResolvesNothingAt(ctx context.Context, address string) error {
+	w, err := visit(ctx, "/api/content/v1/resolve?path="+address)
+	if err != nil {
+		return err
+	}
+	return w.expect(http.StatusNotFound)
+}
+
+// theAnswerIsNeverCached asserts the last answer forbids every cache from keeping it.
+func theAnswerIsNeverCached(ctx context.Context) error {
+	w, err := worldOf(ctx)
+	if err != nil {
+		return err
+	}
+	if w.answer == nil {
+		return fmt.Errorf("nothing was answered yet")
+	}
+	if held := w.answer.header.Get("Cache-Control"); held != "no-store" {
+		return fmt.Errorf("Cache-Control = %q, want no cache to keep a failed answer", held)
+	}
+	return nil
+}
+
 // initializeContentServing registers the steps of the content serving feature.
 func initializeContentServing(sc *godog.ScenarioContext) {
 	sc.Before(provisionWorld)
@@ -136,8 +160,10 @@ func initializeContentServing(sc *godog.ScenarioContext) {
 	sc.Then(`^"([^"]*)" answers with "([^"]*)"$`, theAddressAnswersWith)
 	sc.Then(`^"([^"]*)" lists "([^"]*)"$`, theAddressLists)
 	sc.Then(`^"([^"]*)" answers not found$`, theAddressAnswersNotFound)
+	sc.Then(`^the answer is never cached$`, theAnswerIsNeverCached)
 	sc.When(`^a visitor reads the content handshake$`, aVisitorReadsTheContentHandshake)
 	sc.When(`^a visitor resolves "([^"]*)"$`, aVisitorResolves)
+	sc.When(`^a visitor resolves "([^"]*)" and finds nothing$`, aVisitorResolvesNothingAt)
 	sc.Then(`^it carries api (\d+)$`, itCarriesAPI)
 	sc.Then(`^it serves kit "([^"]*)"$`, itServesKit)
 	sc.Then(`^it lists "([^"]*)" as the default type at the root$`, itListsTheDefaultTypeAtTheRoot)

--- a/test/features/steps_media_serving_test.go
+++ b/test/features/steps_media_serving_test.go
@@ -211,6 +211,7 @@ func initializeMediaServing(sc *godog.ScenarioContext) {
 	sc.Then(`^the file is served with the content type "([^"]*)"$`, theFileIsServedWithTheContentType)
 	sc.Then(`^the response allows public caching$`, theResponseAllowsPublicCaching)
 	sc.Then(`^the request reports the file does not exist$`, theRequestReportsTheFileDoesNotExist)
+	sc.Then(`^the answer is never cached$`, theAnswerIsNeverCached)
 	sc.Then(`^the request is refused$`, theRequestIsRefused)
 	sc.Then(`^the answer does not carry the theme's page$`, theAnswerDoesNotCarryTheThemesPage)
 }


### PR DESCRIPTION
Closes #165

## What

A public answer that failed is never cached now. The content API, site assets and uploads all mark a failed answer `no-store`. A successful answer keeps its cache window as before.

## Why

The content API set its cache window before the answer was known. So a 404 or a bad request was kept by shared caches for a minute. A missing asset or upload carried no cache header at all, and some caches keep a 404 by their own rules when nothing tells them otherwise.

A short database hiccup could turn into a minute of errors shown to every reader.

## Testing Instructions

1. Start Gophenberg and ask for an address nothing holds:
   ```
   curl -s -D - -o /dev/null "http://localhost:8081/api/content/v1/resolve?path=/nowhere"
   ```
   The headers show `Cache-Control: no-store`.
2. Ask for a published post the same way. The headers still show the public window.
3. Ask for a file that does not exist under `/media/`. The headers show `Cache-Control: no-store`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failed answers, missing content, invalid requests, and unavailable files are no longer cached.
  * Successful responses continue to receive appropriate caching headers.
  * Unknown media paths now return a not-found response without being cached.
  * Unsupported requests return the appropriate error response and are not cached.

* **Documentation**
  * Clarified that cache windows apply only to successful answers; empty results, missing files, and refused requests are never cached.

* **Tests**
  * Added coverage for cache behavior across failed answers, content resolution, media, and asset requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->